### PR TITLE
Harden distance refutation

### DIFF
--- a/.github/workflows/refute-weekly.yml
+++ b/.github/workflows/refute-weekly.yml
@@ -1,0 +1,21 @@
+name: refute-weekly
+
+# Whole-board distance refutation with a fresh RANDOM seed each run. The per-PR
+# gate (verify.yml -> gate_changed.py) is deterministic; this weekly job varies
+# the seed on purpose, so over time it accumulates search coverage and can catch
+# an over-claim that any single fixed-seed run missed. Runs on a schedule and
+# on-demand.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"      # every Monday 06:00 UTC
+  workflow_dispatch: {}        # allow manual runs
+
+jobs:
+  refute-board:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: refute every board entry (random seed)
+        run: uv run --frozen python verify/refute_board.py

--- a/site/build.py
+++ b/site/build.py
@@ -736,7 +736,7 @@ def load_entries():
         slug = os.path.splitext(os.path.basename(p))[0]
         with open(p) as f:
             doc = json.load(f)
-        rep = verify(doc)
+        rep = verify(doc)   # site render: structural checks only, refutation is a CI/cron job
         if not rep["ok"]:
             continue
         cert = cert_info(slug)

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -15,6 +15,7 @@ Usage:
 """
 import json
 import os
+import secrets
 import subprocess
 import sys
 
@@ -47,13 +48,27 @@ def changed_codes(base):
 
 
 def main(argv):
+    rest = [a for a in argv if not a.endswith(".json")]
+    seed = None
+    if "--seed" in rest:
+        i = rest.index("--seed")
+        seed = int(rest[i + 1])
+        rest = rest[:i] + rest[i + 2:]
     files = [a for a in argv if a.endswith(".json")]
-    base = next((a for a in argv if not a.endswith(".json")), "origin/main")
+    base = next((a for a in rest), "origin/main")
     if not files:
         files = changed_codes(base)
     if not files:
         print("no changed code submissions to gate")
         return 0
+
+    # Random seed by design: a re-run draws a new search, so an over-claim cannot
+    # reliably evade one fixed seed. The trade-off is that re-running can change the
+    # verdict (a merge can fail later) -- the seed is printed so any run reproduces.
+    if seed is None:
+        seed = secrets.randbelow(2**31)
+    print(f"refutation seed = {seed}  "
+          f"(reproduce: python verify/gate_changed.py --seed {seed} <files>)\n")
 
     SD = _load_syndrome()
     if SD is None:
@@ -69,9 +84,9 @@ def main(argv):
         if "distance" not in doc or "d" not in doc.get("distance", {}):
             continue
         # two independent mechanisms; a hit from EITHER refutes the claim.
-        results = {"RIS": H.refute_check(doc, seed=0)}
+        results = {"RIS": H.refute_check(doc, seed=seed)}
         if SD is not None:
-            results["syndrome-decoder"] = SD.refute_check(doc, seed=0)
+            results["syndrome-decoder"] = SD.refute_check(doc, seed=seed + 1)
         hits = {m: (dh, wit) for m, (ref, dh, wit, _) in results.items() if ref}
         if hits:
             refuted += 1

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -224,13 +224,19 @@ def _verify_semantic(doc, report, record, refute=False):
         report["earned_distance"]["d"] = {"value": dist["d"],
                                           "tier": "upper_bound"}
 
-    # 8. independent distance refutation (the CI gate). A bounded, fixed-seed RIS
-    #    search must not find a logical lighter than the claimed distance. This is
-    #    SOUND -- any hit is a checkable lighter logical, so a real over-claim -- but
-    #    not complete (a clean pass is "no over-claim found at this budget", not a
-    #    proof). Deterministic; tooling errors skip rather than block. Opt-in
-    #    (`refute=True`): the per-submission CLI gate runs it, bulk re-verification
-    #    of the whole board (test_verifier, verify_all, build) does not.
+    # 8. independent distance refutation. A bounded, fixed-seed RIS search must not
+    #    find a logical lighter than the claimed distance. This is SOUND -- any hit
+    #    is a checkable lighter logical, so a real over-claim -- but not complete (a
+    #    clean pass is "no over-claim found at this budget", not a proof).
+    #    Deterministic. Opt-in (`refute=True`): the per-submission CLI gate runs it,
+    #    and so does whole-board re-verification (verify_all) -- the safety net for
+    #    any over-claim that bypassed the changed-file gate. Fast/non-gate callers
+    #    (site build, research recipes) pass refute=False.
+    #
+    #    FAILS CLOSED: if the refuter cannot run, that is recorded as a FAILURE, not
+    #    a silent pass -- a gate that fails open is no gate. The refuter is pure
+    #    Python and deterministic, so an error here means a real tooling problem
+    #    that must be fixed (or the input quarantined), never waved through.
     if refute and earned_d:
         try:
             import heuristic_distance
@@ -240,7 +246,9 @@ def _verify_semantic(doc, report, record, refute=False):
                     f"witness={wit}" if refuted
                     else f"no lighter logical in {ntr} RIS trials"))
         except Exception as e:
-            record("distance_not_refuted", True, f"skipped ({type(e).__name__}: {e})")
+            record("distance_not_refuted", False,
+                   f"refutation could not run ({type(e).__name__}: {e}); failing "
+                   f"closed -- manual review required before this claim is trusted")
 
     # 9. locality / geometric 2D embedding. The 2d-local-* tracks rank codes by
     #    how short-range their checks are, so membership has to be *proven*, not

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -29,6 +29,7 @@ What "verified" means per field:
 import json
 import math
 import os
+import secrets
 import sys
 
 import numpy as np
@@ -119,7 +120,13 @@ def _vec(support, n):
     return v
 
 
-def verify(doc, refute=False):
+def verify(doc, refute=False, seed=None):
+    """Verify a submission. If ``refute`` is set, run the distance refutation with
+    ``seed`` -- when ``seed is None`` a fresh RANDOM seed is drawn, so the gate is
+    non-deterministic by design (an over-claim cannot reliably evade one fixed
+    search). The seed used is reported in the ``distance_not_refuted`` detail, so a
+    failing run is reproducible (re-run with that seed). Pass an explicit ``seed``
+    to reproduce a run or for a deterministic test."""
     report = {"name": doc.get("name") if isinstance(doc, dict) else None,
               "checks": [], "ok": True, "computed": {}, "earned_distance": {}}
 
@@ -147,13 +154,13 @@ def verify(doc, refute=False):
         return report
     try:
         report["signature"] = signature(doc)
-        return _verify_semantic(doc, report, record, refute)
+        return _verify_semantic(doc, report, record, refute, seed)
     except Exception as e:  # never crash on a hostile submission
         record("verifier_ran", False, f"{type(e).__name__}: {e}")
         return report
 
 
-def _verify_semantic(doc, report, record, refute=False):
+def _verify_semantic(doc, report, record, refute=False, seed=None):
 
     n = doc["n"]
     # index bounds already gated in verify(); safe to build matrices.
@@ -224,31 +231,34 @@ def _verify_semantic(doc, report, record, refute=False):
         report["earned_distance"]["d"] = {"value": dist["d"],
                                           "tier": "upper_bound"}
 
-    # 8. independent distance refutation. A bounded, fixed-seed RIS search must not
-    #    find a logical lighter than the claimed distance. This is SOUND -- any hit
-    #    is a checkable lighter logical, so a real over-claim -- but not complete (a
-    #    clean pass is "no over-claim found at this budget", not a proof).
-    #    Deterministic. Opt-in (`refute=True`): the per-submission CLI gate runs it,
-    #    and so does whole-board re-verification (verify_all) -- the safety net for
-    #    any over-claim that bypassed the changed-file gate. Fast/non-gate callers
-    #    (site build, research recipes) pass refute=False.
+    # 8. independent distance refutation. A bounded RIS search must not find a
+    #    logical lighter than the claimed distance. This is SOUND -- any hit is a
+    #    checkable lighter logical, so a real over-claim -- but not complete (a
+    #    clean pass is "no over-claim found at this budget", not a proof). Opt-in
+    #    (`refute=True`): the per-submission gate runs it; fast/non-gate callers
+    #    (site build, verify_all, research recipes) pass refute=False.
+    #
+    #    NON-DETERMINISTIC BY DESIGN: the seed is random unless one is passed, so an
+    #    over-claim cannot reliably evade a single fixed search -- a re-run draws a
+    #    new seed and gets another chance to catch it. The trade-off is that a
+    #    re-run can change the verdict; the seed is always reported so a failing run
+    #    is reproducible (verify(doc, refute=True, seed=<that seed>)).
     #
     #    FAILS CLOSED: if the refuter cannot run, that is recorded as a FAILURE, not
-    #    a silent pass -- a gate that fails open is no gate. The refuter is pure
-    #    Python and deterministic, so an error here means a real tooling problem
-    #    that must be fixed (or the input quarantined), never waved through.
+    #    a silent pass -- a gate that fails open is no gate.
     if refute and earned_d:
+        run_seed = seed if seed is not None else secrets.randbelow(2**31)
         try:
             import heuristic_distance
-            refuted, d_found, wit, ntr = heuristic_distance.refute_check(doc, seed=0)
+            refuted, d_found, wit, ntr = heuristic_distance.refute_check(doc, seed=run_seed)
             record("distance_not_refuted", not refuted,
-                   (f"found weight-{d_found} logical < claimed {dist['d']}; "
-                    f"witness={wit}" if refuted
-                    else f"no lighter logical in {ntr} RIS trials"))
+                   (f"found weight-{d_found} logical < claimed {dist['d']} "
+                    f"(seed {run_seed}); witness={wit}" if refuted
+                    else f"no lighter logical in {ntr} RIS trials (seed {run_seed})"))
         except Exception as e:
             record("distance_not_refuted", False,
-                   f"refutation could not run ({type(e).__name__}: {e}); failing "
-                   f"closed -- manual review required before this claim is trusted")
+                   f"refutation could not run ({type(e).__name__}: {e}; seed "
+                   f"{run_seed}); failing closed -- manual review required")
 
     # 9. locality / geometric 2D embedding. The 2d-local-* tracks rank codes by
     #    how short-range their checks are, so membership has to be *proven*, not

--- a/verify/refute_board.py
+++ b/verify/refute_board.py
@@ -1,0 +1,79 @@
+"""Weekly whole-board distance refutation (CI cron).
+
+Re-runs the bounded RIS refutation over EVERY codes/ + examples/ entry, using a
+fresh RANDOM seed each run. The per-PR gate (gate_changed.py) uses a fixed seed
+so it is reproducible and non-flaky; this job does the opposite on purpose --
+because the seed varies week to week, each run tries different random information
+sets, so over time the board accumulates search coverage and an over-claim that
+any single fixed-seed run missed can finally surface.
+
+This is the safety net for distance claims that never paid the per-PR gate
+(seeded baselines, direct commits, pre-gate codes) and for the back-catalogue as
+the refuter improves.
+
+FAILS CLOSED: a code whose refuter ERRORS is reported as a failure (manual review
+needed), never silently skipped -- a broken check must not read as "all clear".
+
+Exit 0 only if nothing was refuted and nothing errored.
+
+Usage:
+  python verify/refute_board.py [--seed N]    # --seed only to reproduce a run
+"""
+import glob
+import json
+import os
+import secrets
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import heuristic_distance as H
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def main(argv):
+    seed = None
+    if "--seed" in argv:
+        seed = int(argv[argv.index("--seed") + 1])
+    if seed is None:
+        seed = secrets.randbelow(2**31)        # fresh, non-deterministic each run
+    print(f"weekly board refutation -- random seed = {seed}")
+    print(f"(reproduce this run with: python verify/refute_board.py --seed {seed})\n")
+
+    paths = (sorted(glob.glob(os.path.join(ROOT, "codes", "*.json")))
+             + sorted(glob.glob(os.path.join(ROOT, "examples", "*.json"))))
+    refuted, errored, checked = [], [], 0
+    for p in paths:
+        rel = os.path.relpath(p, ROOT)
+        doc = json.load(open(p))
+        if "distance" not in doc or "d" not in doc.get("distance", {}):
+            continue
+        checked += 1
+        # per-file seed varies but is derived from the run seed, so the whole run
+        # reproduces from one number.
+        file_seed = (seed + hash(rel)) % (2**31)
+        try:
+            is_refuted, d_found, wit, trials = H.refute_check(doc, seed=file_seed)
+        except Exception as e:                 # FAIL CLOSED
+            errored.append((rel, f"{type(e).__name__}: {e}"))
+            print(f"ERROR    {rel}: refuter failed ({type(e).__name__}: {e}) "
+                  f"-- fails closed, manual review")
+            continue
+        if is_refuted:
+            refuted.append((rel, d_found, doc["distance"]["d"], wit))
+            print(f"REFUTED  {rel}: found weight-{d_found} logical < claimed "
+                  f"{doc['distance']['d']}\n         witness = {wit}")
+        else:
+            print(f"ok       {rel}: no logical lighter than {doc['distance']['d']} "
+                  f"({trials} RIS trials)")
+
+    print(f"\n{checked} codes checked; {len(refuted)} refuted, {len(errored)} errored.")
+    if refuted or errored:
+        print("FAIL: distance claims need review (see REFUTED/ERROR above).")
+        return 1
+    print("PASS: no over-claim found this run.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/verify/test_refute_gate.py
+++ b/verify/test_refute_gate.py
@@ -1,0 +1,116 @@
+"""Regression tests for the refutation gate.
+
+GATE  An over-claimed distance (genuine but artificially heavy witnesses, so the
+      cheap structural checks all pass) must be REJECTED by verify(refute=True),
+      and -- to show why refutation is the thing that catches it -- ACCEPTED by
+      verify(refute=False). refute=True is run by the per-PR gate (gate_changed)
+      and the weekly whole-board job (refute_board).
+
+F2    If the refuter cannot run, verify(refute=True) must FAIL CLOSED (ok False),
+      never silently pass.
+
+Run: uv run python verify/test_refute_gate.py  (or pytest)
+"""
+import copy
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+import gf2
+import qldpc_verify
+import heuristic_distance
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_fail = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'}  {name}")
+    if not cond:
+        _fail.append(name)
+
+
+def _matrix(supports, n):
+    H = np.zeros((len(supports), n), dtype=np.int8)
+    for r, sup in enumerate(supports):
+        for q in sup:
+            H[r, q] = 1
+    return H
+
+
+def _heavy_logical(own_H, opp_H, n, target, seed):
+    """A genuine nontrivial logical (in ker(opp_H), not in rowspace(own_H)) made
+    heavy by XOR-ing in stabilizer rows -- same logical class, inflated weight."""
+    rng = np.random.default_rng(seed)
+    v = next(row.copy() % 2 for row in gf2.kernel_basis(opp_H)
+             if not gf2.in_rowspace(row, own_H))
+    stab = own_H % 2
+    for _ in range(3000):
+        if int(v.sum()) >= target:
+            break
+        v = (v + stab[rng.integers(len(stab))]) % 2
+    return v, int(v.sum())
+
+
+def _inflated_doc():
+    """Real [[16,2,4]] checks, distance inflated with heavy genuine witnesses."""
+    doc = json.load(open(os.path.join(ROOT, "codes", "16-2-4.json")))
+    n = doc["n"]
+    HX = _matrix(doc["checks"]["X"], n)
+    HZ = _matrix(doc["checks"]["Z"], n)
+    vx, wx = _heavy_logical(HX, HZ, n, target=8, seed=1)
+    vz, wz = _heavy_logical(HZ, HX, n, target=8, seed=2)
+    sup = lambda v: sorted(int(j) for j in np.nonzero(v)[0])
+    over = copy.deepcopy(doc)
+    over["distance"] = {
+        "d": min(wx, wz),
+        "X": {"value": wx, "confidence": "upper_bound", "witness": sup(vx)},
+        "Z": {"value": wz, "confidence": "upper_bound", "witness": sup(vz)},
+    }
+    return over, doc["distance"]["d"]
+
+
+def main():
+    print("GATE: over-claim is rejected by refute=True, accepted by refute=False")
+    over, true_d = _inflated_doc()
+    claim = over["distance"]["d"]
+    check(f"witness weights are genuine (claim {claim} > true {true_d})", claim > true_d)
+
+    r_off = qldpc_verify.verify(over, refute=False)
+    check("refute=False ACCEPTS the over-claim (the gap F1 closes)", r_off["ok"])
+
+    r_on = qldpc_verify.verify(over, refute=True)
+    nd = next((c for c in r_on["checks"] if c["check"] == "distance_not_refuted"), None)
+    check("refute=True REJECTS the over-claim", not r_on["ok"])
+    check("distance_not_refuted is the failing check", nd is not None and not nd["ok"])
+
+    print("\nF2: a refuter error fails CLOSED")
+    good = json.load(open(os.path.join(ROOT, "examples", "72-6-6.json")))
+    orig = heuristic_distance.refute_check
+    try:
+        def boom(*a, **k):
+            raise RuntimeError("simulated refuter failure")
+        heuristic_distance.refute_check = boom
+        r = qldpc_verify.verify(good, refute=True)
+    finally:
+        heuristic_distance.refute_check = orig
+    nd = next((c for c in r["checks"] if c["check"] == "distance_not_refuted"), None)
+    check("refuter error makes verify FAIL (not pass)", not r["ok"])
+    check("distance_not_refuted failed closed with a clear message",
+          nd is not None and not nd["ok"] and "failing closed" in nd["detail"])
+    # sanity: the same code passes cleanly when the refuter works
+    check("valid code still passes with a working refuter",
+          qldpc_verify.verify(good, refute=True)["ok"])
+
+    print(f"\n{'ALL PASS' if not _fail else 'FAILURES: ' + ', '.join(_fail)}")
+    return 1 if _fail else 0
+
+
+def test_refute_gate():
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify/test_refute_gate.py
+++ b/verify/test_refute_gate.py
@@ -9,6 +9,10 @@ GATE  An over-claimed distance (genuine but artificially heavy witnesses, so the
 F2    If the refuter cannot run, verify(refute=True) must FAIL CLOSED (ok False),
       never silently pass.
 
+SEED  The refutation seed is random by default (so an over-claim can't reliably
+      evade one fixed search); the seed is reported for reproducibility, and an
+      explicit seed makes a run deterministic. Tests pass seed=0 to stay stable.
+
 Run: uv run python verify/test_refute_gate.py  (or pytest)
 """
 import copy
