### PR TITLE
Track-tab selector + mobile padding pass

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/docs/index.html
+++ b/docs/index.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}
@@ -353,7 +364,7 @@ cd qldpc-challenge
 <span class=cmt># bring your H_X / H_Z as mycode.npz (keys hx, hz)</span>
 ./qldpc submit mycode.npz --authors @you</code></pre></div><p class=modalfoot>It finds the distance witness, runs the verifier, and opens the PR for you.</p><p class=modalfoot>Have an LLM or coding agent? <a href="https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md#contribute-with-an-llm">Paste the research prompt</a> and it runs the whole loop. <a href="https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md">Full guide</a></p><script>(function(){var d=document.getElementById("participate");if(!d)return;d.addEventListener("click",function(e){if(e.target===d)d.close();});var c=d.querySelector(".copybtn");if(c)c.addEventListener("click",function(){navigator.clipboard.writeText(c.dataset.copy);var o=c.textContent;c.textContent="copied";setTimeout(function(){c.textContent=o;},1200);});})();</script></dialog></section>
 <div class=how><div class=card><span class=n>1</span><h3>Build a code</h3><p>A CSS qLDPC code, written as one JSON file with its parity checks and a distance witness.</p></div><div class=card><span class=n>2</span><h3>Open a PR</h3><p>Add it under <code>codes/</code>. CI runs the verifier on every submission automatically.</p></div><div class=card><span class=n>3</span><h3>Climb the board</h3><p>If it advances a track&rsquo;s frontier it is highlighted. Click any row for the witness, certificate, and checks.</p></div></div>
