### PR TITLE
Gate: cell-aware record detection for the deep refutation tier

### DIFF
--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -71,10 +71,54 @@ def changed_codes(base, code_root=ROOT):
     return [f for f in out.split() if f.endswith(".json")]
 
 
+def _locality_rank(doc):
+    """Home locality class as a tightness rank: 0 = local-2d-single,
+    1 = local-2d-bilayer, 2 = unrestricted. Mirrors the verifier's derivation
+    (TRACKS.md): an honest layout -- full coverage, at most `layers` qubits per
+    site, distinct sites unit-spaced -- earns a class when the measured check
+    radius is within the class cap; anything else is unrestricted. Used only
+    to pick the refutation BUDGET; the authoritative classification stays in
+    qldpc_verify."""
+    import math
+    from collections import Counter
+    loc = doc.get("locality")
+    n = doc["n"]
+    if not loc or len(loc.get("coordinates", [])) != n:
+        return 2
+    coords = loc["coordinates"]
+    layers = loc.get("layers", 1)
+
+    def diam(sup):
+        pts = [coords[q] for q in sup]
+        return max((math.dist(a, b) for a in pts for b in pts), default=0.0)
+    radius = max((diam(s) for s in doc["checks"]["X"] + doc["checks"]["Z"]),
+                 default=0.0)
+    mult = Counter(tuple(c) for c in coords)
+    sites = sorted(mult)
+    min_sp = min((math.dist(a, b) for i, a in enumerate(sites)
+                  for b in sites[i + 1:]), default=float("inf"))
+    if min_sp < 1.0:
+        return 2
+    for rank, (lay, cap) in enumerate(((1, 4.0), (2, 7.0))):
+        if layers <= lay and max(mult.values()) <= lay and radius <= cap:
+            return rank
+    return 2
+
+
+def _weight_rank(w):
+    """Check-weight class as a tightness rank: weight-4 < weight-6 < weight-8
+    < any weight."""
+    return 0 if w <= 4 else 1 if w <= 6 else 2 if w <= 8 else 3
+
+
 def board_record_slugs(code_root=ROOT):
-    """Slugs on the board's global (n, k, d, w) Pareto frontier. A code that
-    claims to advance the frontier gets deeper refutation than a dominated one,
-    so over-claims pay extra scrutiny exactly where gaming would matter."""
+    """Slugs that are records of their own primary-track CELL: undominated on
+    (n, k, d, w) among board codes whose locality and weight classes are
+    stricter or equal (the codes that share the cell under TRACKS.md nesting).
+    A code that claims a cell record gets deeper refutation than a dominated
+    one, so over-claims pay extra scrutiny exactly where gaming would matter.
+    Cell-aware on purpose: a 2D-local record is a record even when a nonlocal
+    code beats it globally, and it deserves the deep battery too."""
     rows = []
     for p in sorted(glob.glob(os.path.join(code_root, "codes", "*.json"))):
         try:
@@ -82,13 +126,16 @@ def board_record_slugs(code_root=ROOT):
             ck = d.get("checks", {})
             w = max((len(s) for s in ck.get("X", []) + ck.get("Z", [])), default=0)
             rows.append((os.path.splitext(os.path.basename(p))[0],
-                         d["n"], d["k"], d["distance"]["d"], w))
+                         d["n"], d["k"], d["distance"]["d"], w,
+                         _weight_rank(w), _locality_rank(d)))
         except Exception:
             continue
     rec = set()
     for i, a in enumerate(rows):
         dominated = any(
-            j != i and b[1] <= a[1] and b[2] >= a[2] and b[3] >= a[3] and b[4] <= a[4]
+            j != i
+            and b[5] <= a[5] and b[6] <= a[6]          # shares a's home cell
+            and b[1] <= a[1] and b[2] >= a[2] and b[3] >= a[3] and b[4] <= a[4]
             and (b[1] < a[1] or b[2] > a[2] or b[3] > a[3] or b[4] < a[4])
             for j, b in enumerate(rows))
         if not dominated:
@@ -208,11 +255,11 @@ def main(argv):
         doc = json.load(open(p))
         if "distance" not in doc or "d" not in doc.get("distance", {}):
             continue
-        # A code that advances the frontier is checked harder: several independent
-        # deep RIS seeds, not one short pass, so an over-claim cannot lean on a
-        # single search missing the lighter logical. Trials and wall-clock both
-        # scale with code size (see _budget). Dominated codes pay only the
-        # standard, size-scaled pass.
+        # A code that is a record of its own primary-track cell is checked
+        # harder: several independent deep RIS seeds, not one short pass, so an
+        # over-claim cannot lean on a single search missing the lighter logical.
+        # Trials and wall-clock both scale with code size (see _budget).
+        # Dominated codes pay only the standard, size-scaled pass.
         slug = os.path.splitext(os.path.basename(f))[0]
         deep = slug in records
         trials, budget, nseeds = _budget(int(doc["n"]), deep, fast=GF is not None)

