### PR TITLE
Require earned distance witnesses

### DIFF
--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -34,9 +34,8 @@ Two principles drive the format:
   of checks; each check is the sorted list of distinct qubit indices (0-based,
   `< n`) it acts on. So `H_X` has `len(checks.X)` rows.
 - `distance.d`: claimed code distance, must equal the minimum over the
-  provided sides.
-- `distance.X`, `distance.Z` (each optional, but at least the minimizing side
-  is needed to certify `d`):
+  earned X and Z side distances.
+- `distance.X`, `distance.Z` (both required):
   - `value`: claimed minimum weight of a nontrivial logical of that type.
   - `confidence`: `"upper_bound"` or `"exact"`.
   - `witness`: support of a logical operator of that Pauli type and weight
@@ -99,6 +98,5 @@ through a maintainer-run path until the verifier is sparse end-to-end.
   away and silently change the code).
 - Store `interaction_radius` as the exact measured value, not a rounded one;
   a value rounded down below the true diameter will fail the `<=` check.
-- The minimizing distance side is what sets `d`. Provide both sides when you
-  know them; it is more informative and matches how distance is computed
-  (per Pauli type, `d = min(dX, dZ)`).
+- Both distance sides are required. The verifier earns the global `d` only when
+  both witnesses validate and `distance.d = min(dX, dZ)`.

