### PR TITLE
research kit: migrate examples to the layered track scheme

### DIFF
--- a/research/GETTING_STARTED.md
+++ b/research/GETTING_STARTED.md
@@ -36,14 +36,17 @@ Every constructor returns two parity-check matrices `HX, HZ` (numpy int arrays,
 shape `(num_checks, n)`) for a CSS code. Pick by the track you're aiming at
 (see `../TRACKS.md`):
 
-Check weight is not a track — it is the `w` property (filtered by the board's
-weight slider), shown below as the typical check weight each family produces.
+Track membership is **computed by the verifier**, not declared: the check-weight
+class (`weight-4`/`weight-6`/`weight-8`) is derived from the max row weight of
+`H_X`, `H_Z`, and the locality class from the layout (none here → `unrestricted`).
+The `family` tag below is the only self-declared label, and it is filterable,
+never ranked. The weight column is the class each family typically lands in.
 
-| Module | Family | Track / weight | CSS holds because |
+| Module | `family` tag | Typical weight class | CSS holds because |
 |---|---|---|---|
-| `bb.py` | bivariate bicycle on a torus Z_l × Z_m (the "gross code" family) | `bivariate bicycle (periodic)`, w 6 | abelian circulants commute |
-| `group_algebra.py` | two-block group-algebra (2BGA) on **any** finite group | `generalized bicycle`, w 6 | left/right multiplication commute |
-| `coset.py` | coset 2BGA on G/H (record efficiencies; non-normal H) | no track, w 8 | left action commutes with right action by the normalizer |
+| `bb.py` | `bivariate-bicycle` (torus Z_l × Z_m, the "gross code" family) | `weight-6` | abelian circulants commute |
+| `group_algebra.py` | `generalized-bicycle` (2BGA on **any** finite group) | `weight-6` | left/right multiplication commute |
+| `coset.py` | `2bga-coset` (G/H cosets, record efficiencies; non-normal H) | `weight-8` | left action commutes with right action by the normalizer |
 
 `bb.py` is the place to start — it's the simplest and any choice of monomials is
 a valid code. `group_algebra.py` generalizes it to non-abelian groups (which can
@@ -129,16 +132,19 @@ doc = make_submission(
     name="[[72,12,6]] my BB code",
     construction="Bivariate bicycle on Z_6 x Z_6, A = x^3+y+y^2, B = y^3+x+x^2.",
     authors=["your-handle"],
-    tracks=["bivariate bicycle (periodic)"],
+    family="bivariate-bicycle",
     references=["arXiv:2308.07915"],
     confidence="upper_bound",
 )
 save_submission(doc, "codes/my-72-12-6.json")
 ```
 
-For the `2d-local-*` tracks, also pass `coordinates=[[x,y], ...]` (one per qubit)
-and `layers=`; `submit.py` fills the `locality` block and computes the true
-interaction radius for you.
+`family` is a filterable Layer-2 tag, never ranked. You do **not** declare which
+tracks you enter: the verifier computes primary-track membership (the weight and
+locality classes) from `H` and the layout. To enter the `2d-local-*` tracks, give
+the code a layout — pass `coordinates=[[x,y], ...]` (one per qubit) and `layers=`;
+`submit.py` fills the `locality` block and computes the interaction radius, and the
+verifier derives the locality class from it.
 
 ## 3b. Confirm the distance (optional but recommended)
 

--- a/research/recipes/01_build_and_submit_bb.py
+++ b/research/recipes/01_build_and_submit_bb.py
@@ -47,7 +47,7 @@ doc = make_submission(
     construction=("Periodic bivariate-bicycle code on Z_6 x Z_6, "
                   "A = x^3 + y + y^2, B = y^3 + x + x^2 (Bravyi et al.)."),
     authors=["your-handle"],
-    tracks=["bivariate bicycle (periodic)"],
+    family="bivariate-bicycle",
     references=["arXiv:2308.07915"],
     confidence="upper_bound",
 )

--- a/research/recipes/02_search_a_family.py
+++ b/research/recipes/02_search_a_family.py
@@ -53,13 +53,16 @@ assert compute_k(HX, HZ) == best["k"]
 # 4. Package + verify the winner. (make_submission re-evaluates the witnesses at
 #    higher trials, tightening the upper bound before we claim it. In a real
 #    search you would also confirm exactly -- research/distance.py.)
+#    `family` is the only self-declared tag (a filterable label, never ranked);
+#    the primary track membership (weight + locality class) is COMPUTED by the
+#    verifier from H and the layout, so we do not declare it.
 doc = make_submission(
     HX, HZ,
     name=f"[[{best['n']},{best['k']},{best['d']}]] searched BB code",
     construction=f"Bivariate bicycle on Z_{s['l']} x Z_{s['m']}, "
                  f"A={s['A']}, B={s['B']} (found by random search over the BB family).",
     authors=["your-handle"],
-    tracks=["bivariate bicycle (periodic)"],
+    family="bivariate-bicycle",
     confidence="upper_bound",
     trials=4000,
 )

--- a/research/submit.py
+++ b/research/submit.py
@@ -66,8 +66,8 @@ def validate(doc):
             for e in sorted(v.iter_errors(doc), key=lambda e: list(e.path))]
 
 
-def make_submission(HX, HZ, *, name, construction, authors, tracks,
-                    references=None, notes=None, date=None,
+def make_submission(HX, HZ, *, name, construction, authors, family=None,
+                    references=None, notes=None, date=None, tracks=(),
                     confidence="upper_bound", coordinates=None, layers=None,
                     trials=8000, seed=0):
     """Build a submission dict for the CSS code (HX, HZ).
@@ -78,15 +78,24 @@ def make_submission(HX, HZ, *, name, construction, authors, tracks,
         The CSS parity checks. CSS commutation is asserted.
     name, construction : str
         Human-readable name and how the code was built (provenance).
-    authors, tracks : list of str
-        Your author handle(s) and the tracks to enter (see TRACKS.md).
+    authors : list of str
+        Your author handle(s).
+    family : optional str
+        The Layer-2 construction-family tag (e.g. "bivariate-bicycle"; see the
+        schema enum / TRACKS.md). A filterable tag only -- it is never ranked,
+        and the primary track membership (locality + weight class) is computed by
+        the verifier from H and the layout, not declared here.
     confidence : {"upper_bound", "exact"}
         Distance confidence. ``distance_rand``-derived witnesses are honest
         upper bounds; mark ``"exact"`` only if you intend server certification.
     coordinates : optional list of [x, y], length n
-        Per-qubit layout for the 2d-local-* tracks; enables the locality block.
+        Per-qubit layout; enables the locality block, from which the verifier
+        derives the 2d-local track membership.
     layers : optional int
         Physical layers for the locality block (e.g. 2 for a flip-chip bilayer).
+    tracks : optional list of str
+        DEPRECATED and ignored for ranking; retained only for backward
+        compatibility. Track membership is computed by the verifier. Leave unset.
     trials, seed : int
         Budget/seed for the witness search.
 
@@ -131,8 +140,11 @@ def make_submission(HX, HZ, *, name, construction, authors, tracks,
             "date": date or datetime.date.today().isoformat(),
             "notes": notes or "",
         },
-        "tracks": list(tracks),
     }
+    if family is not None:
+        doc["family"] = family            # Layer-2 tag (filterable, never ranked)
+    if tracks:
+        doc["tracks"] = list(tracks)      # deprecated; only if explicitly passed
     if coordinates is not None:
         coords = [[float(x), float(y)] for x, y in coordinates]
         assert len(coords) == n, f"need {n} coordinates, got {len(coords)}"

--- a/research/test_smoke.py
+++ b/research/test_smoke.py
@@ -52,7 +52,7 @@ def main():
 
     # 3. Package and run through the REAL verifier (the drift gate).
     doc = make_submission(HX, HZ, name="[[72,12,6]] smoke", construction="bb torus",
-                          authors=["ci"], tracks=["bivariate bicycle (periodic)"],
+                          authors=["ci"], family="bivariate-bicycle",
                           confidence="upper_bound", trials=1000)
     check("packaged submission is schema-valid", not validate(doc))
     rep = qldpc_verify.verify(doc, refute=False)


### PR DESCRIPTION
The starter-kit examples still declared the legacy `tracks=["bivariate bicycle (periodic)"]`, but that field is deprecated and ignored for ranking -- primary track membership (weight + locality class) is now computed by the verifier from H and the layout, and construction family is a self-declared Layer-2 tag.

- make_submission: add `family` (writes the Layer-2 tag); make `tracks` optional and documented as deprecated/back-compat (only written if explicitly passed).
- recipes 01 & 02, test_smoke: pass `family="bivariate-bicycle"` instead of the legacy track; recipe 02 notes that membership is computed, not declared.
- GETTING_STARTED: update the make_submission snippet and the family table (family tag + computed weight class, not self-declared tracks).

Verified: smoke test + both recipes pass; packaged docs carry `family` and no `tracks`, and the verifier computes weight_class/locality_class from H.