### PR TITLE
Add a distance range slider (mirrors the weight slider)

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;
@@ -364,7 +364,7 @@ cd qldpc-challenge
 <span class=cmt># bring your H_X / H_Z as mycode.npz (keys hx, hz)</span>
 ./qldpc submit mycode.npz --authors @you</code></pre></div><p class=modalfoot>It finds the distance witness, runs the verifier, and opens the PR for you.</p><p class=modalfoot>Have an LLM or coding agent? <a href="https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md#contribute-with-an-llm">Paste the research prompt</a> and it runs the whole loop. <a href="https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md">Full guide</a></p><script>(function(){var d=document.getElementById("participate");if(!d)return;d.addEventListener("click",function(e){if(e.target===d)d.close();});var c=d.querySelector(".copybtn");if(c)c.addEventListener("click",function(){navigator.clipboard.writeText(c.dataset.copy);var o=c.textContent;c.textContent="copied";setTimeout(function(){c.textContent=o;},1200);});})();</script></dialog></section>
 <div class=how><div class=card><span class=n>1</span><h3>Build a code</h3><p>A CSS qLDPC code, written as one JSON file with its parity checks and a distance witness.</p></div><div class=card><span class=n>2</span><h3>Open a PR</h3><p>Add it under <code>codes/</code>. CI runs the verifier on every submission automatically.</p></div><div class=card><span class=n>3</span><h3>Climb the board</h3><p>If it advances a track&rsquo;s frontier it is highlighted. Click any row for the witness, certificate, and checks.</p></div></div>
