### PR TITLE
Skip the verify workflow for docs-only PRs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,10 @@ on:
       - "run_tests.py"
       - "pyproject.toml"
       - "uv.lock"
+      # Markdown can't affect anything the jobs below execute (run_tests.py only
+      # runs test_*.py; the verifier reads codes/*.json), so docs-only PRs skip
+      # the workflow entirely. A PR mixing .md with any matching file still runs.
+      - "!**/*.md"
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

PR #134 (a markdown-only edit to `research/AUTORESEARCH.md`) triggered the full verify workflow — including `verify/test_heuristic_distance.py`, the deliberately slow corroboration test that runs the heuristic refuter at 2500 trials against all 29 exact certs (~10 min, growing with the board).

The workflow already reasons that a PR which "cannot have touched the stack the self-tests exercise" should skip them (the `only_codes` skip); docs-only PRs satisfy the same reasoning but weren't covered. This adds a `!**/*.md` paths negation so markdown-only PRs skip the workflow entirely — no runner spin-up at all.

## Safety

- A PR mixing `.md` with **any** file matching the trigger paths (code, workflows, schema, lockfiles) still runs the workflow unchanged — negation only removes `.md` files from matching, it never masks other files.
- `run_tests.py` discovers only `test_*.py`; the verifier reads `codes/*.json`; no job executes markdown.
- Pushes to `main` have no paths filter and still run everything.

## Test plan

- This PR itself touches `.github/workflows/**`, so verify runs here (correctly — workflow changes must stay gated).
- After merge: the next docs-only PR should show no verify check; the next code PR should run it as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)