### PR TITLE
Full-width primary-tracks grid; hover a plot point to scroll its row into view

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}
@@ -360,10 +343,7 @@ border-radius:5px;padding:1px 6px;white-space:nowrap;text-decoration:none}
 <header class=hero><svg class=heroflow viewBox="0 0 1200 360" preserveAspectRatio="xMidYMid slice" aria-hidden="true"><path d="M-60,90 C250,20 450,260 760,150 S1160,40 1300,120"/><path d="M-60,205 C200,300 500,80 790,225 S1110,265 1300,180"/><path d="M-60,300 C300,180 520,360 820,255 S1130,120 1300,300"/><path d="M-60,40 C220,140 480,-20 760,90 S1090,180 1300,50"/><path d="M-60,260 C280,360 540,200 800,320 S1190,220 1300,260"/></svg><div class=wrap><div class=brand><span class=brandmark><a href="https://unitary.foundation" aria-label="Unitary Foundation"><svg class=uflogo viewBox="0 0 295 69" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Unitary Foundation"><path fill-rule="evenodd" clip-rule="evenodd" d="M197.618 0.5H0.166016V68.5H294.833V35.2556H197.618V0.5Z" fill="#FFFF00"/><path d="M30.4623 32.9741H0.166992V2.67886H6.36507V27.0078H24.4959V2.67886H30.4623V32.9741ZM60.977 8.87694V32.9741H55.0106V14.8433H42.8462V32.9741H36.8798V8.87694H60.977ZM73.1668 1.11486V5.80686H67.2004V1.11486H73.1668ZM67.2004 9.22449H73.1668V32.9741H67.2004V9.22449ZM85.329 14.8433V27.0078H97.4934V32.9741H79.3626V0.999007H85.329V8.87694H97.4934V14.8433H85.329ZM127.959 8.81901V32.9162H103.63V18.4347H121.761V14.4958H103.63V8.81901H127.959ZM121.761 27.5291V23.3584H109.828V27.5291H121.761ZM153.007 8.87694V20.8097H146.809V14.8433H140.206V32.9741H134.008V8.87694H153.007ZM182.542 32.9741L172.463 42.9374H167.771V39.0563L174.085 32.9741H158.445V8.87694H164.411V27.0078H176.576V8.87694H182.542V32.9741Z" fill="black"/><path d="M6.13336 44.4082V50.6062H30.2306V56.5726H6.13336V68.7371H0.166992V38.4418H30.2306V44.4082H6.13336ZM61.2087 44.6399V68.7371H36.8798V44.6399H61.2087ZM55.0106 50.6062H43.0779V62.7707H55.0106V50.6062ZM91.5239 68.7371H67.4267V44.6399H73.3931V62.7707H85.5575V44.6399H91.5239V68.7371ZM121.731 44.6399V68.7371H115.765V50.6062H103.601V68.7371H97.6342V44.6399H121.731ZM152.284 36.5882V68.7371H127.955V44.6399H146.086V36.5882H152.284ZM146.086 62.7707V50.6062H133.921V62.7707H146.086ZM182.604 44.5819V68.6791H158.275V54.1977H176.406V50.2587H158.275V44.5819H182.604ZM176.406 63.292V59.1214H164.473V63.292H176.406ZM194.619 50.6062V62.7707H206.783V68.7371H188.653V36.7619H194.619V44.6399H206.783V50.6062H194.619ZM218.887 36.8778V41.5698H212.92V36.8778H218.887ZM212.92 44.9874H218.887V68.7371H212.92V44.9874ZM249.411 44.6399V68.7371H225.083V44.6399H249.411ZM243.213 50.6062H231.281V62.7707H243.213V50.6062ZM279.727 44.6399V68.7371H273.76V50.6062H261.596V68.7371H255.629V44.6399H279.727Z" fill="black"/></svg></a></span></div><h1>QEC Challenge</h1><p>Find better quantum LDPC codes. <a href="planar_code_challenge.pdf">Read the whitepaper.</a></p><nav class=topnav><a href="faq.html">FAQ</a><a href="references.html">References</a><a href="https://github.com/unitaryfoundation/qldpc-challenge"><svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a></nav></div></header>
 <div class=wrap>
 <section class=statsbar><div class="stat-card hero" title="new codes found and submitted through the challenge"><div class=v>21</div><div class=l>new codes</div></div><div class="stat-card" title="published codes seeded as the bar to beat"><div class=v>19</div><div class=l>literature baselines</div></div><div class="stat-card" title="distance proven exact by server-side certification (d =)"><div class=v>27</div><div class=l>certified exact</div></div><div class="stat-card" title="kd^2/n is the Bravyi-Poulin-Terhal saturation ratio. It is bounded and meaningful for 2D-local / bounded-weight codes at comparable n, but grows with n for high-rate codes, so it is compared within tracks, not as a global record. This is the best among the codes on this board."><div class=v>21.778</div><div class=l>best kd&sup2;/n on the board</div></div></section>
