### PR TITLE
Normalize certs + cert-vs-code consistency check

### DIFF
--- a/certs/126-28-8.json
+++ b/certs/126-28-8.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 28 Z-logical cosets = 8, all proven"
+   "note": "min over 28 Z-logical cosets = 8, all proven",
+   "value": 8,
+   "exact": true
   },
   "Z": {
-   "note": "min over 28 X-logical cosets = 8, all proven"
+   "note": "min over 28 X-logical cosets = 8, all proven",
+   "value": 8,
+   "exact": true
   }
- }
+ },
+ "d": 8
 }

--- a/certs/16-2-4.json
+++ b/certs/16-2-4.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 2 Z-logical cosets = 4, all proven"
+   "note": "min over 2 Z-logical cosets = 4, all proven",
+   "value": 4,
+   "exact": true
   },
   "Z": {
-   "note": "min over 2 X-logical cosets = 4, all proven"
+   "note": "min over 2 X-logical cosets = 4, all proven",
+   "value": 4,
+   "exact": true
   }
- }
+ },
+ "d": 4
 }

--- a/certs/25-1-5.json
+++ b/certs/25-1-5.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 1 Z-logical cosets = 5, all proven"
+   "note": "min over 1 Z-logical cosets = 5, all proven",
+   "value": 5,
+   "exact": true
   },
   "Z": {
-   "note": "min over 1 X-logical cosets = 5, all proven"
+   "note": "min over 1 X-logical cosets = 5, all proven",
+   "value": 5,
+   "exact": true
   }
- }
+ },
+ "d": 5
 }

--- a/certs/36-2-6.json
+++ b/certs/36-2-6.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 2 Z-logical cosets = 6, all proven"
+   "note": "min over 2 Z-logical cosets = 6, all proven",
+   "value": 6,
+   "exact": true
   },
   "Z": {
-   "note": "min over 2 X-logical cosets = 6, all proven"
+   "note": "min over 2 X-logical cosets = 6, all proven",
+   "value": 6,
+   "exact": true
   }
- }
+ },
+ "d": 6
 }

--- a/certs/49-1-7.json
+++ b/certs/49-1-7.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 1 Z-logical cosets = 7, all proven"
+   "note": "min over 1 Z-logical cosets = 7, all proven",
+   "value": 7,
+   "exact": true
   },
   "Z": {
-   "note": "min over 1 X-logical cosets = 7, all proven"
+   "note": "min over 1 X-logical cosets = 7, all proven",
+   "value": 7,
+   "exact": true
   }
- }
+ },
+ "d": 7
 }

--- a/certs/64-2-8.json
+++ b/certs/64-2-8.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 2 Z-logical cosets = 8, all proven"
+   "note": "min over 2 Z-logical cosets = 8, all proven",
+   "value": 8,
+   "exact": true
   },
   "Z": {
-   "note": "min over 2 X-logical cosets = 8, all proven"
+   "note": "min over 2 X-logical cosets = 8, all proven",
+   "value": 8,
+   "exact": true
   }
- }
+ },
+ "d": 8
 }

--- a/certs/7-1-3.json
+++ b/certs/7-1-3.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 1 Z-logical cosets = 3, all proven"
+   "note": "min over 1 Z-logical cosets = 3, all proven",
+   "value": 3,
+   "exact": true
   },
   "Z": {
-   "note": "min over 1 X-logical cosets = 3, all proven"
+   "note": "min over 1 X-logical cosets = 3, all proven",
+   "value": 3,
+   "exact": true
   }
- }
+ },
+ "d": 3
 }

--- a/certs/81-1-9.json
+++ b/certs/81-1-9.json
@@ -3,10 +3,15 @@
  "solver": "scipy/HiGHS MILP",
  "sides": {
   "X": {
-   "note": "min over 1 Z-logical cosets = 9, all proven"
+   "note": "min over 1 Z-logical cosets = 9, all proven",
+   "value": 9,
+   "exact": true
   },
   "Z": {
-   "note": "min over 1 X-logical cosets = 9, all proven"
+   "note": "min over 1 X-logical cosets = 9, all proven",
+   "value": 9,
+   "exact": true
   }
- }
+ },
+ "d": 9
 }

--- a/site/build.py
+++ b/site/build.py
@@ -860,6 +860,22 @@ def cert_info(slug):
     return None
 
 
+def cert_consistent(cert, doc):
+    """An exact certificate may only be honored if it agrees with the code's
+    current distance (overall and per side). Guards against a stale cert left
+    behind when a code's distance is edited without re-certifying."""
+    dist = doc["distance"]
+    if cert.get("d") is not None and cert["d"] != dist["d"]:
+        return False
+    sides = cert.get("sides") or {}
+    for side in ("X", "Z"):
+        cv = (sides.get(side) or {}).get("value")
+        dv = (dist.get(side) or {}).get("value")
+        if cv is not None and dv is not None and cv != dv:
+            return False
+    return True
+
+
 def heuristic_cert_info(slug):
     """Heuristic distance result (certs/heuristic/<slug>.json), if any. Carries a
     `verdict` of corroborated / refuted / inconclusive (see verify/heuristic_*)."""
@@ -884,9 +900,16 @@ def load_entries():
             continue
         cert = cert_info(slug)
         hcert = heuristic_cert_info(slug)
-        if cert and cert.get("d_exact"):
+        corroborated = hcert and hcert.get("verdict") == "corroborated"
+        if cert and cert.get("d_exact") and cert_consistent(cert, doc):
             tier = "exact"
-        elif hcert and hcert.get("verdict") == "corroborated":
+        elif cert and cert.get("d_exact"):
+            # cert claims exact but disagrees with the code's current distance
+            # (e.g. the code was edited without re-certifying); do not honor it.
+            print(f"  warning: {slug}: exact cert disagrees with the code's "
+                  f"distance; not labeling it d= (re-run verify/certify.py)")
+            tier = "corroborated" if corroborated else "ub"
+        elif corroborated:
             tier = "corroborated"
         else:
             tier = "ub"


### PR DESCRIPTION
Closes #63.

- Normalize the 8 legacy thin certs (the surface/toric/Steane codes and 126-28-8) to the structured format certify.py emits: a top-level d and per-side value/exact.
- Add a build-time consistency check: an exact cert is honored only if it agrees with the code's current distance, overall and per side. A stale cert (code edited without re-certifying) no longer silently labels the code d=; it logs a warning and the code falls back to corroborated/upper-bound. This is the systemic guard for the class of bug behind the surface-code side-distance issue.

Verified: all 27 exact codes stay exact (certs consistent), the check catches both d-drift and per-side drift, pytest passes.