### PR TITLE
Ci deep refutation budget

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ Useful flags:
 - `--open-pr` create the branch, commit, push, and open the PR for you;
 - `--dry-run` build and verify without writing.
 
-Then open a pull request adding only your file under `codes/`. CI re-runs the
+Then open a pull request adding only your file under `codes/` — **one new code
+per PR** (CI enforces this): each frontier submission gets a deep, ~10-minute
+refutation search, and that budget is per code. CI re-runs the
 verifier; a green check is required to merge. Open the PR from your own account:
 CI checks that the PR author is one of the code's `@handle` authors, so list
 yourself (literature baselines with no `@handle` are exempt).

--- a/verify/check_submission_scope.py
+++ b/verify/check_submission_scope.py
@@ -4,6 +4,10 @@ Code submissions are untrusted data. Verifier, schema, workflow, and site-builde
 changes are trusted-code changes. A PR that changes both can otherwise submit a
 code and weaken the code that validates it in the same diff.
 
+Also enforces one NEW code per PR: the deep refutation gate spends ~10 minutes
+per frontier code, so batched submissions would blow the CI budget or force a
+shallower search per code.
+
 Usage:
   python verify/check_submission_scope.py [--root PATH] [--base origin/main]
 """
@@ -38,6 +42,18 @@ def changed_files(base, root):
     return [f for f in out.splitlines() if f]
 
 
+def added_files(base, root):
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "--diff-filter=A",
+             f"{base}...HEAD"],
+            cwd=root, text=True)
+    except Exception as e:
+        print(f"could not diff vs {base}: {e}; failing closed")
+        return None
+    return [f for f in out.splitlines() if f]
+
+
 def is_code_submission(path):
     return path.startswith("codes/") and path.endswith(".json")
 
@@ -58,10 +74,22 @@ def main(argv):
         base = argv[i + 1]
 
     files = changed_files(base, root)
-    if files is None:
+    added = added_files(base, root)
+    if files is None or added is None:
         return 1
     codes = [f for f in files if is_code_submission(f)]
+    new_codes = [f for f in added if is_code_submission(f)]
     critical = [f for f in files if is_critical(f)]
+    # One new code per PR: the deep refutation gate budgets ~10 min per code, so
+    # a PR that batches submissions would either blow the CI budget or dilute the
+    # per-code scrutiny. Corrections to existing entries are not capped.
+    if len(new_codes) > 1:
+        print("Submission PR adds more than one new code; submit one code per PR "
+              "so each gets the full refutation budget.")
+        print("\nNew code submissions:")
+        for f in new_codes:
+            print(f"  {f}")
+        return 1
     if not codes or not critical:
         print("submission scope ok")
         return 0

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -6,7 +6,8 @@ only on the code/example submissions changed in this PR, and exits non-zero if
 EITHER finds a logical lighter than the claimed distance (an over-claim). The
 syndrome-decoder cross-check is skipped if ldpc is unavailable (RIS-only). Bulk
 re-verification of the whole board stays cheap -- only new/changed files pay the
-search cost (~10 s per method).
+search cost (~10 s per method; frontier-advancing codes get 4 RIS seeds at 60 s
+each, ~4-5 min per code).
 
 Usage:
   python verify/gate_changed.py [--code-root PATH] [BASE] [files...]
@@ -126,19 +127,25 @@ def main(argv):
         if "distance" not in doc or "d" not in doc.get("distance", {}):
             continue
         # A code that advances the frontier is checked harder: several independent
-        # RIS seeds, not one, so an over-claim cannot lean on a single search
-        # missing the lighter logical. Dominated codes pay only the standard pass.
+        # RIS seeds with a long budget each, not one short pass, so an over-claim
+        # cannot lean on a single search missing the lighter logical. At n ~ 300 a
+        # modest over-claim needs on the order of minutes of RIS to expose, so the
+        # deep budget is sized for ~8-9 min per frontier code (CI allows ~10 min
+        # per code; submissions are one new code per PR). Dominated codes pay only
+        # the standard pass.
         slug = os.path.splitext(os.path.basename(f))[0]
         deep = slug in records
         seeds = [seed, seed + 2, seed + 3, seed + 5] if deep else [seed]
+        budget = 120.0 if deep else 10.0
         # two independent mechanisms; a hit from EITHER (any seed) refutes.
         results = {}
         for si, s in enumerate(seeds):
-            results[f"RIS#{si}"] = H.refute_check(doc, seed=s)
+            results[f"RIS#{si}"] = H.refute_check(doc, seed=s, max_seconds=budget)
         if SD is not None:
             results["syndrome-decoder"] = SD.refute_check(doc, seed=seed + 1)
         hits = {m: (dh, wit) for m, (ref, dh, wit, _) in results.items() if ref}
-        tag = f"deep, {len(seeds)} RIS seeds" if deep else "standard"
+        tag = (f"deep, {len(seeds)} RIS seeds x {budget:.0f}s" if deep
+               else "standard")
         if hits:
             refuted += 1
             for m, (dh, wit) in hits.items():


### PR DESCRIPTION
Increase refutation budget for new code (~10 mins per new code), to increase probability of catching inflated distance.