-<div class=toprow>
-<section class=challenges><h2 class=chalh>Open challenges</h2><p class=chalsub>Bars to beat. Found a better code? <code>./qldpc submit mycode.npz --authors @you</code></p><div class=chalgrid><div class=chal><div class=chaltitle>2D-local efficiency</div><div class=chalnow>best on board kd&sup2;/n 8 (<a href="codes/294-12-14.html">[[294,12,14]]</a>)</div><div class=chalgoal>reach kd&sup2;/n 12.7, the [[512,18,19]] tile code (arXiv:2504.09171, exact, check weight 8), with a verified flip-chip layout.</div></div><div class=chal><div class=chaltitle>High-rate / large-block</div><div class=chalnow>no verified entries yet</div><div class=chalgoal>land a high-rate code with a checkable distance witness. Bars: [[9216,4612,&le;48]] and [[16384,4142,&le;40]] (Kasai et al, arXiv:2601.08824 / 2604.20838).</div></div></div></section>
-<section class=ptgrid><h2 class=track>Primary tracks</h2><p class=ptsub>The leaderboards are the computed grid of locality &times; check weight. Membership is derived from <code>H</code> and the layout, not self-declared, and nests: a tighter cell&rsquo;s codes also compete in the looser ones. Each cell shows its size and its kd&sup2;/n leader.</p><div class=ptscroll><table class=grid><tr><th class=gcorner></th><th>weight ≤ 4</th><th>weight ≤ 6</th><th>weight ≤ 8</th><th>any weight</th></tr><tr><th class=grow>2D-local single</th><td class=gempty></td><td class=gempty></td><td class=gempty></td><td class=gempty></td></tr><tr><th class=grow>2D-local bilayer</th><td class=gempty></td><td class=gcell><div class=gcount>13 codes</div><a class=gbest href="codes/288-8-12.html">[[288,8,12]]</a><div class=geff>kd&sup2;/n 4</div></td><td class=gcell><div class=gcount>14 codes</div><a class=gbest href="codes/294-12-14.html">[[294,12,14]]</a><div class=geff>kd&sup2;/n 8</div></td><td class=gcell><div class=gcount>14 codes</div><a class=gbest href="codes/294-12-14.html">[[294,12,14]]</a><div class=geff>kd&sup2;/n 8</div></td></tr><tr><th class=grow>unrestricted</th><td class=gcell><div class=gcount>7 codes</div><a class=gbest href="codes/16-2-4.html">[[16,2,4]]</a><div class=geff>kd&sup2;/n 2</div></td><td class=gcell><div class=gcount>36 codes</div><a class=gbest href="codes/288-12-18.html">[[288,12,18]]</a><div class=geff>kd&sup2;/n 13.5</div></td><td class=gcell><div class=gcount>39 codes</div><a class=gbest href="codes/180-20-14.html">[[180,20,14]]</a><div class=geff>kd&sup2;/n 21.778</div></td><td class=gcell><div class=gcount>40 codes</div><a class=gbest href="codes/180-20-14.html">[[180,20,14]]</a><div class=geff>kd&sup2;/n 21.778</div></td></tr></table></div></section>
-</div>
+<section class=ptgrid><h2 class=track>Primary tracks</h2><p class=ptsub>The leaderboards are the computed grid of locality &times; check weight. Membership is derived from <code>H</code> and the layout, not self-declared, and nests: a tighter cell&rsquo;s codes also compete in the looser ones. Each cell shows its size and its kd&sup2;/n leader.</p><div class=ptscroll><table class=grid><tr><th class=gcorner></th><th>weight ≤ 4</th><th>weight ≤ 6</th><th>weight ≤ 8</th><th>any weight</th></tr><tr><th class=grow>2D-local single</th><td class=gempty></td><td class=gempty></td><td class=gempty></td><td class=gempty></td></tr><tr><th class=grow>2D-local bilayer</th><td class=gempty></td><td class=gcell><div class=gcount>13 codes</div><a class=gbest href="codes/288-8-12.html">[[288,8,12]]</a><div class=geff>kd&sup2;/n 4</div></td><td class=gcell><div class=gcount>14 codes</div><a class=gbest href="codes/294-12-14.html">[[294,12,14]]</a><div class=geff>kd&sup2;/n 8</div></td><td class=gcell><div class=gcount>14 codes</div><a class=gbest href="codes/294-12-14.html">[[294,12,14]]</a><div class=geff>kd&sup2;/n 8</div></td></tr><tr><th class=grow>unrestricted</th><td class=gcell><div class=gcount>7 codes</div><a class=gbest href="codes/16-2-4.html">[[16,2,4]]</a><div class=geff>kd&sup2;/n 2</div></td><td class=gcell><div class=gcount>36 codes</div><a class=gbest href="codes/288-12-18.html">[[288,12,18]]</a><div class=geff>kd&sup2;/n 13.5</div></td><td class=gcell><div class=gcount>39 codes</div><a class=gbest href="codes/180-20-14.html">[[180,20,14]]</a><div class=geff>kd&sup2;/n 21.778</div></td><td class=gcell><div class=gcount>40 codes</div><a class=gbest href="codes/180-20-14.html">[[180,20,14]]</a><div class=geff>kd&sup2;/n 21.778</div></td></tr></table></div><p class=ptbars>Bars to beat (external): 2D-local kd&sup2;/n 12.7, the [[512,18,19]] tile code (arXiv:2504.09171); high-rate [[9216,4612,&le;48]] and [[16384,4142,&le;40]] (Kasai et al, arXiv:2601.08824 / 2604.20838).</p></section>
 <section class=lb id=leaderboard><div class=lbhead><div><h2 class=lbh>Leaderboard</h2><p class=lbsub>2 contributors &middot; 21 codes found through the challenge</p></div><button class=lbcta type=button onclick="document.getElementById(&quot;participate&quot;).showModal()">Participate</button></div><div class=lblist><a class=lbrow href="https://github.com/FarLab"><span class=lbrank>1</span><img class=lbav loading=lazy alt="" src="https://github.com/FarLab.png?size=64"><span class=lbname>@FarLab <span class=lbcrown title="top contributor">&#128081;</span></span><span class=lbm><b>20</b><span class=lbml>codes</span></span><span class=lbm><b>14</b><span class=lbml>on frontier</span></span><span class=lbm><b>16</b><span class=lbml>exact</span></span><span class=lbm><b>21.778</b><span class=lbml>best kd&sup2;/n</span></span></a><a class=lbrow href="https://github.com/vprusso"><span class=lbrank>2</span><img class=lbav loading=lazy alt="" src="https://github.com/vprusso.png?size=64"><span class=lbname>@vprusso</span><span class=lbm><b>18</b><span class=lbml>codes</span></span><span class=lbm><b>13</b><span class=lbml>on frontier</span></span><span class=lbm><b>16</b><span class=lbml>exact</span></span><span class=lbm><b>8</b><span class=lbml>best kd&sup2;/n</span></span></a></div><dialog id=participate class=modal><form method=dialog><button class=modalx autofocus aria-label="close">&times;</button></form><h3 class=modalh>Participate</h3><p class=modalsub>Run it yourself, or point a coding agent at it.</p><div class=codeblock><button class=copybtn type=button data-copy="git clone https://github.com/unitaryfoundation/qldpc-challenge
 cd qldpc-challenge
 ./qldpc submit mycode.npz --authors @you">copy</button><pre><code>git clone https://github.com/unitaryfoundation/qldpc-challenge