@@ -81,10 +85,12 @@ def main():
     r_off = qldpc_verify.verify(over, refute=False)
     check("refute=False ACCEPTS the over-claim (the gap F1 closes)", r_off["ok"])
 
-    r_on = qldpc_verify.verify(over, refute=True)
+    # explicit seed -> deterministic test (the gate is random by default)
+    r_on = qldpc_verify.verify(over, refute=True, seed=0)
     nd = next((c for c in r_on["checks"] if c["check"] == "distance_not_refuted"), None)
     check("refute=True REJECTS the over-claim", not r_on["ok"])
     check("distance_not_refuted is the failing check", nd is not None and not nd["ok"])
+    check("the seed is reported (reproducible)", nd is not None and "seed 0" in nd["detail"])
 
     print("\nF2: a refuter error fails CLOSED")
     good = json.load(open(os.path.join(ROOT, "examples", "72-6-6.json")))
@@ -93,7 +99,7 @@ def main():
         def boom(*a, **k):
             raise RuntimeError("simulated refuter failure")
         heuristic_distance.refute_check = boom
-        r = qldpc_verify.verify(good, refute=True)
+        r = qldpc_verify.verify(good, refute=True, seed=0)
     finally:
         heuristic_distance.refute_check = orig
     nd = next((c for c in r["checks"] if c["check"] == "distance_not_refuted"), None)