-<section id=board><h2 class=track>Codes <span class=tcount>&middot; 40 total, 32 records</span></h2><div class=searchbar><input id=boardsearch type=text autocomplete=off placeholder="search, e.g.  w&lt;=6 k&gt;=10 d&gt;=8  or  eff&gt;5" aria-label="search codes"><span id=boardcount class=searchcount></span></div><nav class=tracktabs><button type=button class="ttab active" data-q="" title="all codes">All</button><button type=button class=ttab data-q="2d-local" title="2D-local codes">2D-local</button><button type=button class=ttab data-q="2bga" title="the 2BGA coset family">2BGA coset</button><button type=button class=ttab data-q="bivariate" title="the bivariate bicycle family">bivariate bicycle</button><button type=button class=ttab data-q="generalized" title="the generalized bicycle family">generalized bicycle</button><button type=button class=ttab data-q="tile" title="the tile family">tile</button><button type=button class=ttab data-q="topological" title="the topological family">topological</button></nav><div class=filterrow><span class=wfilter title="filter by maximum check weight w"><span class=wflabel>weight</span><span class=wfslider><span class=wftrack></span><span class=wffill id=wffill></span><input type=range id=wlo class=wfrange min=4 max=10 value=4 step=1 aria-label="minimum check weight"><input type=range id=whi class=wfrange min=4 max=10 value=10 step=1 aria-label="maximum check weight"></span><span class=wfval id=wfval>4&ndash;10</span></span></div><p class=searchhelp>Type terms (all must match): a family, author, or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> <code>eff&gt;=5</code>; <code>record</code> keeps only frontier rows.</p></section>
+<section id=board><h2 class=track>Codes <span class=tcount>&middot; 40 total, 32 records</span></h2><div class=searchbar><input id=boardsearch type=text autocomplete=off placeholder="search, e.g.  w&lt;=6 k&gt;=10 d&gt;=8  or  eff&gt;5" aria-label="search codes"><span id=boardcount class=searchcount></span></div><nav class=tracktabs><button type=button class="ttab active" data-q="" title="all codes">All</button><button type=button class=ttab data-q="2d-local" title="2D-local codes">2D-local</button><button type=button class=ttab data-q="2bga" title="the 2BGA coset family">2BGA coset</button><button type=button class=ttab data-q="bivariate" title="the bivariate bicycle family">bivariate bicycle</button><button type=button class=ttab data-q="generalized" title="the generalized bicycle family">generalized bicycle</button><button type=button class=ttab data-q="tile" title="the tile family">tile</button><button type=button class=ttab data-q="topological" title="the topological family">topological</button></nav><div class=filterrow><span class=wfilter title="filter by maximum check weight w"><span class=wflabel>weight</span><span class=wfslider><span class=wftrack></span><span class=wffill id=wffill></span><input type=range id=wlo class=wfrange min=4 max=10 value=4 step=1 aria-label="minimum check weight"><input type=range id=whi class=wfrange min=4 max=10 value=10 step=1 aria-label="maximum check weight"></span><span class=wfval id=wfval>4&ndash;10</span></span><span class=wfilter title="filter by code distance d"><span class=wflabel>distance</span><span class=wfslider><span class=wftrack></span><span class=wffill id=dffill></span><input type=range id=dlo class=wfrange min=3 max=18 value=3 step=1 aria-label="minimum distance"><input type=range id=dhi class=wfrange min=3 max=18 value=18 step=1 aria-label="maximum distance"></span><span class=wfval id=dfval>3&ndash;18</span></span></div><p class=searchhelp>Type terms (all must match): a family, author, or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> <code>eff&gt;=5</code>; <code>record</code> keeps only frontier rows.</p></section>
 <div class=explorer>
 <div class=plots><svg viewBox="0 0 520 274" class="plot" role="img"><line x1="54" y1="22" x2="54" y2="248" stroke="#eef2f7"/><text x="54" y="266" font-size="12" fill="#475569" text-anchor="middle">0</text><line x1="189" y1="22" x2="189" y2="248" stroke="#eef2f7"/><text x="189" y="266" font-size="12" fill="#475569" text-anchor="middle">100</text><line x1="324" y1="22" x2="324" y2="248" stroke="#eef2f7"/><text x="324" y="266" font-size="12" fill="#475569" text-anchor="middle">200</text><line x1="459" y1="22" x2="459" y2="248" stroke="#eef2f7"/><text x="459" y="266" font-size="12" fill="#475569" text-anchor="middle">300</text><line x1="54" y1="248" x2="508" y2="248" stroke="#eef2f7"/><text x="46" y="252" font-size="12" fill="#475569" text-anchor="end">0</text><line x1="54" y1="185" x2="508" y2="185" stroke="#eef2f7"/><text x="46" y="189" font-size="12" fill="#475569" text-anchor="end">5</text><line x1="54" y1="122" x2="508" y2="122" stroke="#eef2f7"/><text x="46" y="126" font-size="12" fill="#475569" text-anchor="end">10</text><line x1="54" y1="60" x2="508" y2="60" stroke="#eef2f7"/><text x="46" y="64" font-size="12" fill="#475569" text-anchor="end">15</text><text x="14" y="135" font-size="13" fill="#334155" text-anchor="middle" transform="rotate(-90 14 135)">Code Distance (d)</text><circle class=pt data-code="108-8-10" cx="199.9" cy="122.4" r="4" fill="#fff" stroke="#36006c" stroke-width="2" pointer-events="none"/><circle class=hit data-code="108-8-10" cx="199.9" cy="122.4" r="12" fill="transparent" data-tip="[[108,8,10]]  kd2/n=7.407
 upper bound"/><circle class=pt data-code="112-6-7" cx="205.3" cy="160.1" r="6" fill="#059669" stroke="#059669" stroke-width="2" pointer-events="none"/><circle class=hit data-code="112-6-7" cx="205.3" cy="160.1" r="12" fill="transparent" data-tip="[[112,6,7]]  kd2/n=2.625
@@ -539,6 +539,9 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
  const wlo=document.getElementById('wlo'),whi=document.getElementById('whi');
  const wfill=document.getElementById('wffill'),wval=document.getElementById('wfval');
  const WMIN=wlo?+wlo.min:0,WMAX=wlo?+wlo.max:0,wspan=(WMAX-WMIN)||1;
+ const dlo=document.getElementById('dlo'),dhi=document.getElementById('dhi');
+ const dfill=document.getElementById('dffill'),dval=document.getElementById('dfval');
+ const DMIN=dlo?+dlo.min:0,DMAX=dlo?+dlo.max:0,dspan=(DMAX-DMIN)||1;
  const cmp=/^(n|k|d|w|eff)(>=|<=|>|<|=)(-?\d+(?:\.\d+)?)$/;
  function term(r,t){
   const m=t.match(cmp);
@@ -557,12 +560,18 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
   if(wfill){wfill.style.left=((b[0]-WMIN)/wspan*100)+'%';
    wfill.style.width=((b[1]-b[0])/wspan*100)+'%';}
   if(wval)wval.textContent=(b[0]===b[1])?(''+b[0]):(b[0]+'\u2013'+b[1]);}
