### PR TITLE
Use Manrope for page-level H1/H2 headings

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/294-8-19.html
+++ b/docs/codes/294-8-19.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/docs/references.html
+++ b/docs/references.html
@@ -2,11 +2,13 @@
 :root{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:#36006c;--ex:#059669;
 --corr:#d97706;--exb:#ffff00;--dark:#111111;--bg:#fff;--soft:#f8fafc}
 *{box-sizing:border-box}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
+h1,h2{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
+h3,.codehead .big,.lbh,.ph{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}
 .mono{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}

--- a/site/build.py
+++ b/site/build.py
@@ -304,11 +304,13 @@ CSS = f"""
 :root{{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:{ACCENT};--ex:{EXACT};
 --corr:{CORR};--exb:{GREEN_BRIGHT};--dark:{DARK};--bg:#fff;--soft:#f8fafc}}
 *{{box-sizing:border-box}}
-/* Unitary Foundation type stack: Space Grotesk for display/headings, Manrope
-   for body, Space Mono for code. Loaded from Google Fonts in head(). */
+/* Unitary Foundation type stack: Manrope for body and page-level headings
+   (H1/H2, per UF homepage), Space Grotesk for in-container display text,
+   Space Mono for code. Loaded from Google Fonts in head(). */
 body{{font-family:'Manrope',system-ui,-apple-system,sans-serif;
 color:var(--ink);margin:0;background:var(--bg);line-height:1.55}}
-h1,h2,h3,.brand h1,.codehead .big,.lbh,.ph{{font-family:'Space Grotesk',
+h1,h2{{font-family:'Manrope',system-ui,sans-serif;letter-spacing:-.01em}}
+h3,.codehead .big,.lbh,.ph{{font-family:'Space Grotesk',
 'Manrope',system-ui,sans-serif;letter-spacing:-.01em}}
 .mono{{font-family:'Space Mono',ui-monospace,'SF Mono',Menlo,monospace;
 font-weight:700}}


### PR DESCRIPTION
Closes #98

Per the QEC brand feedback (UF homepage as design baseline), H1 and H2 headings on the page (hero title, track sections, "Codes", etc.) now use Manrope instead of Space Grotesk. Headers inside containers (leaderboard, cards, code pages) are unchanged here; they are covered separately by #101.

Since the CSS is inlined into every generated page, `docs/` is regenerated via `make build`. The other brand-feedback PRs also regenerate `docs/`, so merge them one at a time and rebase + `make build` the rest.