### PR TITLE
Correct factual errors in the QSW 2026 abstract

### DIFF
--- a/talks/qsw-2026/abstract.tex
+++ b/talks/qsw-2026/abstract.tex
@@ -19,8 +19,9 @@
   Vincent Russo, and William J. Zeng\\[4pt]
   Unitary Foundation\\
   \texttt{github.com/unitaryfoundation/qldpc-challenge}}
-\date{Extended abstract, lightning talk, Quantum Software Workshop 2026
-  (IEEE Quantum Week, Toronto)}
+\date{Extended abstract, lightning talk, Quantum Software 2.6 Workshop,
+  IEEE Quantum Week (IEEE QCE 2026), Metro Toronto Convention Centre,
+  17 September 2026}
 
 \begin{document}
 \maketitle

--- a/talks/qsw-2026/abstract.tex
+++ b/talks/qsw-2026/abstract.tex
@@ -88,7 +88,7 @@ distance does not scale, the board separates three confidence tiers. An
 \emph{upper bound} ($d \le$) is backed by an explicit logical-operator witness
 that the verifier confirms is a genuine nontrivial logical of the claimed weight,
 so the bound is checkable with no trust required. A \emph{corroborated} bound
-($d \le^{\!*}$) is an upper bound that an independent search has tried and failed
+($d \le^{*}$) is an upper bound that an independent search has tried and failed
 to beat. An \emph{exact} value ($d =$) is one a server-side integer program has
 proven minimal. Nothing is ever silently upgraded.
 
@@ -167,25 +167,23 @@ Rotated surface~\cite{kitaev2003fault}          & $[[d^2,1,d]]$   & planar      
 Gross code~\cite{bravyi2024high}                & $[[144,12,12]]$ & periodic     & 6  & $12$\\
 Tile code~\cite{steffan2025tile}                & $[[512,18,19]]$ & planar       & 8  & $12.7$\\
 Generalized bicycle~\cite{panteleev2021degenerate} & $[[126,28,8]]$  & periodic  & 10 & $14.2$\\
-Coset 2BGA~\cite{aydin2026breaking}             & $[[168,20,14]]$ & unrestricted & 8  & $23.3$\\
+Coset 2BGA~\cite{aydin2026breaking}             & $[[168,16,15]]$ & unrestricted & 8  & $21.4$\\
 \bottomrule
 \end{tabular}
-\caption{Reference points spanning the efficiency range. The tile code, the sole
-2D-local weight-8 entry, has an integer-programming-certified exact distance; the
-others are the published parameters.}
+\caption{Reference points spanning the efficiency range; all values are the
+published parameters. The tile code is the sole 2D-local weight-8 entry.}
 \label{tab:ref}
 \end{table}
 
-At the time of writing the board holds 42 verified codes, 22 submitted through
-the challenge and 20 literature baselines, with 27 certified exact, across the
+At the time of writing the board holds 44 verified codes, 23 submitted through
+the challenge and 21 literature baselines, with 29 certified exact, across the
 bivariate-bicycle, generalized-bicycle, two-block group-algebra, tile, and
 topological families. It is seeded against a selection of published codes (the
 planar open-boundary codes~\cite{liang2025planar}, the bivariate-bicycle gross
 code~\cite{bravyi2024high}, the generalized-bicycle
-codes~\cite{panteleev2021degenerate,wang2022distance}, the coset two-block
-codes~\cite{aydin2026breaking}, and the surface, toric, and Steane
-codes~\cite{kitaev2003fault,steane1996error}), so a submission is always measured
-against known codes. The seed set is selected, not an exhaustive snapshot, and
+codes~\cite{panteleev2021degenerate,wang2022distance,lin2024quantum}, and the
+surface, toric, and Steane codes~\cite{kitaev2003fault,steane1996error}), so a
+submission is always measured against known codes. The seed set is selected, not an exhaustive snapshot, and
 the board states this: an on-board leader may still be matched by a published
 code that has not been seeded. The badges and figures are regenerated from the
 live board on every build, so they track the current numbers rather than a

--- a/talks/qsw-2026/refs.bib
+++ b/talks/qsw-2026/refs.bib
@@ -121,6 +121,21 @@
   note          = {arXiv:2606.02418}
 }
 
+@article{lin2024quantum,
+  title   = {Quantum two-block group algebra codes},
+  author  = {Lin, Hsiang-Ku and Pryadko, Leonid P.},
+  journal = {Physical Review A},
+  volume  = {109},
+  number  = {2},
+  pages   = {022407},
+  year    = {2024},
+  eprint  = {2306.16400},
+  archivePrefix = {arXiv},
+  primaryClass  = {quant-ph},
+  doi     = {10.1103/PhysRevA.109.022407},
+  note    = {arXiv:2306.16400}
+}
+
 @article{bravyi2010tradeoffs,
   title   = {Tradeoffs for reliable quantum information storage in {2D} systems},
   author  = {Bravyi, Sergey and Poulin, David and Terhal, Barbara},


### PR DESCRIPTION
Fixes to `talks/qsw-2026/abstract.tex` after cross-checking every verifiable claim against the live board and the cited papers.

## Factual corrections

1. **Fabricated reference-table entry.** The Coset 2BGA row cited `[[168,20,14]]` (kd²/n 23.3) to Aydin-Tamo-Barg (arXiv:2606.17268). That parameter set does not appear anywhere in the paper (its weight-8 codes are `[[84,16,8]]`, `[[112,16,10]]`, `[[128,16,12]]`, `[[168,16,15]]`). Replaced with the paper's actual highest-efficiency code, `[[168,16,15]]` (kd²/n 21.4).

2. **False certified-exact claim.** The caption said the tile code has an "integer-programming-certified exact distance." The board's only 2D-local weight-8 code, `[[294,12,14]]`, is an upper bound (no cert), and the tabulated tile `[[512,18,19]]` is a published Steffan et al reference, not an on-board certified code. Dropped the claim; the table is now all published parameters.

3. **Stale board counts.** Updated to the current live board: 44 verified, 23 submitted, 21 literature baselines, 29 certified exact (were 42 / 22 / 20 / 27). These had drifted after the recently-merged baselines.

4. **Seed-list accuracy.** The coset two-block codes are challenge *submissions*, not seeded baselines, so they're removed from the "seeded against" list. Added `lin2024quantum` (the Lin-Pryadko GB/2BGA baselines `[[24,6,4]]`/`[[40,6,5]]` we recently seeded).

5. **Style.** Replaced the `\le^{\!*}` negative-space hack with `\le^{*}`.

## Not done: seeding [[168,20,14]]

The original plan was to seed `[[168,20,14]]` to resolve a published-code-beats-the-board tension. That code **does not exist in the literature** — the number in the table was wrong. With the real figure (`[[168,16,15]]`, 21.4), the published code does **not** beat the board's best (`[[180,20,14]]`, 21.778), so there is nothing to resolve and no baseline to seed. Seeding a `[[168,20,14]]` would have fabricated a literature baseline.

## Verification

Isolated `pdflatex` + `bibtex` + `pdflatex`×2: exit 0, no undefined citations, zero overfull hboxes. Added the missing `lin2024quantum` entry to the talk-local `refs.bib`. Table and prose confirmed correct in the rendered PDF.