@@ -502,9 +482,22 @@ document.querySelectorAll('tr[data-href]').forEach(r=>{
 (function(){
  const mark=(code,on)=>document.querySelectorAll('[data-code="'+code+'"]')
   .forEach(el=>el.classList.toggle('xh',on));
+ const plots=document.querySelector('.explorer .plots');
+ // Hovering a chart point brings its table row into view (only when the row is
+ // hidden behind the pinned plots or below the fold, so a small sweep over
+ // visible points does not yank the page around).
+ const reveal=code=>{
+  const r=document.querySelector('tr[data-code="'+code+'"]');
+  if(!r||r.offsetParent===null)return;
+  const rect=r.getBoundingClientRect();
+  const top=plots?plots.getBoundingClientRect().bottom:0;
+  if(rect.top<top+8||rect.bottom>innerHeight-8)
+   r.scrollIntoView({block:'center'});
+ };
  document.querySelectorAll('[data-code]').forEach(el=>{
   const code=el.dataset.code;
-  el.addEventListener('mouseenter',()=>mark(code,true));
+  const isPoint=el.tagName.toLowerCase()==='circle';
+  el.addEventListener('mouseenter',()=>{mark(code,true); if(isPoint)reveal(code);});
   el.addEventListener('mouseleave',()=>mark(code,false));
  });
 })();

--- a/docs/references.html
+++ b/docs/references.html
@@ -62,18 +62,6 @@ background:var(--soft)}
 .stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
-.challenges{margin:20px 0}
-.chalh{margin:0 0 2px;font-size:20px}
-.chalsub{margin:0 0 12px;color:var(--mut);font-size:14px}
-.chalsub code{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}
-.chalgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}
-.chal{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}
-.chaltitle{font-weight:700;margin-bottom:6px}
-.chalnow{font-size:13px;color:var(--mut)}
-.chalgoal{font-size:14px;margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -186,14 +174,9 @@ box-shadow:inset 3px 0 0 var(--ac)}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}
 .tchip.loc{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}