+ function dbounds(){if(!dlo||!dhi)return[-Infinity,Infinity];
+  return[Math.min(+dlo.value,+dhi.value),Math.max(+dlo.value,+dhi.value)];}
+ function dpaint(){const b=dbounds();
+  if(dfill){dfill.style.left=((b[0]-DMIN)/dspan*100)+'%';
+   dfill.style.width=((b[1]-b[0])/dspan*100)+'%';}
+  if(dval)dval.textContent=(b[0]===b[1])?(''+b[0]):(b[0]+'\u2013'+b[1]);}
  function apply(){
   const toks=q.value.toLowerCase().trim().split(/\s+/).filter(Boolean);
-  const wb=wbounds();
+  const wb=wbounds(),db=dbounds();
   const vis=new Set();let shown=0;
-  rows.forEach(r=>{const w=+r.dataset.w;
-   const ok=(w>=wb[0]&&w<=wb[1])&&toks.every(t=>term(r,t));
+  rows.forEach(r=>{const w=+r.dataset.w,d=+r.dataset.d;
+   const ok=(w>=wb[0]&&w<=wb[1])&&(d>=db[0]&&d<=db[1])&&toks.every(t=>term(r,t));
    r.style.display=ok?'':'none';if(ok){shown++;vis.add(r.dataset.code);}});
   if(count)count.textContent=shown+(shown===rows.length?'':' of '+rows.length)+' codes';
   document.querySelectorAll('.plots svg.plot circle[data-code]').forEach(c=>{
@@ -578,11 +587,14 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
    document.querySelectorAll('.ttab').forEach(t=>t.classList.remove('active'));
    p.classList.add('active');
    q.value=p.dataset.q;
-   // the All tab (empty filter) also resets the weight slider.
-   if(p.dataset.q===''&&wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+   // the All tab (empty filter) also resets the weight and distance sliders.
+   if(p.dataset.q===''){if(wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+    if(dlo&&dhi){dlo.value=DMIN;dhi.value=DMAX;dpaint();}}
    apply();});});
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
+ if(dlo&&dhi){dlo.addEventListener('input',()=>{dpaint();apply();});
+  dhi.addEventListener('input',()=>{dpaint();apply();});dpaint();}
  apply();
 })();
 

--- a/docs/references.html
+++ b/docs/references.html
@@ -230,7 +230,7 @@ transform:translateY(-50%);border-radius:3px}
 .wffill{background:var(--ac)}
 .wfrange{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}
-#whi{z-index:2}
+#whi,#dhi{z-index:2}
 .wfrange::-webkit-slider-runnable-track{-webkit-appearance:none;background:none;
 height:16px}
 .wfrange::-webkit-slider-thumb{-webkit-appearance:none;pointer-events:auto;

--- a/site/build.py
+++ b/site/build.py
@@ -532,7 +532,7 @@ transform:translateY(-50%);border-radius:3px}}
 .wffill{{background:var(--ac)}}
 .wfrange{{position:absolute;top:0;left:0;width:100%;height:16px;margin:0;
 background:none;pointer-events:none;-webkit-appearance:none;appearance:none}}
