### PR TITLE
README: cross-platform uv install instead of brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ This repo uses [uv](https://docs.astral.sh/uv/) to manage the Python environment
 **Install uv** (one-time):
 
 ```bash
-brew install uv        # macOS
-# or: pip install uv   # any platform
+pip install uv
 ```
+
+(or any method from the [uv install docs](https://docs.astral.sh/uv/getting-started/installation/))
 
 **Verify a code locally:**
 


### PR DESCRIPTION
The install snippet led with `brew install uv` (macOS-only). Lead with `pip install uv`, which works on any platform, and link uv's install docs for other methods.