### PR TITLE
Add visible hover states for hero link and Participate button

### DIFF
--- a/docs/codes/108-8-10.html
+++ b/docs/codes/108-8-10.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/112-6-7.html
+++ b/docs/codes/112-6-7.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/120-5-8.html
+++ b/docs/codes/120-5-8.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/120-8-12.html
+++ b/docs/codes/120-8-12.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/126-28-8.html
+++ b/docs/codes/126-28-8.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/128-6-8.html
+++ b/docs/codes/128-6-8.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/128-8-6.html
+++ b/docs/codes/128-8-6.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/144-12-12.html
+++ b/docs/codes/144-12-12.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/153-5-9.html
+++ b/docs/codes/153-5-9.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/16-2-4.html
+++ b/docs/codes/16-2-4.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/160-6-9.html
+++ b/docs/codes/160-6-9.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/180-18-14.html
+++ b/docs/codes/180-18-14.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/180-20-14.html
+++ b/docs/codes/180-20-14.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/180-6-10.html
+++ b/docs/codes/180-6-10.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/198-12-7.html
+++ b/docs/codes/198-12-7.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/200-8-9.html
+++ b/docs/codes/200-8-9.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/231-5-11.html
+++ b/docs/codes/231-5-11.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/240-6-11.html
+++ b/docs/codes/240-6-11.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/25-1-5.html
+++ b/docs/codes/25-1-5.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/264-6-12.html
+++ b/docs/codes/264-6-12.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/288-12-18.html
+++ b/docs/codes/288-12-18.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/288-8-12.html
+++ b/docs/codes/288-8-12.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/294-12-14.html
+++ b/docs/codes/294-12-14.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/294-8-19.html
+++ b/docs/codes/294-8-19.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/299-5-13.html
+++ b/docs/codes/299-5-13.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/336-6-14.html
+++ b/docs/codes/336-6-14.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/36-2-6.html
+++ b/docs/codes/36-2-6.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/42-8-3.html
+++ b/docs/codes/42-8-3.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/45-5-4.html
+++ b/docs/codes/45-5-4.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/49-1-7.html
+++ b/docs/codes/49-1-7.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/50-6-4.html
+++ b/docs/codes/50-6-4.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/56-2-8.html
+++ b/docs/codes/56-2-8.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/64-2-8.html
+++ b/docs/codes/64-2-8.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/66-5-5.html
+++ b/docs/codes/66-5-5.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/7-1-3.html
+++ b/docs/codes/7-1-3.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/72-12-6.html
+++ b/docs/codes/72-12-6.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/72-6-6.html
+++ b/docs/codes/72-6-6.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/81-1-9.html
+++ b/docs/codes/81-1-9.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/88-6-6.html
+++ b/docs/codes/88-6-6.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/90-8-10.html
+++ b/docs/codes/90-8-10.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/codes/91-5-7.html
+++ b/docs/codes/91-5-7.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/docs/references.html
+++ b/docs/references.html
@@ -48,6 +48,7 @@ header.hero h1{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}
 header.hero h1 a{color:#fff}
 header.hero p{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}
 header.hero p a{color:#ffff00;text-decoration:underline}
+header.hero p a:hover{background:#ffff00;color:#111;text-decoration:none}
 .topnav{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
 .topnav a{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -79,8 +80,8 @@ text-transform:uppercase;letter-spacing:.03em}
 .lbcta{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}
-.lbcta:hover{filter:brightness(1.08)}
+text-decoration:none;cursor:pointer;transition:background .15s}
+.lbcta:hover{background:#5b21b6}
 .modal{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}
 .modal::backdrop{background:rgba(17,17,17,.45)}

--- a/site/build.py
+++ b/site/build.py
@@ -350,6 +350,7 @@ header.hero h1{{font-size:clamp(30px,6vw,44px);margin:0;letter-spacing:-1px}}
 header.hero h1 a{{color:#fff}}
 header.hero p{{font-size:18px;max-width:640px;margin:0;color:#e4e4e7}}
 header.hero p a{{color:{HILITE};text-decoration:underline}}
+header.hero p a:hover{{background:{HILITE};color:#111;text-decoration:none}}
 .topnav{{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}}
 .topnav a{{display:inline-flex;align-items:center;gap:7px;color:#e4e4e7;
 font-family:'Space Mono',ui-monospace,monospace;
@@ -381,8 +382,8 @@ text-transform:uppercase;letter-spacing:.03em}}
 .lbcta{{flex:0 0 auto;font-size:13px;font-weight:700;color:#fff;
 font-family:'Space Mono',ui-monospace,monospace;
 background:var(--ac);border:none;border-radius:8px;padding:8px 14px;
-text-decoration:none;cursor:pointer}}
-.lbcta:hover{{filter:brightness(1.08)}}
+text-decoration:none;cursor:pointer;transition:background .15s}}
+.lbcta:hover{{background:#5b21b6}}
 .modal{{position:relative;border:none;border-radius:14px;padding:22px 24px;
 max-width:520px;width:92%;box-shadow:0 20px 60px rgba(17,17,17,.25)}}
 .modal::backdrop{{background:rgba(17,17,17,.45)}}


### PR DESCRIPTION
Closes #102

Per the QEC brand feedback (item 5.1), the two interactive elements flagged as lacking hover feedback now have visible hover states:

- The "Read the whitepaper" link in the hero inverts to the signature yellow highlight with dark text, matching the existing top nav pill hover.
- The Participate button transitions to a brighter purple. It technically had a `brightness(1.08)` hover before, but on the deep purple background that was imperceptible.

Other links and buttons (top nav, GitHub link, table rows, footer links) already had hover styling and are unchanged.

`docs/` is regenerated via `make build`. The other brand-feedback PRs also regenerate `docs/`, so merge them one at a time and rebase + `make build` the rest.