### PR TITLE
Sticky board scatters so the row-hover highlight stays visible

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/docs/references.html
+++ b/docs/references.html
@@ -111,6 +111,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){.plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/site/build.py
+++ b/site/build.py
@@ -360,6 +360,13 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}}
 .tcount{{color:var(--mut);font-size:14px;font-weight:400}}
 .plots{{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}}
+/* Keep the scatters pinned while scrolling the long table below, so the
+   row-hover -> point highlight stays visible. Only when the two plots sit
+   side by side (wide screens); on narrow screens they stack tall and pinning
+   would swallow the viewport. */
+@media(min-width:760px){{.plots{{position:sticky;top:0;z-index:5;
+background:var(--bg);padding-top:8px;
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}}}
 .plot{{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}}
 .chartlegend{{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;


### PR DESCRIPTION
The redesign moved the charts above the leaderboard, far from the table, so the row-hover to point-highlight was off-screen while scrolling. This pins the plots (position:sticky) on wide screens (two scatters side by side, bounded height); narrow screens stack them tall and are left unpinned. Verified: plots stay pinned while scrolling the table and the hover highlight still fires.