-#whi{{z-index:2}}
+#whi,#dhi{{z-index:2}}
 .wfrange::-webkit-slider-runnable-track{{-webkit-appearance:none;background:none;
 height:16px}}
 .wfrange::-webkit-slider-thumb{{-webkit-appearance:none;pointer-events:auto;
@@ -734,6 +734,9 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
  const wlo=document.getElementById('wlo'),whi=document.getElementById('whi');
  const wfill=document.getElementById('wffill'),wval=document.getElementById('wfval');
  const WMIN=wlo?+wlo.min:0,WMAX=wlo?+wlo.max:0,wspan=(WMAX-WMIN)||1;
+ const dlo=document.getElementById('dlo'),dhi=document.getElementById('dhi');
+ const dfill=document.getElementById('dffill'),dval=document.getElementById('dfval');
+ const DMIN=dlo?+dlo.min:0,DMAX=dlo?+dlo.max:0,dspan=(DMAX-DMIN)||1;
  const cmp=/^(n|k|d|w|eff)(>=|<=|>|<|=)(-?\\d+(?:\\.\\d+)?)$/;
  function term(r,t){
   const m=t.match(cmp);
@@ -752,12 +755,18 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
   if(wfill){wfill.style.left=((b[0]-WMIN)/wspan*100)+'%';
    wfill.style.width=((b[1]-b[0])/wspan*100)+'%';}
   if(wval)wval.textContent=(b[0]===b[1])?(''+b[0]):(b[0]+'\\u2013'+b[1]);}
+ function dbounds(){if(!dlo||!dhi)return[-Infinity,Infinity];
+  return[Math.min(+dlo.value,+dhi.value),Math.max(+dlo.value,+dhi.value)];}
+ function dpaint(){const b=dbounds();
+  if(dfill){dfill.style.left=((b[0]-DMIN)/dspan*100)+'%';
+   dfill.style.width=((b[1]-b[0])/dspan*100)+'%';}
+  if(dval)dval.textContent=(b[0]===b[1])?(''+b[0]):(b[0]+'\\u2013'+b[1]);}
  function apply(){
   const toks=q.value.toLowerCase().trim().split(/\\s+/).filter(Boolean);
-  const wb=wbounds();
+  const wb=wbounds(),db=dbounds();
   const vis=new Set();let shown=0;
-  rows.forEach(r=>{const w=+r.dataset.w;
-   const ok=(w>=wb[0]&&w<=wb[1])&&toks.every(t=>term(r,t));
+  rows.forEach(r=>{const w=+r.dataset.w,d=+r.dataset.d;
+   const ok=(w>=wb[0]&&w<=wb[1])&&(d>=db[0]&&d<=db[1])&&toks.every(t=>term(r,t));
    r.style.display=ok?'':'none';if(ok){shown++;vis.add(r.dataset.code);}});
   if(count)count.textContent=shown+(shown===rows.length?'':' of '+rows.length)+' codes';
   document.querySelectorAll('.plots svg.plot circle[data-code]').forEach(c=>{
@@ -773,11 +782,14 @@ document.querySelectorAll('circle.hit[data-code]').forEach(c=>{
    document.querySelectorAll('.ttab').forEach(t=>t.classList.remove('active'));
    p.classList.add('active');
    q.value=p.dataset.q;
-   // the All tab (empty filter) also resets the weight slider.
-   if(p.dataset.q===''&&wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+   // the All tab (empty filter) also resets the weight and distance sliders.
+   if(p.dataset.q===''){if(wlo&&whi){wlo.value=WMIN;whi.value=WMAX;wpaint();}
+    if(dlo&&dhi){dlo.value=DMIN;dhi.value=DMAX;dpaint();}}
    apply();});});
  if(wlo&&whi){wlo.addEventListener('input',()=>{wpaint();apply();});
   whi.addEventListener('input',()=>{wpaint();apply();});wpaint();}
+ if(dlo&&dhi){dlo.addEventListener('input',()=>{dpaint();apply();});
+  dhi.addEventListener('input',()=>{dpaint();apply();});dpaint();}
  apply();
 })();
 
@@ -1613,6 +1625,21 @@ def board_controls(entries, records):
         '</span>'
         f'<span class=wfval id=wfval>{wmin}&ndash;{wmax}</span>'
         '</span>')
+    dists = [e["d"] for e in entries]
+    dmin, dmax = (min(dists), max(dists)) if dists else (0, 0)
+    # Same dual-handle range slider over the code distance d.
+    dslider = (
+        '<span class=wfilter title="filter by code distance d">'
+        '<span class=wflabel>distance</span>'
+        '<span class=wfslider>'
+        '<span class=wftrack></span><span class=wffill id=dffill></span>'
+        f'<input type=range id=dlo class=wfrange min={dmin} max={dmax} '
+        f'value={dmin} step=1 aria-label="minimum distance">'
+        f'<input type=range id=dhi class=wfrange min={dmin} max={dmax} '
+        f'value={dmax} step=1 aria-label="maximum distance">'
+        '</span>'
+        f'<span class=wfval id=dfval>{dmin}&ndash;{dmax}</span>'
+        '</span>')
     return ('<section id=board>'
             '<h2 class=track>Codes '
             f'<span class=tcount>&middot; {len(entries)} total, '
@@ -1623,7 +1650,7 @@ def board_controls(entries, records):
             'eff&gt;5" aria-label="search codes">'
             '<span id=boardcount class=searchcount></span></div>'
             f'<nav class=tracktabs>{tabs}</nav>'
-            f'<div class=filterrow>{wslider}</div>'
+            f'<div class=filterrow>{wslider}{dslider}</div>'
             '<p class=searchhelp>Type terms (all must match): a family, author, '
             'or a comparison like <code>k&gt;=10</code> <code>d&gt;8</code> '
             '<code>eff&gt;=5</code>; <code>record</code> keeps only frontier '


### PR DESCRIPTION
Adds a dual-handle range slider over code distance d next to the weight slider. It filters the table and the charts to a [d_min, d_max] range, resets with the All tab, and reuses the weight slider's styling. Verified: setting 12-14 filters 40 -> 9 rows, all with d in {12,13,14}.