-<section id=board><h2 class=track>Codes <span class=tcount>&middot; 40 total, 32 records</span></h2><div class=searchbar><input id=boardsearch type=text autocomplete=off placeholder="search, e.g.  w&lt;=6 k&gt;=10 d&gt;=8  or  eff&gt;5" aria-label="search codes"><span id=boardcount class=searchcount></span></div><div class=typepills><button type=button class=typepill data-q="2d-local" title="filter to 2D-local codes">2D-local</button><button type=button class=typepill data-q="2bga" title="filter to the 2BGA coset family">2BGA coset</button><button type=button class=typepill data-q="bivariate" title="filter to the bivariate bicycle family">bivariate bicycle</button><button type=button class=typepill data-q="generalized" title="filter to the generalized bicycle family">generalized bicycle</button><button type=button class=typepill data-q="tile" title="filter to the tile family">tile</button><button type=button class=typepill data-q="topological" title="filter to the topological family">topological</button><span class=wfilter title="filter by maximum check weight w"><span class=wflabel>weight</span><span class=wfslider><span class=wftrack></span><span class=wffill id=wffill></span><input type=range id=wlo class=wfrange min=4 max=10 value=4 step=1 aria-label="minimum check weight"><input type=range id=whi class=wfrange min=4 max=10 value=10 step=1 aria-label="maximum check weight"></span><span class=wfval id=wfval>4&ndash;10</span></span><button type=button class="typepill clearpill" data-q="">clear</button></div><p class=searchhelp>Type terms (all must match): a family, author, or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> <code>eff&gt;=5</code>; <code>record</code> keeps only frontier rows.</p></section>
+<section id=board><h2 class=track>Codes <span class=tcount>&middot; 40 total, 32 records</span></h2><div class=searchbar><input id=boardsearch type=text autocomplete=off placeholder="search, e.g.  w&lt;=6 k&gt;=10 d&gt;=8  or  eff&gt;5" aria-label="search codes"><span id=boardcount class=searchcount></span></div><nav class=tracktabs><button type=button class="ttab active" data-q="" title="all codes">All</button><button type=button class=ttab data-q="2d-local" title="2D-local codes">2D-local</button><button type=button class=ttab data-q="2bga" title="the 2BGA coset family">2BGA coset</button><button type=button class=ttab data-q="bivariate" title="the bivariate bicycle family">bivariate bicycle</button><button type=button class=ttab data-q="generalized" title="the generalized bicycle family">generalized bicycle</button><button type=button class=ttab data-q="tile" title="the tile family">tile</button><button type=button class=ttab data-q="topological" title="the topological family">topological</button></nav><div class=filterrow><span class=wfilter title="filter by maximum check weight w"><span class=wflabel>weight</span><span class=wfslider><span class=wftrack></span><span class=wffill id=wffill></span><input type=range id=wlo class=wfrange min=4 max=10 value=4 step=1 aria-label="minimum check weight"><input type=range id=whi class=wfrange min=4 max=10 value=10 step=1 aria-label="maximum check weight"></span><span class=wfval id=wfval>4&ndash;10</span></span></div><p class=searchhelp>Type terms (all must match): a family, author, or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> <code>eff&gt;=5</code>; <code>record</code> keeps only frontier rows.</p></section>
 <div class=explorer>
 <div class=plots><svg viewBox="0 0 520 274" class="plot" role="img"><line x1="54" y1="22" x2="54" y2="248" stroke="#eef2f7"/><text x="54" y="266" font-size="12" fill="#475569" text-anchor="middle">0</text><line x1="189" y1="22" x2="189" y2="248" stroke="#eef2f7"/><text x="189" y="266" font-size="12" fill="#475569" text-anchor="middle">100</text><line x1="324" y1="22" x2="324" y2="248" stroke="#eef2f7"/><text x="324" y="266" font-size="12" fill="#475569" text-anchor="middle">200</text><line x1="459" y1="22" x2="459" y2="248" stroke="#eef2f7"/><text x="459" y="266" font-size="12" fill="#475569" text-anchor="middle">300</text><line x1="54" y1="248" x2="508" y2="248" stroke="#eef2f7"/><text x="46" y="252" font-size="12" fill="#475569" text-anchor="end">0</text><line x1="54" y1="185" x2="508" y2="185" stroke="#eef2f7"/><text x="46" y="189" font-size="12" fill="#475569" text-anchor="end">5</text><line x1="54" y1="122" x2="508" y2="122" stroke="#eef2f7"/><text x="46" y="126" font-size="12" fill="#475569" text-anchor="end">10</text><line x1="54" y1="60" x2="508" y2="60" stroke="#eef2f7"/><text x="46" y="64" font-size="12" fill="#475569" text-anchor="end">15</text><text x="14" y="135" font-size="13" fill="#334155" text-anchor="middle" transform="rotate(-90 14 135)">Code Distance (d)</text><circle class=pt data-code="108-8-10" cx="199.9" cy="122.4" r="4" fill="#fff" stroke="#36006c" stroke-width="2" pointer-events="none"/><circle class=hit data-code="108-8-10" cx="199.9" cy="122.4" r="12" fill="transparent" data-tip="[[108,8,10]]  kd2/n=7.407
 upper bound"/><circle class=pt data-code="112-6-7" cx="205.3" cy="160.1" r="6" fill="#059669" stroke="#059669" stroke-width="2" pointer-events="none"/><circle class=hit data-code="112-6-7" cx="205.3" cy="160.1" r="12" fill="transparent" data-tip="[[112,6,7]]  kd2/n=2.625
@@ -557,14 +568,19 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
   document.querySelectorAll('.plots svg.plot circle[data-code]').forEach(c=>{
    c.style.display=vis.has(c.dataset.code)?'':'none';});
  }
- q.addEventListener('input',apply);
- document.querySelectorAll('.typepill').forEach(p=>{
-  p.addEventListener('click',()=>{q.value=p.dataset.q;
-   // 'clear' resets every filter, including the weight slider, since it lives
-   // in this same filter row.
-   if(p.classList.contains('clearpill')&&wlo&&whi){
-    wlo.value=WMIN;whi.value=WMAX;wpaint();}
-   apply();q.focus();});});
+ // typing syncs the active tab (the one whose filter term matches, else none).
+ q.addEventListener('input',()=>{
+  document.querySelectorAll('.ttab').forEach(t=>
+   t.classList.toggle('active', t.dataset.q===q.value.trim()));
+  apply();});
+ document.querySelectorAll('.ttab').forEach(p=>{
+  p.addEventListener('click',()=>{
+   document.querySelectorAll('.ttab').forEach(t=>t.classList.remove('active'));
+   p.classList.add('active');
+   q.value=p.dataset.q;
+   // the All tab (empty filter) also resets the weight slider.
+   if(p.dataset.q===''&&wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+   apply();});});
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
  apply();

--- a/docs/references.html
+++ b/docs/references.html
@@ -201,11 +201,17 @@ font-family:inherit}
 #boardsearch:focus{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}
 .searchcount{font-size:13px;color:var(--mut);white-space:nowrap}
