### PR TITLE
Use Space Mono for CTA buttons

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/294-8-19.html
+++ b/docs/codes/294-8-19.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/docs/references.html
+++ b/docs/references.html
@@ -39,7 +39,8 @@ gap:16px;margin:0 0 18px}
 .uflogo{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}
 .ghlink{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}
 .ghlink:hover{background:rgba(255,255,255,.18)}
@@ -49,7 +50,8 @@ header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
@@ -70,7 +72,8 @@ background:#fff;overflow:hidden}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
 .lbh{font-size:18px;margin:0}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
-.lbcta{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}
 .lbcta:hover{filter:brightness(1.08)}

--- a/site/build.py
+++ b/site/build.py
@@ -341,7 +341,8 @@ gap:16px;margin:0 0 18px}}
 .uflogo{{height:38px;width:auto;display:block;
 filter:drop-shadow(0 4px 14px rgba(0,0,0,.35))}}
 .ghlink{{display:inline-flex;align-items:center;gap:8px;color:#fff;
-text-decoration:none;font-size:14px;font-weight:600;
+font-family:'Space Mono',ui-monospace,monospace;
+text-decoration:none;font-size:14px;font-weight:700;
 border:1px solid rgba(255,255,255,.28);border-radius:9px;padding:8px 14px;
 background:rgba(255,255,255,.08)}}
 .ghlink:hover{{background:rgba(255,255,255,.18)}}
@@ -351,7 +352,8 @@ header.hero p{{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}}
 header.hero p a{{color:{HILITE};text-decoration:underline}}
 .topnav{{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}}
 .topnav a{{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
-font-size:14px;font-weight:600;padding:7px 14px;
+font-family:'Space Mono',ui-monospace,monospace;
+font-size:14px;font-weight:700;padding:7px 14px;
 border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}}
 .topnav a:hover{{background:{HILITE};color:#111;border-color:{HILITE}}}
@@ -372,7 +374,8 @@ background:#fff;overflow:hidden}}
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}}
 .lbh{{font-size:18px;margin:0}}
 .lbsub{{margin:4px 0 0;font-size:13px;color:var(--mut)}}
-.lbcta{{flex:0 0 auto;font-size:13px;font-weight:600;color:#fff;
+.lbcta{{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
+font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
 text-decoration:none;cursor:pointer}}
 .lbcta:hover{{filter:brightness(1.08)}}


### PR DESCRIPTION
Closes #99

Per the QEC brand feedback (UF homepage as design baseline), CTA buttons now use Space Mono: the top nav pills (FAQ, References, GitHub, whitepaper), the hero GitHub link, and the Participate button. Font weight moves from 600 to 700 since Space Mono only ships 400 and 700.

The purple background on Participate is unchanged, as the feedback called it out as working well.

`docs/` is regenerated via `make build`. The other brand-feedback PRs also regenerate `docs/`, so merge them one at a time and rebase + `make build` the rest.