### PR TITLE
Use Space Mono uppercase for table and container headers

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/294-8-19.html
+++ b/docs/codes/294-8-19.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/docs/references.html
+++ b/docs/references.html
@@ -73,7 +73,8 @@ font-family:'Space Mono',ui-monospace,monospace}
 background:#fff;overflow:hidden}
 .lbhead{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}
-.lbh{font-size:18px;margin:0}
+.lbh{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
 .lbsub{margin:4px 0 0;font-size:13px;color:var(--mut)}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -120,9 +121,17 @@ flex:0 0 auto}
 background:var(--soft)}
 .how .n{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}
 .how h3{margin:.2rem 0;font-size:16px}.how p{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}
+.how h3{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}
+.how p{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}
 .legend{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -158,6 +167,7 @@ font-size:14px;margin:12px 0}
 .board th,.board td{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}
 .board th{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -194,8 +204,11 @@ table.grid{border-collapse:collapse;font-size:13px;margin:0 auto}
 table.grid th,table.grid td{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}
 table.grid thead th,table.grid tr:first-child th{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}
-.grow{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
+.grow{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}
 .gcorner{background:var(--soft)}
 .gcell .gcount{font-size:11px;color:var(--mut)}
 .gcell .gbest{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;

--- a/site/build.py
+++ b/site/build.py
@@ -375,7 +375,8 @@ font-family:'Space Mono',ui-monospace,monospace}}
 background:#fff;overflow:hidden}}
 .lbhead{{display:flex;justify-content:space-between;align-items:center;gap:16px;
 padding:16px 20px;background:var(--soft);border-bottom:1px solid var(--ln)}}
-.lbh{{font-size:18px;margin:0}}
+.lbh{{font-size:16px;margin:0;font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}}
 .lbsub{{margin:4px 0 0;font-size:13px;color:var(--mut)}}
 .lbcta{{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -422,9 +423,17 @@ flex:0 0 auto}}
 background:var(--soft)}}
 .how .n{{display:inline-flex;width:26px;height:26px;border-radius:50%;
 background:var(--ac);color:#fff;align-items:center;justify-content:center;
+<<<<<<< HEAD
 font-size:14px;font-weight:700;margin-bottom:10px;
 font-family:'Space Mono',ui-monospace,monospace}}
 .how h3{{margin:.2rem 0;font-size:16px}}.how p{{margin:0;color:var(--mut);
+=======
+font-size:14px;font-weight:700;margin-bottom:10px}}
+.how h3{{margin:.2rem 0;font-size:14px;
+font-family:'Space Mono',ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.03em}}
+.how p{{margin:0;color:var(--mut);
+>>>>>>> df2c121 (Use Space Mono uppercase for table and container headers)
 font-size:14px}}
 .legend{{display:flex;flex-wrap:wrap;gap:18px;margin:28px 0 4px;padding:14px 16px;
 background:var(--soft);border:1px solid var(--ln);border-radius:10px;
@@ -460,6 +469,7 @@ font-size:14px;margin:12px 0}}
 .board th,.board td{{padding:.55rem .9rem;text-align:left;white-space:nowrap;
 border-bottom:1px solid var(--ln)}}
 .board th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+font-family:'Space Mono',ui-monospace,monospace;
 color:var(--mut);cursor:pointer;user-select:none;border-bottom:2px solid var(--ln)}}
 /* Header stays visible while the table scrolls. It pins below the pinned plots,
    whose rendered height a script keeps in --ploth (0 when nothing is pinned).
@@ -496,8 +506,11 @@ table.grid{{border-collapse:collapse;font-size:13px;margin:0 auto}}
 table.grid th,table.grid td{{border:1px solid var(--ln);padding:8px 12px;
 text-align:left;vertical-align:top}}
 table.grid thead th,table.grid tr:first-child th{{background:var(--soft);
-font-weight:600;color:var(--ink);white-space:nowrap}}
-.grow{{background:var(--soft);font-weight:600;color:var(--ink);white-space:nowrap}}
+font-weight:700;color:var(--ink);white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}}
+.grow{{background:var(--soft);font-weight:700;color:var(--ink);
+white-space:nowrap;font-size:12px;
+font-family:'Space Mono',ui-monospace,monospace;text-transform:uppercase}}
 .gcorner{{background:var(--soft)}}
 .gcell .gcount{{font-size:11px;color:var(--mut)}}
 .gcell .gbest{{font-family:'Space Mono',ui-monospace,monospace;font-size:12px;


### PR DESCRIPTION
Closes #101

Per the QEC brand feedback (UF homepage as design baseline), headers inside tables and bordered containers now use Space Mono in upper case, replacing the inconsistent Manrope/Space Grotesk mix in sentence case. Covered:

- Codes table column headers (CODE, TYPE, N, K, D, ...), which were already uppercase but in Manrope
- Primary-tracks grid column headers (weight bounds) and row labels (locality classes)
- The Leaderboard container header
- The "Build a code / Open a PR / Climb the board" step-card titles

Font sizes are trimmed a point or two where needed since uppercase mono renders wider than the previous sentence-case text.

`docs/` is regenerated via `make build`. The other brand-feedback PRs also regenerate `docs/`, so merge them one at a time and rebase + `make build` the rest.