-.typepills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
-.typepill{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}
-.typepill:hover{border-color:var(--ac);color:var(--ac)}
-.clearpill{color:var(--mut)}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.tracktabs::-webkit-scrollbar{display:none}
+.ttab{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}
+.ttab:hover{border-color:var(--ac);color:var(--ac)}
+.ttab.active{background:var(--ac);border-color:var(--ac);color:#fff}
+.filterrow{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}
 .searchhelp{font-size:12px;color:var(--mut);margin:0 0 14px}
 .searchhelp code{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}
@@ -265,6 +271,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}
 @media(max-width:880px){table.board{table-layout:auto;min-width:600px}
 .board .model{display:none}}
 @media(max-width:680px){.board .date{display:none}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){.wrap{padding:0 14px}
+header.hero{padding:34px 0 30px}
+.statsbar{grid-template-columns:repeat(2,1fr);gap:10px}
+.stat-card{padding:14px 16px}.stat-card .v{font-size:27px}}
 .claimed{color:var(--mut);font-size:12px;font-style:italic}
 .b{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}

--- a/site/build.py
+++ b/site/build.py
@@ -503,11 +503,17 @@ font-family:inherit}}
 #boardsearch:focus{{outline:none;border-color:var(--ac);
 box-shadow:0 0 0 3px rgba(54,0,108,.15)}}
 .searchcount{{font-size:13px;color:var(--mut);white-space:nowrap}}
