### PR TITLE
Validate submissions with trusted verifier code

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,12 +1,18 @@
 name: verify
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
+      - ".github/workflows/**"
       - "codes/**"
       - "verify/**"
       - "schema/**"
       - "research/**"
+      - "pyproject.toml"
+      - "uv.lock"
   push:
     branches: [main]
 
@@ -14,18 +20,62 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: check out submitted tree
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0          # full history so the gate can diff vs the base
+          path: submitted
+      - name: check out trusted verifier tree (base branch)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+          path: trusted
+      - name: check out trusted verifier tree (current ref)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: trusted
       - uses: astral-sh/setup-uv@v5
+      - name: detect changed code submissions
+        if: github.event_name == 'pull_request'
+        id: changes
+        working-directory: submitted
+        run: |
+          if git diff --quiet --diff-filter=AM origin/${{ github.base_ref }}...HEAD -- codes; then
+            echo "codes_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "codes_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: submission scope check (code data cannot change its own verifier)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        working-directory: trusted
+        run: uv run --frozen python verify/check_submission_scope.py --root ../submitted --base origin/${{ github.base_ref }}
       - name: verifier self-tests (must reject bad submissions)
+        working-directory: submitted
         run: uv run --frozen python verify/test_verifier.py
       - name: research starter-kit smoke test (kit stays in sync with the verifier)
+        working-directory: submitted
         run: uv run --frozen python research/test_smoke.py
+      - name: verify all submissions (trusted verifier for code changes)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        working-directory: trusted
+        run: uv run --frozen python verify/verify_all.py --root ../submitted
       - name: verify all submissions
+        if: github.event_name != 'pull_request' || steps.changes.outputs.codes_changed != 'true'
+        working-directory: submitted
         run: uv run --frozen python verify/verify_all.py
+      - name: distance refutation gate (trusted verifier for code changes)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        working-directory: trusted
+        run: uv run --frozen --with ldpc python verify/gate_changed.py --code-root ../submitted origin/${{ github.base_ref || 'main' }}
       - name: distance refutation gate (changed submissions only)
+        if: github.event_name != 'pull_request'
+        working-directory: submitted
         run: uv run --frozen --with ldpc python verify/gate_changed.py origin/${{ github.base_ref || 'main' }}
       - name: authorship check (PR author must be a listed @handle author)