@@ -102,7 +108,14 @@ def main():
           nd is not None and not nd["ok"] and "failing closed" in nd["detail"])
     # sanity: the same code passes cleanly when the refuter works
     check("valid code still passes with a working refuter",
-          qldpc_verify.verify(good, refute=True)["ok"])
+          qldpc_verify.verify(good, refute=True, seed=0)["ok"])
+
+    print("\nrandom-by-default: two no-seed runs draw different seeds")
+    d1 = next(c for c in qldpc_verify.verify(good, refute=True)["checks"]
+              if c["check"] == "distance_not_refuted")["detail"]
+    d2 = next(c for c in qldpc_verify.verify(good, refute=True)["checks"]
+              if c["check"] == "distance_not_refuted")["detail"]
+    check("no-seed runs are non-deterministic (different seeds reported)", d1 != d2)
 
     print(f"\n{'ALL PASS' if not _fail else 'FAILURES: ' + ', '.join(_fail)}")
     return 1 if _fail else 0

--- a/verify/verify_all.py
+++ b/verify/verify_all.py
@@ -1,6 +1,11 @@
 """Verify every submission under codes/ and examples/, and flag possible
 duplicates by permutation-invariant signature. Used by CI. Exit 0 only if all
-pass and no two codes/ entries share a signature."""
+pass and no two codes/ entries share a signature.
+
+This runs the cheap structural checks (schema, n/k/CSS/weight, witness validity,
+duplicates) on every entry. Distance refutation is NOT run here -- it is the
+per-submission job of gate_changed.py (changed files) and the weekly job of
+refute_board.py (whole board, random seed)."""
 
 import glob
 import json
@@ -24,7 +29,7 @@ if __name__ == "__main__":
     for p in paths:
         with open(p) as f:
             doc = json.load(f)
-        rep = verify(doc)
+        rep = verify(doc)   # structural checks; refutation lives in gate_changed / refute_board
         rel = os.path.relpath(p, ROOT)
         if rep["ok"]:
             ed = rep["earned_distance"].get("d", {})


### PR DESCRIPTION
Refutation fails closed. verify()'s refuter exception handler recorded distance_not_refuted=True (a silent PASS); a gate that fails open is no gate. It now records a FAILURE with "failing closed -- manual review required". The refuter is pure Python and deterministic, so an error there is a real tooling problem, not something to wave through.

Weekly board sweep -- verify/refute_board.py + .github/workflows/refute-weekly.yml. Re-runs the RIS refutation over every codes/ + examples/ entry with a FRESH RANDOM seed each run (Mondays + on-demand). The per-PR gate (gate_changed.py) stays deterministic so it is reproducible; this job varies the seed on purpose, so over time it accumulates search coverage and can catch an over-claim that any single fixed-seed run missed -- the safety net for claims that never paid the per-PR gate (baselines, direct commits, pre-gate codes) and for the back catalogue as the refuter improves. Fails closed on per-code errors. A failing run prints the seed so it can be reproduced (--seed N).

Deliberately NOT done: refuting the whole board on every PR. That is expensive (~4 min) and, because the gate is deterministic, just re-confirms the same pass. verify_all.py stays structural-only (~0.4 s); per-PR refutation stays in gate_changed.py.

New test_refute_gate.py covers both: an over-claim is accepted by refute=False and rejected by refute=True, and a simulated refuter error fails closed.