-.toprow>.challenges{flex:1 1 300px;margin:0;min-width:0}
-.toprow>.ptgrid{flex:2 1 460px;margin:0;min-width:0}
-.toprow .challenges .chalgrid{grid-template-columns:1fr}
-.toprow .ptgrid h2.track{margin:0 0 4px;padding-top:0}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{margin:8px 0 4px}
+.ptbars{font-size:12px;color:var(--mut);margin:10px 0 0}
 .ptsub{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}
 .ptscroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table.grid{border-collapse:collapse;font-size:13px}

--- a/site/build.py
+++ b/site/build.py
@@ -364,18 +364,6 @@ background:var(--soft)}}
 .stat-card .v{{font-size:34px;font-weight:700;line-height:1.05}}
 .stat-card.hero .v{{color:var(--ac)}}
 .stat-card .l{{font-size:13px;color:var(--mut);margin-top:6px}}
-.challenges{{margin:20px 0}}
-.chalh{{margin:0 0 2px;font-size:20px}}
-.chalsub{{margin:0 0 12px;color:var(--mut);font-size:14px}}
-.chalsub code{{background:var(--soft);border:1px solid var(--ln);
-border-radius:6px;padding:2px 6px;font-size:13px}}
-.chalgrid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-gap:14px}}
-.chal{{border:1px solid var(--ln);border-radius:12px;padding:14px 16px;
-background:var(--soft)}}
-.chaltitle{{font-weight:700;margin-bottom:6px}}
-.chalnow{{font-size:13px;color:var(--mut)}}
-.chalgoal{{font-size:14px;margin-top:6px}}
 .lb{{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
 background:#fff;overflow:hidden}}
 .lbhead{{display:flex;justify-content:space-between;align-items:center;gap:16px;
@@ -488,14 +476,9 @@ box-shadow:inset 3px 0 0 var(--ac)}}
 margin:2px 4px 2px 0;border-radius:999px;background:var(--soft);color:var(--mut);
 border:1px solid var(--ln);white-space:nowrap}}
 .tchip.loc{{background:#eef2ff;color:#3730a3;border-color:#c7d2fe}}
-/* Open challenges beside the primary-tracks grid, one row to save height. */
-.toprow{{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;margin:20px 0}}
-.toprow>.challenges{{flex:1 1 300px;margin:0;min-width:0}}
-.toprow>.ptgrid{{flex:2 1 460px;margin:0;min-width:0}}
-.toprow .challenges .chalgrid{{grid-template-columns:1fr}}
-.toprow .ptgrid h2.track{{margin:0 0 4px;padding-top:0}}
 /* Primary-tracks grid (locality x weight). */
 .ptgrid{{margin:8px 0 4px}}
+.ptbars{{font-size:12px;color:var(--mut);margin:10px 0 0}}
 .ptsub{{font-size:13px;color:var(--mut);margin:2px 0 12px;max-width:760px}}
 .ptscroll{{overflow-x:auto;-webkit-overflow-scrolling:touch}}
 table.grid{{border-collapse:collapse;font-size:13px}}
@@ -694,9 +677,22 @@ document.querySelectorAll('tr[data-href]').forEach(r=>{
 (function(){
  const mark=(code,on)=>document.querySelectorAll('[data-code="'+code+'"]')
   .forEach(el=>el.classList.toggle('xh',on));
+ const plots=document.querySelector('.explorer .plots');
+ // Hovering a chart point brings its table row into view (only when the row is
+ // hidden behind the pinned plots or below the fold, so a small sweep over
+ // visible points does not yank the page around).
+ const reveal=code=>{
+  const r=document.querySelector('tr[data-code="'+code+'"]');
+  if(!r||r.offsetParent===null)return;
+  const rect=r.getBoundingClientRect();
+  const top=plots?plots.getBoundingClientRect().bottom:0;
+  if(rect.top<top+8||rect.bottom>innerHeight-8)
+   r.scrollIntoView({block:'center'});
+ };
  document.querySelectorAll('[data-code]').forEach(el=>{
   const code=el.dataset.code;
-  el.addEventListener('mouseenter',()=>mark(code,true));
+  const isPoint=el.tagName.toLowerCase()==='circle';
+  el.addEventListener('mouseenter',()=>{mark(code,true); if(isPoint)reveal(code);});
   el.addEventListener('mouseleave',()=>mark(code,false));
  });
 })();
@@ -1202,37 +1198,6 @@ def references_page(entries):
 
 
 
-def open_challenges_panel(entries):
-    """Bars to beat, stated up front so the board reads as a live competition.
-    The current-best figures are derived from the board; the targets are
-    external references (see TRACKS.md)."""
-    loc = [e for e in entries
-           if e["locality_class"] in ("local-2d-single", "local-2d-bilayer")]
-    best = max(loc, key=lambda e: e["eff"], default=None)
-    cur2d = (f'best on board kd&sup2;/n {best["eff"]:g} '
-             f'(<a href="codes/{best["slug"]}.html">'
-             f'[[{best["n"]},{best["k"]},{best["d"]}]]</a>)'
-             if best else "no entries yet")
-    cards = [
-        ("2D-local efficiency", cur2d,
-         "reach kd&sup2;/n 12.7, the [[512,18,19]] tile code "
-         "(arXiv:2504.09171, exact, check weight 8), with a verified flip-chip "
-         "layout."),
-        ("High-rate / large-block", "no verified entries yet",
-         "land a high-rate code with a checkable distance witness. Bars: "
-         "[[9216,4612,&le;48]] and [[16384,4142,&le;40]] "
-         "(Kasai et al, arXiv:2601.08824 / 2604.20838)."),
-    ]
-    body = "".join(f'<div class=chal><div class=chaltitle>{t}</div>'
-                   f'<div class=chalnow>{now}</div>'
-                   f'<div class=chalgoal>{goal}</div></div>'
-                   for t, now, goal in cards)
-    return ('<section class=challenges><h2 class=chalh>Open challenges</h2>'
-            '<p class=chalsub>Bars to beat. Found a better code? '
-            '<code>./qldpc submit mycode.npz --authors @you</code></p>'
-            f'<div class=chalgrid>{body}</div></section>')
-
-
 def progress_panel(entries, n_exact, best_eff):
     """The prominent stats bar at the top of the board: the headline numbers as
     big cards. This is the single home for the board's numbers (the hero carries
@@ -1573,7 +1538,11 @@ def primary_tracks_grid(entries, records):
             'codes also compete in the looser ones. Each cell shows its size and '
             'its kd&sup2;/n leader.</p>'
             f'<div class=ptscroll><table class=grid>{head}'
-            f'{"".join(body)}</table></div></section>')
+            f'{"".join(body)}</table></div>'
+            '<p class=ptbars>Bars to beat (external): 2D-local kd&sup2;/n 12.7, '
+            'the [[512,18,19]] tile code (arXiv:2504.09171); high-rate '
+            '[[9216,4612,&le;48]] and [[16384,4142,&le;40]] '
+            '(Kasai et al, arXiv:2601.08824 / 2604.20838).</p></section>')
 
 
 def board_controls(entries, records):
@@ -1766,12 +1735,7 @@ def build():
              '</div></header>')
     P.append('<div class=wrap>')
     P.append(progress_panel(entries, n_exact, best_eff))
-    # Open challenges and the primary-tracks grid sit side by side to save
-    # vertical space (they stack on narrow screens).
-    P.append('<div class=toprow>')
-    P.append(open_challenges_panel(entries))
     P.append(primary_tracks_grid(entries, records))
-    P.append('</div>')
     P.append(contributors_panel(entries))
     P.append('<div class=how>'
              '<div class=card><span class=n>1</span><h3>Build a code</h3>'


### PR DESCRIPTION
- Remove the Open challenges two-card panel (redundant with the grid and TRACKS.md, and cramped beside the grid). The primary-tracks grid is full width again, and the external bars to beat are kept as a single compact line under it.
- Hovering a chart point now repositions the table to that code's row (instant scrollIntoView centered, only when the row is hidden behind the pinned plots or below the fold, so a small sweep over visible points does not yank the page).