### PR TITLE
Harden submission integrity: k>=1 gate and PR-author identity binding

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,3 +26,6 @@ jobs:
         run: uv run --frozen python verify/verify_all.py
       - name: distance refutation gate (changed submissions only)
         run: uv run --frozen --with ldpc python verify/gate_changed.py origin/${{ github.base_ref || 'main' }}
+      - name: authorship check (PR author must be a listed @handle author)
+        if: github.event_name == 'pull_request'
+        run: uv run --frozen python verify/check_authorship.py --author "${{ github.event.pull_request.user.login }}" --base origin/${{ github.base_ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,9 @@ Useful flags:
 - `--dry-run` build and verify without writing.
 
 Then open a pull request adding only your file under `codes/`. CI re-runs the
-verifier; a green check is required to merge.
+verifier; a green check is required to merge. Open the PR from your own account:
+CI checks that the PR author is one of the code's `@handle` authors, so list
+yourself (literature baselines with no `@handle` are exempt).
 
 The distance gate is probabilistic: it runs a random-information-set search with
 a fresh random seed each run, so a green check is not a permanent guarantee. A

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -1,0 +1,104 @@
+"""Bind a submission to the person opening the PR.
+
+Author handles in a code's provenance are self-reported, so without a check
+anyone could submit a code under someone else's @handle. This asserts that the
+GitHub user opening the PR is listed among the @handle authors of every code
+they add or change. Literature baselines (no @handle authors) are exempt, and a
+maintainer submitting on someone's behalf just adds themselves as a co-author.
+
+Fails CLOSED only on a definite author/PR-author mismatch. Anything ambiguous
+(no author info, git/parse error) fails OPEN with a warning -- a bug here must
+not block legitimate contributions, since impersonation is lower-stakes than the
+distance checks and is also caught in human review.
+
+Usage:
+  python verify/check_authorship.py --author <github-login> [--base origin/main]
+  python verify/check_authorship.py --author <login> codes/a.json codes/b.json
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HANDLE = re.compile(r"^@([A-Za-z0-9-]+)$")
+
+
+def changed_codes(base):
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "--diff-filter=AM",
+             f"{base}...HEAD", "--", "codes"],
+            cwd=ROOT, text=True)
+    except Exception as e:
+        print(f"(could not diff vs {base}: {e}); skipping authorship check")
+        return None
+    return [f for f in out.split() if f.endswith(".json")]
+
+
+def handles(doc):
+    auth = (doc.get("provenance") or {}).get("authors") or []
+    out = []
+    for a in auth:
+        m = HANDLE.match(str(a).strip())
+        if m:
+            out.append(m.group(1).lower())
+    return out
+
+
+def main(argv):
+    author = None
+    if "--author" in argv:
+        i = argv.index("--author")
+        author = argv[i + 1].lower().lstrip("@")
+        argv = argv[:i] + argv[i + 2:]
+    base = "origin/main"
+    if "--base" in argv:
+        i = argv.index("--base")
+        base = argv[i + 1]
+        argv = argv[:i] + argv[i + 2:]
+    if not author:
+        print("no --author given; skipping authorship check")  # fail open
+        return 0
+
+    files = [a for a in argv if a.endswith(".json")]
+    if not files:
+        files = changed_codes(base)
+    if files is None or not files:
+        print("no added/changed code submissions to check")
+        return 0
+
+    violations = []
+    for f in files:
+        p = f if os.path.isabs(f) else os.path.join(ROOT, f)
+        if not os.path.exists(p):
+            continue
+        try:
+            doc = json.load(open(p))
+        except Exception as e:
+            print(f"(could not parse {f}: {e}); skipping it")  # fail open
+            continue
+        hs = handles(doc)
+        if not hs:
+            print(f"ok    {f}: no @handle authors (baseline/anonymous), exempt")
+            continue
+        if author in hs:
+            print(f"ok    {f}: PR author @{author} is listed")
+        else:
+            violations.append((f, hs))
+
+    if violations:
+        print("\nAuthorship mismatch: the PR author must be one of a code's "
+              "@handle authors.")
+        for f, hs in violations:
+            print(f"  {f}: authors {['@' + h for h in hs]} do not include "
+                  f"@{author}")
+        print("If you are submitting on someone's behalf, add yourself as a "
+              "co-author, or have them open the PR.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -200,6 +200,10 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     report["computed"].update(n=n, rank_HX=rx, rank_HZ=rz, k=k_computed)
     record("k_matches_claim", k_computed == doc["k"],
            f"computed k={k_computed}, claimed {doc['k']}")
+    # A code must encode at least one logical qubit; k<=0 is degenerate (nothing
+    # to protect) and has no distance, so reject it outright.
+    record("k_at_least_1", k_computed >= 1,
+           f"computed k={k_computed}; a submission must encode >= 1 logical qubit")
 
     # 5. check weights (for the weight-bounded tracks)
     wmax = max((len(s) for s in doc["checks"]["X"] + doc["checks"]["Z"]),


### PR DESCRIPTION
Two defenses against incorrect / garbage / impersonated submissions.

- Verifier rejects k < 1 (a degenerate code encodes nothing and has no distance).
- Author-identity binding: verify/check_authorship.py plus a CI step asserts the PR author is one of the code's @handle authors, so a code cannot be submitted under someone else's name. Literature baselines (no @handle) are exempt. It fails closed only on a definite mismatch and fails open on any ambiguity (git/parse error, no author info), so a bug here can't block a legitimate contribution.

Already in place (context): the verifier recomputes n, k, CSS commutation, check weight, and the distance witness from H (so those can't be faked), the refutation gate runs RIS + syndrome-decoder, and the weekly sweep re-runs with random seeds. Deeper/adaptive refutation specifically for record-claiming codes is filed as a follow-up.