### PR TITLE
README: drop the seeding-baseline note

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,3 @@ Verify locally before opening a PR (uv handles the environment):
 ```
 uv run python verify/qldpc_verify.py codes/your-code.json
 ```
-
-The boards are seeded with the codes of Liang, Eberhardt, Chen
-(arXiv:2504.08887) as the reference baseline.


### PR DESCRIPTION
Removes the closing line about the boards being seeded with Liang/Eberhardt/Chen. Not needed in the README; TRACKS.md covers the baseline.