### PR TITLE
Use Space Mono for header stat numbers

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/294-8-19.html
+++ b/docs/codes/294-8-19.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/docs/references.html
+++ b/docs/references.html
@@ -56,14 +56,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}
 .topnav a:hover{background:#ffff00;color:#111;border-color:#ffff00}
 .stats{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}
-.stat .v{font-size:30px;font-weight:700}.stat .l{color:#c7d2fe;font-size:13px;
+.stat .v{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}
+.stat .l{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}
 .statsbar{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}
 .stat-card{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}
 .stat-card.hero{border-color:var(--ac);background:#fffbe0}
-.stat-card .v{font-size:34px;font-weight:700;line-height:1.05}
+.stat-card .v{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}
 .stat-card.hero .v{color:var(--ac)}
 .stat-card .l{font-size:13px;color:var(--mut);margin-top:6px}
 .lb{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -117,7 +120,8 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;

--- a/site/build.py
+++ b/site/build.py
@@ -358,14 +358,17 @@ border:1px solid rgba(255,255,255,.18);border-radius:8px;
 background:rgba(255,255,255,.06)}}
 .topnav a:hover{{background:{HILITE};color:#111;border-color:{HILITE}}}
 .stats{{display:flex;gap:40px;margin-top:30px;flex-wrap:wrap}}
-.stat .v{{font-size:30px;font-weight:700}}.stat .l{{color:#c7d2fe;font-size:13px;
+.stat .v{{font-size:30px;font-weight:700;
+font-family:'Space Mono',ui-monospace,monospace}}
+.stat .l{{color:#c7d2fe;font-size:13px;
 text-transform:uppercase;letter-spacing:.05em}}
 .statsbar{{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
 gap:14px;margin:28px 0 8px}}
 .stat-card{{border:1px solid var(--ln);border-radius:14px;padding:18px 20px;
 background:var(--soft)}}
 .stat-card.hero{{border-color:var(--ac);background:#fffbe0}}
-.stat-card .v{{font-size:34px;font-weight:700;line-height:1.05}}
+.stat-card .v{{font-size:34px;font-weight:700;line-height:1.05;
+font-family:'Space Mono',ui-monospace,monospace}}
 .stat-card.hero .v{{color:var(--ac)}}
 .stat-card .l{{font-size:13px;color:var(--mut);margin-top:6px}}
 .lb{{margin:18px 0 8px;border:1px solid var(--ln);border-radius:14px;
@@ -419,7 +422,8 @@ flex:0 0 auto}}
 background:var(--soft)}}
 .how .n{{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
-font-size:14px;font-weight:700;margin-bottom:10px}}
+font-size:14px;font-weight:700;margin-bottom:10px;
+font-family:'Space Mono',ui-monospace,monospace}}
 .how h3{{margin:.2rem 0;font-size:16px}}.how p{{margin:0;color:var(--mut);
 font-size:14px}}
 .legend{{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;


### PR DESCRIPTION
Closes #100

Per the QEC brand feedback (UF homepage as design baseline), the big numbers in the header stat tiles (submitted codes, literature baselines, certified exact, best kd^2/n) and the hero stats now render in Space Mono, along with the numbered badges on the "Build a code / Open a PR / Climb the board" step cards.

`docs/` is regenerated via `make build`. The other brand-feedback PRs also regenerate `docs/`, so merge them one at a time and rebase + `make build` the rest.