--- a/verify/setup_gf2_fast.py
+++ b/verify/setup_gf2_fast.py
@@ -1,7 +1,9 @@
 """Build the OPTIONAL gf2_fast C++ accelerator (see gf2_fast.cpp).
 
-Not part of the trusted validation stack and never built by CI; the pure-Python
-engine is the reference and the fallback. Build it for fast local search:
+Not part of the trusted validation stack; the pure-Python engine is the
+reference and the fallback. CI builds it best-effort (continue-on-error) so
+the gate's deep pass can use it -- a failed build only loses the extra
+search depth. Build locally with:
 
     make fast
 """

--- a/verify/test_refute_gate.py
+++ b/verify/test_refute_gate.py
@@ -117,6 +117,42 @@ def main():
               if c["check"] == "distance_not_refuted")["detail"]
     check("no-seed runs are non-deterministic (different seeds reported)", d1 != d2)
 
+    print("\nCELL: deep-tier record detection is cell-aware, not global")
+    # A 2D-local cell record that a nonlocal code dominates GLOBALLY must still
+    # count as a record (and so face the deep refutation tier). Regression for
+    # the locality-blind global frontier the gate used before.
+    import tempfile
+    import gate_changed
+    with tempfile.TemporaryDirectory() as td:
+        cd = os.path.join(td, "codes")
+        os.makedirs(cd)
+        docs = {
+            # local-2d-single record: nothing in its cell dominates it
+            "local-rec": {"n": 4, "k": 2, "distance": {"d": 2},
+                          "checks": {"X": [[0, 1]], "Z": [[2, 3]]},
+                          "locality": {"coordinates": [[0, 0], [1, 0],
+                                                       [0, 1], [1, 1]],
+                                       "layers": 1}},
+            # nonlocal code that dominates local-rec on every (n,k,d,w) axis
+            "global-dom": {"n": 2, "k": 9, "distance": {"d": 9},
+                           "checks": {"X": [[0, 1]], "Z": [[0, 1]]}},
+            # local code dominated INSIDE its own cell by local-rec
+            "local-dominated": {"n": 6, "k": 1, "distance": {"d": 1},
+                                "checks": {"X": [[0, 1]], "Z": [[4, 5]]},
+                                "locality": {"coordinates": [[0, 0], [1, 0],
+                                                             [2, 0], [0, 1],
+                                                             [1, 1], [2, 1]],
+                                             "layers": 1}},
+        }
+        for slug, doc in docs.items():
+            json.dump(doc, open(os.path.join(cd, f"{slug}.json"), "w"))
+        rec = gate_changed.board_record_slugs(td)
+        check("locally-undominated code is a record despite global domination",
+              "local-rec" in rec)
+        check("globally-undominated code is still a record", "global-dom" in rec)
+        check("code dominated within its own cell is not a record",
+              "local-dominated" not in rec)
+
     print(f"\n{'ALL PASS' if not _fail else 'FAILURES: ' + ', '.join(_fail)}")
     return 1 if _fail else 0
 


### PR DESCRIPTION
## Summary

Fixes the scrutiny-allocation gap surfaced by the last two 2D-local submissions: `gate_changed.board_record_slugs` decided the deep-vs-standard refutation tier from one **global** (n,k,d,w) Pareto frontier, ignoring locality. A code that is a record of its own locality × weight cell but globally dominated by a nonlocal code — exactly the situation of [[216,15,11]] and [[263,16,12]], both dominated globally by [[180,20,14]] — got only the standard budget (~2 min) instead of the deep battery (~15–30 min). Classification and board placement were never wrong; only the "how hard do we attack this claim" heuristic was.

## Change

- `board_record_slugs` now computes records **per home cell**, mirroring TRACKS.md nesting: a code is deep-tier iff no board code with stricter-or-equal locality and weight classes dominates it on (n,k,d,w).
- The locality class is derived with the verifier's own rules (full coverage, ≤ layers per site, unit spacing, radius caps 4/7) in a small local helper used **only for budget selection** — classification authority stays with `qldpc_verify`, and `gate_changed.py` is not manifest-pinned, so no re-pin.
- Regression test in `test_refute_gate.py`: a synthetic local-cell record that a nonlocal code dominates globally must be in the record set; a code dominated inside its own cell must not.
- Riders: corrected the stale "never built by CI" note in `setup_gf2_fast.py` (CI builds the accelerator best-effort since #113); confirmed `refute_board.py` needs no change (uniform budgets, no record logic).

## Verification

- New test passes; full quick suite 5/5.
- Sanity check against the live board: [[216,15,11]] now registers as a record under the gate's logic (it did not before); the globally-undominated records are unchanged.

Cost note: dominated submissions still pay only the standard pass — this widens the deep tier exactly to cell records, which is what a submission gains by over-claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)