### PR TITLE
Add public submission resource limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ over-claimed one may slip past one seed and get caught on a re-run, at merge, or
 by the weekly board sweep, in which case the code is removed. The seed is printed
 so any failure reproduces.
 
+Public CI also enforces resource limits before dense verifier matrices are
+allocated: 5 MB JSON files, `n <= 5000`, at most 10000 checks per side, max check
+weight 40, at most 200000 total support entries, and at most 5000 locality
+coordinates. Larger codes need maintainer handling until the verifier is sparse
+end-to-end.
+
 ## Contribute with an LLM
 
 If you have an LLM or coding agent, it can do the whole loop: pick a target,

--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -76,6 +76,23 @@ interaction_radius`, and an `earned_distance` block giving the tier each side
 actually earned (an `exact` claim shows as `upper_bound` here and is flagged
 for server certification). Exit code 0 iff every required check passes.
 
+## Public CI limits
+
+The public submission path has generous resource limits so malformed or hostile
+JSON cannot force unbounded dense-matrix allocation in CI. Current automatic
+limits are:
+
+- JSON file size: 5 MB.
+- `n <= 5000`.
+- At most 10000 X-checks and 10000 Z-checks.
+- Max check weight 40.
+- At most 200000 total support entries across all checks.
+- At most 5000 locality coordinate entries.
+- Dense verifier intermediates capped at 50000000 cells.
+
+These are far above the current board entries. A larger code should be handled
+through a maintainer-run path until the verifier is sparse end-to-end.
+
 ## Conventions and gotchas
 
 - A repeated qubit index within a single check is rejected (it would XOR

--- a/schema/code.schema.json
+++ b/schema/code.schema.json
@@ -10,7 +10,7 @@
     "schema_version": {"const": "0.1"},
     "name": {"type": "string", "minLength": 1, "maxLength": 200},
     "code_type": {"enum": ["CSS"]},
-    "n": {"type": "integer", "minimum": 1, "description": "number of physical (data) qubits"},
+    "n": {"type": "integer", "minimum": 1, "maximum": 5000, "description": "number of physical (data) qubits"},
     "k": {"type": "integer", "minimum": 1, "description": "claimed number of logical qubits; verifier recomputes exactly"},
     "checks": {
       "type": "object",
@@ -40,6 +40,7 @@
         "coordinates": {
           "type": "array",
           "description": "one [x, y] per qubit, indexed 0..n-1",
+          "maxItems": 5000,
           "items": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}
         },
         "layers": {"type": "integer", "minimum": 1, "description": "physical layers (e.g. 2 for flip-chip bilayer)"},
@@ -83,10 +84,12 @@
     "supportList": {
       "type": "array",
       "description": "one entry per parity check; each entry is the sorted list of distinct qubit indices in that check's support",
+      "maxItems": 10000,
       "items": {
         "type": "array",
         "items": {"type": "integer", "minimum": 0},
-        "minItems": 1
+        "minItems": 1,
+        "maxItems": 40
       }
     },
     "sideDistance": {

--- a/site/build.py
+++ b/site/build.py
@@ -19,7 +19,7 @@ import urllib.parse
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "verify"))
-from qldpc_verify import verify
+from qldpc_verify import file_size_error, verify
 
 DOCS = os.path.join(ROOT, "docs")
 CERTS = os.path.join(ROOT, "certs")
@@ -893,6 +893,10 @@ def load_entries():
     entries = []
     for p in sorted(glob.glob(os.path.join(ROOT, "codes", "*.json"))):
         slug = os.path.splitext(os.path.basename(p))[0]
+        ferr = file_size_error(p)
+        if ferr:
+            print(f"  warning: {slug}: {ferr}; skipping")
+            continue
         with open(p) as f:
             doc = json.load(f)
         rep = verify(doc)   # site render: structural checks only, refutation is a CI/cron job

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -22,6 +22,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import heuristic_distance as H
+from qldpc_verify import file_size_error
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -102,10 +103,16 @@ def main(argv):
               "running RIS only\n")
 
     refuted = 0
+    failed = 0
     records = board_record_slugs()
     for f in files:
         p = f if os.path.isabs(f) else os.path.join(ROOT, f)
         if not os.path.exists(p):                 # deleted/renamed away
+            continue
+        ferr = file_size_error(p)
+        if ferr:
+            failed += 1
+            print(f"FAIL     {f}: file_size_within_limit: {ferr}")
             continue
         doc = json.load(open(p))
         if "distance" not in doc or "d" not in doc.get("distance", {}):
@@ -135,7 +142,9 @@ def main(argv):
     if refuted:
         print(f"\n{refuted} submission(s) refuted: claimed distance is not supported "
               f"by an independent search. See witnesses above.")
-    return 1 if refuted else 0
+    if failed:
+        print(f"\n{failed} submission(s) failed preflight checks.")
+    return 1 if (refuted or failed) else 0
 
 
 if __name__ == "__main__":

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -59,6 +59,65 @@ _FAMILIES = {"bivariate-bicycle", "generalized-bicycle", "2bga-coset",
              "quantum-tanner", "tile", "topological", "other"}
 _NOVELTY = {"unknown", "known_parameters", "new_parameters"}
 
+# Public CI resource limits. These are intentionally generous relative to the
+# current board (n<=336, row weight<=10) but finite: larger submissions need a
+# maintainer-run path until the verifier is sparse end-to-end.
+MAX_SUBMISSION_BYTES = 5_000_000
+MAX_N = 5_000
+MAX_CHECKS_PER_SIDE = 10_000
+MAX_CHECK_WEIGHT = 40
+MAX_TOTAL_SUPPORT = 200_000
+MAX_COORDINATES = MAX_N
+MAX_DENSE_MATRIX_CELLS = 50_000_000
+MAX_COMMUTATION_CELLS = 50_000_000
+
+
+def file_size_error(path):
+    """Return a validation error string if a JSON submission file is too large."""
+    try:
+        size = os.path.getsize(path)
+    except OSError as e:
+        return f"could not stat file: {e}"
+    if size > MAX_SUBMISSION_BYTES:
+        return f"file has {size} bytes, limit is {MAX_SUBMISSION_BYTES}"
+    return ""
+
+
+def resource_errors(doc):
+    """Resource caps checked before dense matrices are allocated."""
+    n = doc["n"]
+    X, Z = doc["checks"]["X"], doc["checks"]["Z"]
+    supports = X + Z
+    errs = []
+    if n > MAX_N:
+        errs.append(f"n={n} exceeds public CI limit {MAX_N}")
+    if len(X) > MAX_CHECKS_PER_SIDE:
+        errs.append(f"checks.X has {len(X)} rows, limit is {MAX_CHECKS_PER_SIDE}")
+    if len(Z) > MAX_CHECKS_PER_SIDE:
+        errs.append(f"checks.Z has {len(Z)} rows, limit is {MAX_CHECKS_PER_SIDE}")
+    total_support = sum(len(s) for s in supports)
+    if total_support > MAX_TOTAL_SUPPORT:
+        errs.append(f"total support entries {total_support} exceeds limit "
+                    f"{MAX_TOTAL_SUPPORT}")
+    max_weight = max((len(s) for s in supports), default=0)
+    if max_weight > MAX_CHECK_WEIGHT:
+        errs.append(f"max check weight {max_weight} exceeds limit {MAX_CHECK_WEIGHT}")
+    for label, rows in (("H_X", len(X)), ("H_Z", len(Z))):
+        cells = rows * n
+        if cells > MAX_DENSE_MATRIX_CELLS:
+            errs.append(f"{label} dense allocation would have {cells} cells, "
+                        f"limit is {MAX_DENSE_MATRIX_CELLS}")
+    comm_cells = len(X) * len(Z)
+    if comm_cells > MAX_COMMUTATION_CELLS:
+        errs.append(f"H_X H_Z^T commutation check would have {comm_cells} cells, "
+                    f"limit is {MAX_COMMUTATION_CELLS}")
+    loc = doc.get("locality") or {}
+    coords = loc.get("coordinates") or []
+    if len(coords) > MAX_COORDINATES:
+        errs.append(f"locality.coordinates has {len(coords)} points, limit is "
+                    f"{MAX_COORDINATES}")
+    return errs
+
 
 def structure_errors(doc):
     """Return a list of human-readable structural problems, or [] if the doc
@@ -67,13 +126,16 @@ def structure_errors(doc):
         return ["top-level value is not a JSON object"]
     if jsonschema is not None and _SCHEMA is not None:
         v = jsonschema.Draft202012Validator(_SCHEMA)
-        return [f"{'/'.join(str(p) for p in e.path) or '<root>'}: {e.message}"
+        errs = [f"{'/'.join(str(p) for p in e.path) or '<root>'}: {e.message}"
                 for e in sorted(v.iter_errors(doc), key=lambda e: list(e.path))]
-    errs = [f"missing field: {k}" for k in _REQUIRED if k not in doc]
-    if "checks" in doc and not (isinstance(doc["checks"], dict)
-                                and "X" in doc["checks"] and "Z" in doc["checks"]):
-        errs.append("checks must have X and Z support lists")
-    return errs
+    else:
+        errs = [f"missing field: {k}" for k in _REQUIRED if k not in doc]
+        if "checks" in doc and not (isinstance(doc["checks"], dict)
+                                    and "X" in doc["checks"] and "Z" in doc["checks"]):
+            errs.append("checks must have X and Z support lists")
+    if errs:
+        return errs
+    return resource_errors(doc)
 
 
 def signature(doc):
@@ -218,9 +280,10 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     # Sparsity backstop: LDPC means a bounded, small check weight. The cap is far
     # above any plausible qLDPC code on this board (weights run to ~10), so it
     # only rejects a dense matrix submitted as a "code", not a real entry.
-    record("check_weight_is_ldpc", wmax <= 40,
-           f"max check weight {wmax} far exceeds LDPC sparsity (cap 40)"
-           if wmax > 40 else f"max check weight {wmax}")
+    record("check_weight_is_ldpc", wmax <= MAX_CHECK_WEIGHT,
+           f"max check weight {wmax} far exceeds LDPC sparsity "
+           f"(cap {MAX_CHECK_WEIGHT})"
+           if wmax > MAX_CHECK_WEIGHT else f"max check weight {wmax}")
 
     # The model field is self-reported and unverifiable, but if one is claimed it
     # must name a specific version, not a bare vendor name: "Claude" tells a reader
@@ -397,6 +460,14 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
 
 
 def main(path):
+    ferr = file_size_error(path)
+    if ferr:
+        print(json.dumps({"name": None,
+                          "checks": [{"check": "file_size_within_limit",
+                                      "ok": False, "detail": ferr}],
+                          "ok": False, "computed": {}, "earned_distance": {}},
+                         indent=2))
+        return 1
     with open(path) as f:
         doc = json.load(f)
     report = verify(doc, refute=True)   # the per-submission CLI runs the gate

--- a/verify/refute_board.py
+++ b/verify/refute_board.py
@@ -28,6 +28,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import heuristic_distance as H
+from qldpc_verify import file_size_error
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -46,6 +47,12 @@ def main(argv):
     refuted, errored, checked = [], [], 0
     for p in paths:
         rel = os.path.relpath(p, ROOT)
+        ferr = file_size_error(p)
+        if ferr:
+            errored.append((rel, f"file_size_within_limit: {ferr}"))
+            print(f"ERROR    {rel}: file_size_within_limit: {ferr} "
+                  f"-- fails closed, manual review")
+            continue
         doc = json.load(open(p))
         if "distance" not in doc or "d" not in doc.get("distance", {}):
             continue

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -15,9 +15,12 @@ import glob
 import json
 import os
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from qldpc_verify import verify
+import qldpc_verify
+
+verify = qldpc_verify.verify
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GOOD = json.load(open(os.path.join(ROOT, "verify", "fixtures", "72-6-6.json")))
@@ -102,6 +105,30 @@ def main():
     r = rep(d)
     check("inflated distance value rejected",
           not r["ok"] and "distance_X_witness" in failed_checks(r))
+
+    # 6b. resource limits must reject hostile shapes before dense matrices are built.
+    d = copy.deepcopy(GOOD)
+    d["n"] = qldpc_verify.MAX_N + 1
+    r = rep(d)
+    check("oversized n rejected", not r["ok"])
+
+    d = copy.deepcopy(GOOD)
+    d["checks"]["X"] = [d["checks"]["X"][0]] * (qldpc_verify.MAX_CHECKS_PER_SIDE + 1)
+    r = rep(d)
+    check("oversized row count rejected", not r["ok"])
+
+    d = copy.deepcopy(GOOD)
+    heavy_row = list(range(qldpc_verify.MAX_CHECK_WEIGHT))
+    rows = (qldpc_verify.MAX_TOTAL_SUPPORT // qldpc_verify.MAX_CHECK_WEIGHT) + 1
+    d["checks"]["X"] = [heavy_row] * rows
+    r = rep(d)
+    check("oversized total support rejected", not r["ok"])
+
+    if GOOD.get("locality"):
+        d = copy.deepcopy(GOOD)
+        d["locality"]["coordinates"] = [[0.0, 0.0]] * (qldpc_verify.MAX_COORDINATES + 1)
+        r = rep(d)
+        check("oversized coordinate payload rejected", not r["ok"])
 
     # 7. locality claim too tight (interaction radius understated)
     if "locality" in GOOD:
@@ -190,6 +217,15 @@ def main():
             check(f"{os.path.basename(p)} verifies", False)
     if not _fail:
         print("  ok    all shipped submissions verify")
+
+    check("normal file size accepted",
+          qldpc_verify.file_size_error(__file__) == "")
+    with tempfile.NamedTemporaryFile() as f:
+        f.seek(qldpc_verify.MAX_SUBMISSION_BYTES)
+        f.write(b"x")
+        f.flush()
+        check("oversized file size rejected",
+              qldpc_verify.file_size_error(f.name) != "")
 
     print(f"\n{'ALL PASS' if not _fail else 'FAILURES: ' + ', '.join(_fail)}")
     return 1 if _fail else 0

--- a/verify/verify_all.py
+++ b/verify/verify_all.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
-from qldpc_verify import verify
+from qldpc_verify import file_size_error, verify
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -27,10 +27,15 @@ if __name__ == "__main__":
     sigs = {}
     fps = {}
     for p in paths:
+        rel = os.path.relpath(p, ROOT)
+        ferr = file_size_error(p)
+        if ferr:
+            failed.append(rel)
+            print(f"FAIL  {rel}  -> file_size_within_limit: {ferr}")
+            continue
         with open(p) as f:
             doc = json.load(f)
         rep = verify(doc)   # structural checks; refutation lives in gate_changed / refute_board
-        rel = os.path.relpath(p, ROOT)
         if rep["ok"]:
             ed = rep["earned_distance"].get("d", {})
             print(f"PASS  {rel}  -> d{ed.get('value','?')} "


### PR DESCRIPTION
Closes #85.

Summary:
- Adds finite public CI caps for file size, n, row counts, row weight, total support, coordinates, and dense verifier intermediates before matrix allocation.
- Applies preflight file-size checks in verify_all, gate_changed, refute_board, and site build.
- Documents public CI limits in schema and contributing docs.

Validation:
- uv run python verify/test_verifier.py
- uv run python -m py_compile verify/qldpc_verify.py verify/test_verifier.py verify/verify_all.py verify/gate_changed.py verify/refute_board.py site/build.py
- uv run python verify/verify_all.py
- uv run python site/build.py
- uv run python research/test_smoke.py
- uv run python verify/test_refute_gate.py

Note: This was kept independent of PR #86 and PR #87, so it may need a small rebase if either lands first.