-        if: github.event_name == 'pull_request'
-        run: uv run --frozen python verify/check_authorship.py --author "${{ github.event.pull_request.user.login }}" --base origin/${{ github.base_ref }}
+        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        working-directory: trusted
+        run: uv run --frozen python verify/check_authorship.py --root ../submitted --author "${{ github.event.pull_request.user.login }}" --base origin/${{ github.base_ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ verifier; a green check is required to merge. Open the PR from your own account:
 CI checks that the PR author is one of the code's `@handle` authors, so list
 yourself (literature baselines with no `@handle` are exempt).
 
+Submission PRs are treated as untrusted data. CI validates `codes/*.json` with
+verifier, schema, and gate code from the base branch, not from the PR itself. If
+you need to change validation code (`verify/`, `schema/`, workflow files, or the
+site builder), do that in a separate PR from any code submission so a submission
+cannot redefine the checks that judge it.
+
 The distance gate is probabilistic: it runs a random-information-set search with
 a fresh random seed each run, so a green check is not a permanent guarantee. A
 correct distance has no lighter logical to find and passes every time; an

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -12,7 +12,7 @@ not block legitimate contributions, since impersonation is lower-stakes than the
 distance checks and is also caught in human review.
 
 Usage:
-  python verify/check_authorship.py --author <github-login> [--base origin/main]
+  python verify/check_authorship.py --author <github-login> [--root PATH] [--base origin/main]
   python verify/check_authorship.py --author <login> codes/a.json codes/b.json
 """
 import json
@@ -25,12 +25,12 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 HANDLE = re.compile(r"^@([A-Za-z0-9-]+)$")
 
 
-def changed_codes(base):
+def changed_codes(base, root=ROOT):
     try:
         out = subprocess.check_output(
             ["git", "diff", "--name-only", "--diff-filter=AM",
              f"{base}...HEAD", "--", "codes"],
-            cwd=ROOT, text=True)
+            cwd=root, text=True)
     except Exception as e:
         print(f"(could not diff vs {base}: {e}); skipping authorship check")
         return None
@@ -54,6 +54,11 @@ def main(argv):
         author = argv[i + 1].lower().lstrip("@")
         argv = argv[:i] + argv[i + 2:]
     base = "origin/main"
+    root = ROOT
+    if "--root" in argv:
+        i = argv.index("--root")
+        root = os.path.abspath(argv[i + 1])
+        argv = argv[:i] + argv[i + 2:]
     if "--base" in argv:
         i = argv.index("--base")
         base = argv[i + 1]
@@ -64,14 +69,14 @@ def main(argv):
 
     files = [a for a in argv if a.endswith(".json")]
     if not files:
-        files = changed_codes(base)
+        files = changed_codes(base, root)
     if files is None or not files:
         print("no added/changed code submissions to check")
         return 0
 
     violations = []
     for f in files:
-        p = f if os.path.isabs(f) else os.path.join(ROOT, f)
+        p = f if os.path.isabs(f) else os.path.join(root, f)
         if not os.path.exists(p):
             continue
         try:

--- a/verify/check_submission_scope.py
+++ b/verify/check_submission_scope.py
@@ -1,0 +1,81 @@
+"""Guard the trust boundary for public code-submission PRs.
+
+Code submissions are untrusted data. Verifier, schema, workflow, and site-builder
+changes are trusted-code changes. A PR that changes both can otherwise submit a
+code and weaken the code that validates it in the same diff.
+
+Usage:
+  python verify/check_submission_scope.py [--root PATH] [--base origin/main]
+"""
+
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+CRITICAL_PREFIXES = (
+    ".github/workflows/",
+    "schema/",
+    "verify/",
+)
+CRITICAL_FILES = {
+    "site/build.py",
+    "pyproject.toml",
+    "uv.lock",
+}
+
+
+def changed_files(base, root):
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "--diff-filter=AMR",
+             f"{base}...HEAD"],
+            cwd=root, text=True)
+    except Exception as e:
+        print(f"could not diff vs {base}: {e}; failing closed")
+        return None
+    return [f for f in out.splitlines() if f]
+
+
+def is_code_submission(path):
+    return path.startswith("codes/") and path.endswith(".json")
+
+
+def is_critical(path):
+    return path in CRITICAL_FILES or any(path.startswith(p) for p in CRITICAL_PREFIXES)
+
+
+def main(argv):
+    root = ROOT
+    if "--root" in argv:
+        i = argv.index("--root")
+        root = os.path.abspath(argv[i + 1])
+        argv = argv[:i] + argv[i + 2:]
+    base = "origin/main"
+    if "--base" in argv:
+        i = argv.index("--base")
+        base = argv[i + 1]
+
+    files = changed_files(base, root)
+    if files is None:
+        return 1
+    codes = [f for f in files if is_code_submission(f)]
+    critical = [f for f in files if is_critical(f)]
+    if not codes or not critical:
+        print("submission scope ok")
+        return 0
+
+    print("Submission PR changes both untrusted code data and verifier-critical files.")
+    print("Split the PR, or have a maintainer review the trusted-code changes first.")
+    print("\nCode submissions:")
+    for f in codes:
+        print(f"  {f}")
+    print("\nVerifier-critical changes:")
+    for f in critical:
+        print(f"  {f}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -9,7 +9,8 @@ re-verification of the whole board stays cheap -- only new/changed files pay the
 search cost (~10 s per method).
 
 Usage:
-  python verify/gate_changed.py [BASE] [files...]
+  python verify/gate_changed.py [--code-root PATH] [BASE] [files...]
+    --code-root PATH  repository tree containing the submitted codes
     BASE     git ref to diff against (default origin/main); ignored if files given
     files    explicit code JSONs to gate (otherwise computed from the diff)
 """
@@ -38,23 +39,23 @@ def _load_syndrome():
         return None
 
 
-def changed_codes(base):
+def changed_codes(base, code_root=ROOT):
     try:
         out = subprocess.check_output(
             ["git", "diff", "--name-only", f"{base}...HEAD", "--", "codes", "verify/fixtures"],
-            cwd=ROOT, text=True)
+            cwd=code_root, text=True)
     except Exception as e:
-        print(f"(could not compute diff vs {base}: {e}); gating nothing")
-        return []
+        print(f"could not compute diff vs {base}: {e}; failing closed")
+        return None
     return [f for f in out.split() if f.endswith(".json")]
 
 
-def board_record_slugs():
+def board_record_slugs(code_root=ROOT):
     """Slugs on the board's global (n, k, d, w) Pareto frontier. A code that
     claims to advance the frontier gets deeper refutation than a dominated one,
     so over-claims pay extra scrutiny exactly where gaming would matter."""
     rows = []
-    for p in sorted(glob.glob(os.path.join(ROOT, "codes", "*.json"))):
+    for p in sorted(glob.glob(os.path.join(code_root, "codes", "*.json"))):
         try:
             d = json.load(open(p))
             ck = d.get("checks", {})
@@ -77,6 +78,11 @@ def board_record_slugs():
 def main(argv):
     rest = [a for a in argv if not a.endswith(".json")]
     seed = None
+    code_root = ROOT
+    if "--code-root" in rest:
+        i = rest.index("--code-root")
+        code_root = os.path.abspath(rest[i + 1])
+        rest = rest[:i] + rest[i + 2:]
     if "--seed" in rest:
         i = rest.index("--seed")
         seed = int(rest[i + 1])
@@ -84,7 +90,9 @@ def main(argv):
     files = [a for a in argv if a.endswith(".json")]
     base = next((a for a in rest), "origin/main")
     if not files:
-        files = changed_codes(base)
+        files = changed_codes(base, code_root)
+    if files is None:
+        return 1
     if not files:
         print("no changed code submissions to gate")
         return 0
@@ -104,9 +112,9 @@ def main(argv):
 
     refuted = 0
     failed = 0
-    records = board_record_slugs()
+    records = board_record_slugs(code_root)
     for f in files:
-        p = f if os.path.isabs(f) else os.path.join(ROOT, f)
+        p = f if os.path.isabs(f) else os.path.join(code_root, f)
         if not os.path.exists(p):                 # deleted/renamed away
             continue
         ferr = file_size_error(p)

--- a/verify/verify_all.py
+++ b/verify/verify_all.py
@@ -7,6 +7,7 @@ duplicates) on every entry. Distance refutation is NOT run here -- it is the
 per-submission job of gate_changed.py (changed files) and the weekly job of
 refute_board.py (whole board, random seed)."""
 
+import argparse
 import glob
 import json
 import os
@@ -18,8 +19,15 @@ from qldpc_verify import file_size_error, verify
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 if __name__ == "__main__":
-    code_paths = sorted(glob.glob(os.path.join(ROOT, "codes", "*.json")))
-    paths = code_paths + sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json")))
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=ROOT,
+                    help="repository tree containing codes/ to verify; verifier "
+                         "code and fixtures still come from this checkout")
+    args = ap.parse_args()
+    code_root = os.path.abspath(args.root)
+    code_paths = sorted(glob.glob(os.path.join(code_root, "codes", "*.json")))
+    fixture_paths = sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json")))
+    paths = code_paths + fixture_paths
     if not paths:
         print("no submissions found")
         sys.exit(0)
@@ -27,7 +35,9 @@ if __name__ == "__main__":
     sigs = {}
     fps = {}
     for p in paths:
-        rel = os.path.relpath(p, ROOT)
+        is_code = os.path.abspath(p).startswith(
+            os.path.join(code_root, "codes") + os.sep)
+        rel = os.path.relpath(p, code_root if is_code else ROOT)
         ferr = file_size_error(p)
         if ferr:
             failed.append(rel)
@@ -40,7 +50,7 @@ if __name__ == "__main__":
             ed = rep["earned_distance"].get("d", {})
             print(f"PASS  {rel}  -> d{ed.get('value','?')} "
                   f"({ed.get('tier','-')})")
-            if rel.startswith("codes/"):
+            if is_code:
                 if "signature" in rep:
                     sigs.setdefault(rep["signature"]["hash"], []).append(rel)
                 if "fingerprint" in rep:


### PR DESCRIPTION
Closes #84.

## Summary

- Add a read-only-token, two-checkout CI flow: submitted tree for PR data, trusted/base tree for validation code when code submissions change.
- Add root-aware options to verify_all, gate_changed, and check_authorship so trusted scripts can validate codes from another checkout.
- Add check_submission_scope.py to reject PRs that mix codes/*.json submissions with verifier-critical files.
- Make gate_changed fail closed if it cannot compute the changed-code diff.
- Document the code-submission trust boundary in CONTRIBUTING.

## Bootstrap note

The workflow detects whether a PR changes codes/*.json. PRs that do not change code submissions, including this verifier/workflow PR, run validation from the submitted tree. Once this lands, future code-submission PRs are validated with base-branch trusted verifier code.

## Verification

- uv run python -m py_compile verify/verify_all.py verify/gate_changed.py verify/check_authorship.py verify/check_submission_scope.py
- uv run python verify/verify_all.py --root .
- uv run python verify/check_submission_scope.py --root . --base origin/main
- uv run python verify/check_authorship.py --root . --author test-user --base origin/main
- uv run python verify/gate_changed.py --code-root . origin/main --seed 0
- uv run python verify/test_verifier.py
- uv run python research/test_smoke.py
- uv run python verify/test_refute_gate.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify.yml"); puts "yaml ok"'

Also checked fail-closed behavior with a missing base ref for check_submission_scope.py and gate_changed.py.
