### PR TITLE
Rebuild the leaderboard site automatically on pushes to main

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,43 @@
+name: site
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/site.yml"
+      - "codes/**"
+      - "certs/**"
+      - "site/**"
+      - "verify/**"
+      - "refs.bib"
+      - "pyproject.toml"
+      - "uv.lock"
+
+# Serialize rebuilds so two quick merges don't race each other's push.
+concurrency:
+  group: site-build
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: rebuild the leaderboard site
+        run: make build
+      - name: commit regenerated pages (if anything changed)
+        run: |
+          git add docs/index.html docs/codes docs/stats.json docs/references.html
+          if git diff --cached --quiet; then
+            echo "site already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Rebuild leaderboard site [skip ci]"
+          git pull --rebase origin main
+          git push origin main


### PR DESCRIPTION
The site under docs/ is a committed static build, so a merged code submission stays invisible until someone reruns make build by hand — [[294,8,19]] (PR #91) hit exactly this. This workflow rebuilds on any push to main that touches the build inputs (codes, certs, site, verify, refs.bib) and commits the regenerated pages as the actions bot, skipping CI on the docs-only commit.

