### PR TITLE
README: drop the redundant scipy+ldpc note from the research command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run python site/build.py
 # then open docs/index.html
 ```
 
-**Run research tools** (requires scipy + ldpc):
+**Run research tools:**
 
 ```bash
 uv run --extra research python research/recipes/01_build_and_submit_bb.py


### PR DESCRIPTION
The research command already passes `--extra research`, which pulls scipy and ldpc through uv. Stating "(requires scipy + ldpc)" implies a manual install that does not exist.