### PR TITLE
Keep the table header visible while scrolling

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/docs/index.html
+++ b/docs/index.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
@@ -536,5 +546,20 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
  apply();
+})();
+
+// Keep the table header visible while scrolling. On wide screens the plots are
+// pinned at the top, so offset the sticky header by their rendered height; when
+// the plots are not pinned (narrow screens) the offset is 0. Re-sync on resize.
+(function(){
+ const plots=document.querySelector('.explorer .plots');
+ const board=document.querySelector('table.board');
+ if(!plots||!board) return;
+ function sync(){
+  const pinned=getComputedStyle(plots).position==='sticky';
+  const h=pinned?Math.round(plots.getBoundingClientRect().height):0;
+  board.style.setProperty('--ploth',h+'px');
+ }
+ sync();window.addEventListener('resize',sync);window.addEventListener('load',sync);
 })();
 </script></body></html>

--- a/docs/references.html
+++ b/docs/references.html
@@ -162,6 +162,12 @@ font-size:14px;margin:12px 0}
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}
 .board th:hover{color:var(--ink)}.board td.num,.board th.num{text-align:center;
 font-variant-numeric:tabular-nums}
 .board td.auth{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -242,7 +248,11 @@ vertical-align:middle}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{overflow:visible}}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}

--- a/site/build.py
+++ b/site/build.py
@@ -464,6 +464,12 @@ font-size:14px;margin:12px 0}}
 border-bottom:1px solid var(--ln)}}
 .board th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}}
+/* Header stays visible while the table scrolls. It pins below the pinned plots,
+   whose rendered height a script keeps in --ploth (0 when nothing is pinned).
+   box-shadow stands in for the bottom border, which a collapsed table drops
+   from a sticky cell. */
+.board thead th{{position:sticky;top:var(--ploth,0px);z-index:3;
+background:var(--bg);box-shadow:0 2px 0 var(--ln)}}
 .board th:hover{{color:var(--ink)}}.board td.num,.board th.num{{text-align:center;
 font-variant-numeric:tabular-nums}}
 .board td.auth{{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
@@ -544,7 +550,11 @@ vertical-align:middle}}
    instead of pinning over it. Wide screens only (narrow stacks the plots tall). */
 @media(min-width:760px){{.explorer .plots{{position:sticky;top:0;z-index:5;
 background:var(--bg);padding-top:8px;
-box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}}}
+box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
+/* Drop the horizontal-scroll context on wide screens (the table fits the page
+   here), so the sticky header pins to the viewport below the plots rather than
+   to this wrapper, which would trap it. */
+.boardscroll{{overflow:visible}}}}
 @media(max-width:880px){{table.board{{table-layout:auto;min-width:600px}}
 .board .model{{display:none}}}}
 @media(max-width:680px){{.board .date{{display:none}}}}
@@ -731,6 +741,21 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
  apply();
+})();
+
+// Keep the table header visible while scrolling. On wide screens the plots are
+// pinned at the top, so offset the sticky header by their rendered height; when
+// the plots are not pinned (narrow screens) the offset is 0. Re-sync on resize.
+(function(){
+ const plots=document.querySelector('.explorer .plots');
+ const board=document.querySelector('table.board');
+ if(!plots||!board) return;
+ function sync(){
+  const pinned=getComputedStyle(plots).position==='sticky';
+  const h=pinned?Math.round(plots.getBoundingClientRect().height):0;
+  board.style.setProperty('--ploth',h+'px');
+ }
+ sync();window.addEventListener('resize',sync);window.addEventListener('load',sync);
 })();
 """
 


### PR DESCRIPTION
The column header now sticks below the pinned plots as the rows scroll, so you don't lose track of which column is which.

- A small script tracks the pinned plots' rendered height and offsets the sticky header by it (0 when nothing is pinned, e.g. narrow screens).
- The horizontal-scroll wrapper (overflow-x:auto) created a scroll context that trapped the sticky header to the wrapper instead of the viewport. Drop that context on wide screens, where the table fits the page; narrow screens keep horizontal scroll.