--- a/schema/code.schema.json
+++ b/schema/code.schema.json
@@ -23,7 +23,7 @@
     },
     "distance": {
       "type": "object",
-      "required": ["d"],
+      "required": ["d", "X", "Z"],
       "additionalProperties": false,
       "properties": {
         "d": {"type": "integer", "minimum": 1, "description": "claimed code distance = min(dX, dZ)"},

--- a/site/build.py
+++ b/site/build.py
@@ -902,6 +902,10 @@ def load_entries():
         rep = verify(doc)   # site render: structural checks only, refutation is a CI/cron job
         if not rep["ok"]:
             continue
+        earned = rep["earned_distance"].get("d")
+        if not earned:
+            print(f"  warning: {slug}: no earned distance; skipping board entry")
+            continue
         cert = cert_info(slug)
         hcert = heuristic_cert_info(slug)
         corroborated = hcert and hcert.get("verdict") == "corroborated"
@@ -917,7 +921,7 @@ def load_entries():
             tier = "corroborated"
         else:
             tier = "ub"
-        n, k, d = doc["n"], doc["k"], doc["distance"]["d"]
+        n, k, d = doc["n"], doc["k"], earned["value"]
         entries.append({
             "slug": slug, "name": doc["name"], "n": n, "k": k, "d": d,
             "eff": round(k * d * d / n, 3), "tier": tier,

--- a/verify/certify.py
+++ b/verify/certify.py
@@ -80,6 +80,10 @@ def certify(doc, tlim=600):
     result = {"name": doc.get("name"), "d": d, "solver": "scipy/HiGHS MILP",
               "sides": {}}
     overall = True
+    missing = [side for side in ("X", "Z") if side not in doc["distance"]]
+    if missing:
+        result["missing_sides"] = missing
+        overall = False
     for side, H, LZ in (("X", HZ, gf2.logical_basis(HX, HZ)),
                         ("Z", HX, gf2.logical_basis(HZ, HX))):
         if side not in doc["distance"]:

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -133,6 +133,9 @@ def structure_errors(doc):
         if "checks" in doc and not (isinstance(doc["checks"], dict)
                                     and "X" in doc["checks"] and "Z" in doc["checks"]):
             errs.append("checks must have X and Z support lists")
+        if "distance" in doc and not (isinstance(doc["distance"], dict)
+                                      and all(k in doc["distance"] for k in ("d", "X", "Z"))):
+            errs.append("distance must have d, X, and Z witness blocks")
     if errs:
         return errs
     return resource_errors(doc)
@@ -315,8 +318,11 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     # 6. distance witnesses (self-certifying upper bounds)
     dist = doc["distance"]
     earned_d = []
+    earned_sides = set()
     for side, opp_H, own_H in (("X", HZ, HX), ("Z", HX, HZ)):
         if side not in dist:
+            record(f"distance_{side}_present", False,
+                   "both X and Z distance witnesses are required")
             continue
         sd = dist[side]
         v = _vec(sd["witness"], n)
@@ -332,18 +338,24 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
             report["earned_distance"][side] = {"value": sd["value"],
                                                "tier": tier}
             earned_d.append(sd["value"])
+            earned_sides.add(side)
             if sd["confidence"] == "exact":
                 record(f"distance_{side}_exact_flagged", True,
                        "exact claim accepted as upper_bound pending server "
                        "certification")
 
     # 7. code distance consistency
-    if earned_d:
+    if earned_sides == {"X", "Z"}:
         d_earned = min(earned_d)
-        record("d_matches_min_side", d_earned == dist["d"],
+        matches = d_earned == dist["d"]
+        record("d_matches_min_side", matches,
                f"min earned side = {d_earned}, claimed d = {dist['d']}")
-        report["earned_distance"]["d"] = {"value": dist["d"],
-                                          "tier": "upper_bound"}
+        if matches:
+            report["earned_distance"]["d"] = {"value": dist["d"],
+                                              "tier": "upper_bound"}
+    else:
+        record("distance_global_earned", False,
+               "valid X and Z witnesses are required to earn a global distance")
 
     # 8. independent distance refutation. A bounded RIS search must not find a
     #    logical lighter than the claimed distance. This is SOUND -- any hit is a
@@ -360,7 +372,7 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     #
     #    FAILS CLOSED: if the refuter cannot run, that is recorded as a FAILURE, not
     #    a silent pass -- a gate that fails open is no gate.
-    if refute and earned_d:
+    if refute and "d" in report["earned_distance"]:
         run_seed = seed if seed is not None else secrets.randbelow(2**31)
         try:
             import heuristic_distance

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -12,6 +12,7 @@ cannot slip a false claim onto the board.
 
 import copy
 import glob
+import importlib.util
 import json
 import os
 import sys
@@ -40,6 +41,14 @@ def rep(doc):
 
 def failed_checks(r):
     return {c["check"] for c in r["checks"] if not c["ok"]}
+
+
+def load_site_build():
+    spec = importlib.util.spec_from_file_location(
+        "site_build", os.path.join(ROOT, "site", "build.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def main():
@@ -105,6 +114,24 @@ def main():
     r = rep(d)
     check("inflated distance value rejected",
           not r["ok"] and "distance_X_witness" in failed_checks(r))
+    check("invalid side prevents global distance",
+          "d" not in r["earned_distance"])
+
+    # 6b. a bare distance number with no witnesses must not verify or render.
+    d = copy.deepcopy(GOOD)
+    d["distance"] = {"d": 99}
+    r = rep(d)
+    check("distance without witnesses rejected",
+          not r["ok"] and "d" not in r["earned_distance"])
+    build = load_site_build()
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "codes"))
+        with open(os.path.join(td, "codes", "bad.json"), "w") as f:
+            json.dump(d, f)
+        build.ROOT = td
+        build.CERTS = os.path.join(td, "certs")
+        check("site skips entries without an earned distance",
+              build.load_entries() == [])
 
     # 6b. resource limits must reject hostile shapes before dense matrices are built.
     d = copy.deepcopy(GOOD)


### PR DESCRIPTION
Closes #83.

## Summary

- Require both distance.X and distance.Z witness blocks in the submission schema.
- Make the verifier earn global d only when both side witnesses validate and distance.d matches min(dX, dZ).
- Make the site score entries from earned_distance.d and skip entries without an earned distance.
- Add adversarial regressions for bare distance.d claims and invalid one-sided distance earning.
- Make exact certification fail exactness when either side is missing.

## Verification

- uv run python verify/test_verifier.py
- uv run python verify/verify_all.py
- uv run python verify/test_refute_gate.py
- uv run python site/build.py
- uv run python research/test_smoke.py
- uv run python -m py_compile verify/qldpc_verify.py verify/test_verifier.py verify/certify.py site/build.py
