### PR TITLE
CI gate: accelerated deep-refutation pass for frontier claims

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,6 +40,20 @@ jobs:
           fetch-depth: 0
           path: trusted
       - uses: astral-sh/setup-uv@v5
+      # Build the optional RIS accelerator in each tree that runs searches. Best
+      # effort (continue-on-error): the python passes are the gate's baseline and
+      # run unchanged without it, so a failed build only costs the extra depth.
+      # For code PRs the gate runs from the trusted tree, so the extension is
+      # compiled from BASE-BRANCH source -- a PR cannot alter the C++ it is gated by.
+      - name: build optional refutation accelerator (trusted tree)
+        if: github.event_name == 'pull_request'
+        working-directory: trusted
+        continue-on-error: true
+        run: make fast
+      - name: build optional refutation accelerator (submitted tree)
+        working-directory: submitted
+        continue-on-error: true
+        run: make fast
       - name: detect changed code submissions
         if: github.event_name == 'pull_request'
         id: changes

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -1,14 +1,16 @@
 """Distance-refutation gate for the codes changed in a PR (CI).
 
-Runs independent bounded, fixed-seed refutation searches -- RIS
+Runs independent bounded, fixed-seed refutation searches -- python RIS
 (heuristic_distance), the syndrome decoder (decode/distance, needs ldpc), and,
-for frontier-advancing claims, a ~60x-deeper accelerated RIS pass (gf2_fast,
+for frontier-advancing claims, a ~150x-deeper accelerated RIS pass (gf2_fast,
 built via `make fast`) whose finds only count after the pinned python stack
 validates the witness -- only on the code/example submissions changed in this
 PR, and exits non-zero if ANY finds a logical lighter than the claimed distance
-(an over-claim). The syndrome-decoder and accelerated passes are each skipped
-if their dependency is unavailable; the python RIS passes always run, so a
-missing extension can only reduce extra depth, never weaken the baseline gate. Bulk
+(an over-claim). With the extension built, deep claims get 1 python RIS seed
+(the audited floor / canary) plus the fast pass; without it they get the full
+pre-accelerator battery of 3 python seeds, so a missing or broken extension can
+never leave the gate shallower than it was. The syndrome-decoder cross-check is
+skipped if ldpc is unavailable. Bulk
 re-verification of the whole board stays cheap -- only new/changed files pay the
 search cost. The RIS budget is ADAPTIVE (see _budget): trials scale with code
 size, so a small code gets near-exhaustive coverage and a large one a
@@ -94,7 +96,7 @@ def board_record_slugs(code_root=ROOT):
     return rec
 
 
-def _budget(n, deep):
+def _budget(n, deep, fast=False):
     """Adaptive refutation depth for a code with n qubits: (trials, seconds, seeds).
 
     Trials scale with n (the RIS target formula, without the flat 8000 cap the
@@ -108,16 +110,22 @@ def _budget(n, deep):
     deepens the old behavior, where the trial target was flat-capped at 8000 --
     reached in ~10 s -- so the deep pass's extra 120 s bought nothing.
 
-    Deep (frontier-advancing) claims get 3 independent seeds at ~60k-scale trial
+    Deep (frontier-advancing) claims get independent seeds at ~60k-scale trial
     targets: the depth that exposed real over-claims which 8k-trial passes let
-    through. Worst case is 3 x 240 s = 12 min of RIS per code (measured: ~11 min
-    at n=294), paid only by a code claiming a record; dominated rows stay
-    cheap."""
+    through. How many python seeds depends on whether the C++ accelerator is
+    available (``fast``): with it, ONE python seed remains as the audited floor
+    and in-production canary (it would expose a false-negative bug in the
+    extension by finding what the fast pass missed), and the reallocated
+    wall-clock goes into a ~150x-deeper fast pass; without it, the pre-
+    accelerator battery of 3 seeds runs unchanged, so a missing or broken
+    extension can never leave the gate shallower than it was. Worst case per
+    record claim is ~4 min of python RIS + the fast pass (or 3 x 240 s python-
+    only); dominated rows stay cheap."""
     per_trial = 0.0005 + 2.5e-6 * n              # seconds/trial, measured (both sides)
     if deep:
         trials = 25000 + 120 * n
         seconds = min(240.0, max(120.0, trials * per_trial * 3))
-        return trials, seconds, 3
+        return trials, seconds, (1 if fast else 3)
     trials = 2500 + 40 * n
     seconds = min(90.0, max(10.0, trials * per_trial * 4))
     return trials, seconds, 1
@@ -207,7 +215,7 @@ def main(argv):
         # standard, size-scaled pass.
         slug = os.path.splitext(os.path.basename(f))[0]
         deep = slug in records
-        trials, budget, nseeds = _budget(int(doc["n"]), deep)
+        trials, budget, nseeds = _budget(int(doc["n"]), deep, fast=GF is not None)
         seeds = [seed, seed + 2, seed + 3][:nseeds]
         # two independent mechanisms; a hit from EITHER (any seed) refutes.
         results = {}
@@ -217,14 +225,16 @@ def main(argv):
         if SD is not None:
             results["syndrome-decoder"] = SD.refute_check(doc, seed=seed + 1)
         # Frontier claims additionally face the accelerated deep search when the
-        # extension is built (CI builds it; see Makefile `fast`): ~60x the python
-        # trial target in comparable wall-clock. Additive only -- the python
-        # passes above are unchanged, so an absent/broken extension can never
-        # weaken the gate, and a fast hit counts only with a python-validated
-        # witness (see _fast_refute).
+        # extension is built (CI builds it; see Makefile `fast`): ~150x the
+        # python trial target in the wall-clock freed by dropping 2 of the 3
+        # python seeds (see _budget: without the extension the 3-seed battery
+        # runs unchanged, so an absent/broken build can never weaken the gate).
+        # A fast hit counts only with a python-validated witness (_fast_refute);
+        # the remaining python seed is the audited floor and would surface a
+        # false-negative extension bug by finding what the fast pass missed.
         ftrials = 0
         if GF is not None and deep:
-            ftrials = min(4_000_000, 60 * trials)
+            ftrials = min(8_000_000, 150 * trials)
             results["RIS-fast"] = _fast_refute(doc, seed + 7, ftrials)
         hits = {m: (dh, wit) for m, (ref, dh, wit, _) in results.items() if ref}
         fast_tag = (f" + fast x {ftrials}" if ftrials else "")

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -1,10 +1,14 @@
 """Distance-refutation gate for the codes changed in a PR (CI).
 
-Runs two independent bounded, fixed-seed refutation searches -- RIS
-(heuristic_distance) and the syndrome decoder (decode/distance, needs ldpc) --
-only on the code/example submissions changed in this PR, and exits non-zero if
-EITHER finds a logical lighter than the claimed distance (an over-claim). The
-syndrome-decoder cross-check is skipped if ldpc is unavailable (RIS-only). Bulk
+Runs independent bounded, fixed-seed refutation searches -- RIS
+(heuristic_distance), the syndrome decoder (decode/distance, needs ldpc), and,
+for frontier-advancing claims, a ~60x-deeper accelerated RIS pass (gf2_fast,
+built via `make fast`) whose finds only count after the pinned python stack
+validates the witness -- only on the code/example submissions changed in this
+PR, and exits non-zero if ANY finds a logical lighter than the claimed distance
+(an over-claim). The syndrome-decoder and accelerated passes are each skipped
+if their dependency is unavailable; the python RIS passes always run, so a
+missing extension can only reduce extra depth, never weaken the baseline gate. Bulk
 re-verification of the whole board stays cheap -- only new/changed files pay the
 search cost. The RIS budget is ADAPTIVE (see _budget): trials scale with code
 size, so a small code gets near-exhaustive coverage and a large one a
@@ -24,11 +28,23 @@ import secrets
 import subprocess
 import sys
 
+import numpy as np
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gf2
 import heuristic_distance as H
 from qldpc_verify import file_size_error
 
+try:
+    import gf2_fast as GF          # optional C++ accelerator (make fast); the
+except ImportError:                # gate degrades to the python passes without it
+    GF = None
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Fixed thread count for the fast pass so its verdict is reproducible from the
+# printed seed alone (the per-thread RNG streams depend on the split).
+FAST_THREADS = 4
 
 
 def _load_syndrome():
@@ -107,6 +123,33 @@ def _budget(n, deep):
     return trials, seconds, 1
 
 
+def _fast_refute(doc, seed, trials):
+    """Deep RIS via the optional C++ accelerator, kept SOUND the same way the
+    python passes are: the accelerator only proposes (weight, side, support);
+    the find counts as a refutation only after the pinned python stack confirms
+    the support is a genuine nontrivial logical of that weight, lighter than
+    the claim. An invalid or non-improving find is reported as a miss, never
+    trusted. Returns the refute_check tuple shape: (refuted, d, witness, trials)."""
+    n = doc["n"]
+    HX = H._matrix(doc["checks"]["X"], n)
+    HZ = H._matrix(doc["checks"]["Z"], n)
+    w, side, support = GF.distance_rand_witness(
+        HX, HZ, trials=trials, seed=seed, pair_depth=8, threads=FAST_THREADS)
+    claimed = int(doc["distance"]["d"])
+    if not side or w >= claimed:
+        return False, (w if side else None), None, trials
+    v = np.zeros(n, dtype=np.int8)
+    v[list(support)] = 1
+    Hcheck = HZ if side == "X" else HX
+    L = gf2.logical_basis(HX, HZ) if side == "X" else gf2.logical_basis(HZ, HX)
+    valid = (int(v.sum()) == w
+             and not ((Hcheck @ v) % 2).any()
+             and bool(((L @ v) % 2).any()))
+    if not valid:
+        return False, None, None, trials
+    return True, w, sorted(int(q) for q in support), trials
+
+
 def main(argv):
     rest = [a for a in argv if not a.endswith(".json")]
     seed = None
@@ -173,9 +216,20 @@ def main(argv):
                                                   trials=trials)
         if SD is not None:
             results["syndrome-decoder"] = SD.refute_check(doc, seed=seed + 1)
+        # Frontier claims additionally face the accelerated deep search when the
+        # extension is built (CI builds it; see Makefile `fast`): ~60x the python
+        # trial target in comparable wall-clock. Additive only -- the python
+        # passes above are unchanged, so an absent/broken extension can never
+        # weaken the gate, and a fast hit counts only with a python-validated
+        # witness (see _fast_refute).
+        ftrials = 0
+        if GF is not None and deep:
+            ftrials = min(4_000_000, 60 * trials)
+            results["RIS-fast"] = _fast_refute(doc, seed + 7, ftrials)
         hits = {m: (dh, wit) for m, (ref, dh, wit, _) in results.items() if ref}
+        fast_tag = (f" + fast x {ftrials}" if ftrials else "")
         tag = (f"deep, {len(seeds)} RIS seeds x {trials} trials (<={budget:.0f}s each)"
-               if deep else f"standard, {trials} trials (<={budget:.0f}s)")
+               f"{fast_tag}" if deep else f"standard, {trials} trials (<={budget:.0f}s)")
         if hits:
             refuted += 1
             for m, (dh, wit) in hits.items():


### PR DESCRIPTION
## Summary

Follow-up to #112, giving CI the "better verification in the same time" it enables. When the gf2_fast extension is built (CI now builds it, best-effort, in both checkouts), frontier-advancing submissions are gated by a rebalanced deep battery:

- **1 python RIS seed** (unchanged budget: 25k+120n trials, ≤240s) — the manifest-pinned, audited floor, and an in-production canary: it would expose a false-negative bug in the extension by finding what the fast pass missed.
- **The syndrome-decoder cross-check** (unchanged) — mechanism diversity.
- **A gf2_fast witness-returning RIS pass at 150× the python trial target, capped at 8M trials** — the wall-clock freed by dropping 2 of the 3 python seeds, reinvested.

Without the extension (build failure, missing compiler), the full pre-accelerator battery of **3 python seeds runs unchanged** — a broken build can never leave the gate shallower than it was. Dominated (non-record) submissions are unaffected either way.

## Soundness

The accelerator only *proposes* `(weight, side, support)`. A find counts as a refutation only after the pinned python stack (`gf2.py`) validates the witness: kernel membership, anticommutation with a logical, exact weight. Invalid proposals are discarded. False positives are therefore impossible; false negatives are covered by the retained python seed and the parity tests (which now run in CI, since the workflow builds the extension before the self-test step).

Reproducible: fixed `threads=4`, so a verdict reproduces from the printed seed alone. Trust: for code PRs the gate runs from the trusted checkout, so the extension is compiled from **base-branch source** — a submission cannot alter the C++ it is gated by. The 5-file validator manifest is untouched (`gate_changed.py` is base-branch-trusted, not manifest-pinned).

## Why

The [[294,8,20]] over-claim needed ~60k RIS trials to expose; the previous deep gate missed it 3/3 runs. At gf2_fast depth that logical falls in seconds. The same search depth (2M trials/side) refuted 5 of 7 staged n≥300 candidates this week that had passed the 8k-trial packaging gate.

## Measured

| Gate | Search volume (n=320 record) | Wall-clock |
|---|---|---|
| Old deep gate (3 python seeds) | ~190k trials | ~12 min worst case |
| This PR (1 python seed + fast) | 63.4k python + 8M fast trials | **10m42s measured** |

Same time, ~42× the search volume.

- `_fast_refute` refutes the known-inflated [[320,6,30]] candidate with a validated weight-28 witness in 24.5s (500k trials).
- End-to-end deep gate on the merged [[320,6,28]] record: `ok … (deep, 1 RIS seeds x 63400 trials (<=240s each) + fast x 8000000)`, exit 0.
- `test_refute_gate.py` and the quick suite pass; fallback tiers verified: `_budget(320, deep, fast=False)` → 3 seeds, `fast=True` → 1 seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)