-.typepills{{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}}
-.typepill{{font-size:12px;padding:5px 11px;border-radius:999px;cursor:pointer;
-border:1px solid var(--ln);background:#fff;color:var(--mut);font-family:inherit}}
-.typepill:hover{{border-color:var(--ac);color:var(--ac)}}
-.clearpill{{color:var(--mut)}}
+/* Track tabs (OpenRouter-rankings style): a horizontal strip for picking the
+   view; the active tab is filled. Scrolls horizontally on narrow screens. */
+.tracktabs{{display:flex;gap:6px;margin:6px 0 10px;overflow-x:auto;
+-webkit-overflow-scrolling:touch;scrollbar-width:none}}
+.tracktabs::-webkit-scrollbar{{display:none}}
+.ttab{{flex:0 0 auto;font-size:13px;padding:6px 13px;border-radius:999px;
+cursor:pointer;border:1px solid var(--ln);background:#fff;color:var(--mut);
+font-family:inherit;white-space:nowrap}}
+.ttab:hover{{border-color:var(--ac);color:var(--ac)}}
+.ttab.active{{background:var(--ac);border-color:var(--ac);color:#fff}}
+.filterrow{{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px;align-items:center}}
 .searchhelp{{font-size:12px;color:var(--mut);margin:0 0 14px}}
 .searchhelp code{{background:var(--soft);padding:1px 5px;border-radius:4px;
 font-size:11px}}
@@ -567,6 +573,11 @@ box-shadow:0 10px 10px -10px rgba(17,17,17,.18)}}
 @media(max-width:880px){{table.board{{table-layout:auto;min-width:600px}}
 .board .model{{display:none}}}}
 @media(max-width:680px){{.board .date{{display:none}}}}
+/* phones: reclaim horizontal space and shrink oversized headers */
+@media(max-width:560px){{.wrap{{padding:0 14px}}
+header.hero{{padding:34px 0 30px}}
+.statsbar{{grid-template-columns:repeat(2,1fr);gap:10px}}
+.stat-card{{padding:14px 16px}}.stat-card .v{{font-size:27px}}}}
 .claimed{{color:var(--mut);font-size:12px;font-style:italic}}
 .b{{display:inline-block;font-size:11px;font-weight:700;padding:1px 6px;
 border-radius:5px;font-family:ui-monospace,monospace}}
@@ -752,14 +763,19 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
   document.querySelectorAll('.plots svg.plot circle[data-code]').forEach(c=>{
    c.style.display=vis.has(c.dataset.code)?'':'none';});
  }
- q.addEventListener('input',apply);
- document.querySelectorAll('.typepill').forEach(p=>{
-  p.addEventListener('click',()=>{q.value=p.dataset.q;
-   // 'clear' resets every filter, including the weight slider, since it lives
-   // in this same filter row.
-   if(p.classList.contains('clearpill')&&wlo&&whi){
-    wlo.value=WMIN;whi.value=WMAX;wpaint();}
-   apply();q.focus();});});
+ // typing syncs the active tab (the one whose filter term matches, else none).
+ q.addEventListener('input',()=>{
+  document.querySelectorAll('.ttab').forEach(t=>
+   t.classList.toggle('active', t.dataset.q===q.value.trim()));
+  apply();});
+ document.querySelectorAll('.ttab').forEach(p=>{
+  p.addEventListener('click',()=>{
+   document.querySelectorAll('.ttab').forEach(t=>t.classList.remove('active'));
+   p.classList.add('active');
+   q.value=p.dataset.q;
+   // the All tab (empty filter) also resets the weight slider.
+   if(p.dataset.q===''&&wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+   apply();});});
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
  apply();
@@ -1566,14 +1582,18 @@ def board_controls(entries, records):
     finds the table by id, so its position relative to the table is free. Filters:
     a 2D-local pill (locality is computed), a family-tag pill per family present,
     and the check-weight slider."""
-    pills = ""
+    # A tab strip (All + 2D-local + one per family) for picking the view, in the
+    # OpenRouter rankings style. Each tab filters the table and charts; the active
+    # tab is highlighted. The strip scrolls horizontally on narrow screens.
+    tabs = ('<button type=button class="ttab active" data-q="" '
+            'title="all codes">All</button>')
     if any(e["locality_class"] != "unrestricted" for e in entries):
-        pills += ('<button type=button class=typepill data-q="2d-local" '
-                  'title="filter to 2D-local codes">2D-local</button>')
+        tabs += ('<button type=button class=ttab data-q="2d-local" '
+                 'title="2D-local codes">2D-local</button>')
     families = sorted({e["family"] for e in entries})
-    pills += "".join(
-        f'<button type=button class=typepill data-q="{html.escape(FAMILY_TERM.get(f, f))}" '
-        f'title="filter to the {html.escape(family_label(f))} family">'
+    tabs += "".join(
+        f'<button type=button class=ttab data-q="{html.escape(FAMILY_TERM.get(f, f))}" '
+        f'title="the {html.escape(family_label(f))} family">'
         f'{html.escape(family_label(f))}</button>'
         for f in families)
     weights = [e["w"] for e in entries if e["w"] is not None]
@@ -1602,9 +1622,8 @@ def board_controls(entries, records):
             'placeholder="search, e.g.  w&lt;=6 k&gt;=10 d&gt;=8  or  '
             'eff&gt;5" aria-label="search codes">'
             '<span id=boardcount class=searchcount></span></div>'
-            f'<div class=typepills>{pills}{wslider}'
-            '<button type=button class="typepill clearpill" data-q="">'
-            'clear</button></div>'
+            f'<nav class=tracktabs>{tabs}</nav>'
+            f'<div class=filterrow>{wslider}</div>'
             '<p class=searchhelp>Type terms (all must match): a family, author, '
             'or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> '
             '<code>eff&gt;=5</code>; <code>record</code> keeps only frontier '


### PR DESCRIPTION
Borrows the OpenRouter rankings tab pattern: the filter pills become a horizontal tab strip (All / 2D-local / one tab per family). Clicking a tab filters the table and the charts and highlights the active tab; the weight slider moves to its own row. The strip scrolls horizontally on narrow screens.

Also a small-screen pass: reduce page/hero padding and shrink the stat cards under 560px to reclaim horizontal space.

Verified at desktop (tab click sets active state, filters table + charts, updates the count). I could not render a true phone viewport in this environment, so the mobile changes need a check on a real device.