### PR TITLE
Test the heuristic against a pinned panel instead of the full board

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -18,9 +18,9 @@ import time
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
 # Slow tests (about a minute or more locally); skipped with --skip-slow.
-SLOW = {
-    "verify/test_heuristic_distance.py",   # corroborates over every certified code
-}
+# Currently empty: test_heuristic_distance.py used to sweep every certified code
+# (O(board size)) but now checks a fixed panel and runs in seconds.
+SLOW = set()
 
 
 def collect():

--- a/verify/test_heuristic_distance.py
+++ b/verify/test_heuristic_distance.py
@@ -1,10 +1,19 @@
 """Validation for heuristic_distance.
 
-1. Corroboration: over every exact-certified code, the heuristic search must never
-   find a logical LIGHTER than the certified distance (that would be a bug or a bad
-   cert); ideally it corroborates (finds exactly the certified weight).
+1. Corroboration: over a pinned PANEL of exact-certified codes, the heuristic must
+   find exactly the certified distance -- lighter would mean a search bug or a bad
+   cert, and failing to reach it would mean the search got weaker (the panel is
+   sized so the budget reliably reaches d on both the python and gf2_fast engines).
 2. Refutation: an inflated (over-claimed) distance must be refuted.
+
+The panel is fixed and small instead of the whole board on purpose: this test
+validates the heuristic's LOGIC, and the 30th board entry exercises no code path
+the panel doesn't, so board growth must not grow CI time. Auditing the DATA (a bad
+cert on any entry) is the weekly refute_board.py cron's job -- it re-checks every
+entry with a fresh random seed each run. `--all` sweeps the full board the old way
+(tolerant of inconclusive verdicts on large codes) for manual audits.
 """
+import argparse
 import copy
 import glob
 import json
@@ -16,35 +25,60 @@ import heuristic_distance as H
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Diverse in family, shape and code path: topological k=1 (smallest and larger),
+# toric k=2, generalized-bicycle (low-k and the high-k [[126,28,8]]), and the BB
+# gross code. Every member corroborates at trials=2500, seed=0 on BOTH engines
+# (verified 2026-07-11); if one stops corroborating, the search regressed.
+PANEL = ["7-1-3", "16-2-4", "24-6-4", "49-1-7", "72-6-6", "126-28-8"]
 
-def main(trials=2500):
-    certs = sorted(glob.glob(os.path.join(ROOT, "certs", "*.json")))
-    contradictions = corr = inconcl = 0
-    print(f"=== corroboration over {len(certs)} exact certs (trials={trials}) ===")
-    for cf in certs:
-        slug = os.path.basename(cf)
-        codef = os.path.join(ROOT, "codes", slug)
-        if not os.path.exists(codef):
-            continue
-        doc = json.load(open(codef))
-        cert = json.load(open(cf))
-        if not cert.get("d_exact"):
-            continue                       # only validate where exactness is proven
-        exact_d = int(doc["distance"]["d"])  # the cert certifies this as exact
-        res = H.estimate(doc, trials=trials, seed=0)
-        dh = res["d_heuristic"]
-        flag = ""
-        if dh is not None and dh < exact_d:
-            flag = "  <<< FOUND LIGHTER THAN EXACT (bug/bad cert)"
-            contradictions += 1
-        elif res["verdict"] == "corroborated":
-            corr += 1
-        else:
-            inconcl += 1
-        print(f"  {slug:16s} exact_d={exact_d:2d} d_heur={dh} "
-              f"verdict={res['verdict']}{flag}")
-    print(f"\n  corroborated={corr}  inconclusive={inconcl}  "
-          f"contradictions={contradictions}")
+
+def check_code(slug, trials, require_corroboration):
+    """Check one cert/code pair; returns (n_failures, report_line)."""
+    codef = os.path.join(ROOT, "codes", slug + ".json")
+    certf = os.path.join(ROOT, "certs", slug + ".json")
+    if not (os.path.exists(codef) and os.path.exists(certf)):
+        return 1, f"  {slug:16s} MISSING code or cert file (panel rot -- swap the member)"
+    doc = json.load(open(codef))
+    cert = json.load(open(certf))
+    if not cert.get("d_exact"):
+        return 1, f"  {slug:16s} cert is not d_exact (panel rot -- swap the member)"
+    exact_d = int(doc["distance"]["d"])  # the cert certifies this as exact
+    res = H.estimate(doc, trials=trials, seed=0)
+    dh, verdict = res["d_heuristic"], res["verdict"]
+    line = (f"  {slug:16s} exact_d={exact_d:2d} d_heur={dh} "
+            f"verdict={verdict} method={res['method']}")
+    if dh is not None and dh < exact_d:
+        return 1, line + "  <<< FOUND LIGHTER THAN EXACT (bug/bad cert)"
+    if require_corroboration and verdict != "corroborated":
+        return 1, line + "  <<< PANEL MUST CORROBORATE (search regressed?)"
+    return 0, line
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--all", action="store_true",
+                    help="sweep every exact cert on the board (manual audit; "
+                         "inconclusive tolerated) instead of the pinned panel")
+    ap.add_argument("--trials", type=int, default=2500)
+    args = ap.parse_args(argv)
+
+    if args.all:
+        slugs = [os.path.basename(cf)[:-len(".json")]
+                 for cf in sorted(glob.glob(os.path.join(ROOT, "certs", "*.json")))
+                 if json.load(open(cf)).get("d_exact")
+                 and os.path.exists(os.path.join(ROOT, "codes", os.path.basename(cf)))]
+        mode = f"full board ({len(slugs)} exact certs)"
+    else:
+        slugs = PANEL
+        mode = f"pinned panel ({len(slugs)} codes)"
+
+    failures = 0
+    print(f"=== corroboration over {mode}, trials={args.trials} ===")
+    for slug in slugs:
+        bad, line = check_code(slug, args.trials,
+                               require_corroboration=not args.all)
+        failures += bad
+        print(line)
 
     print("\n=== refutation: planted over-claim ===")
     doc = json.load(open(os.path.join(ROOT, "codes", "16-2-4.json")))
@@ -56,9 +90,11 @@ def main(trials=2500):
           f"verdict={res['verdict']} d_heur={res['d_heuristic']}")
     ok = res["verdict"] == "refuted"
     print("  refutation", "OK" if ok else "FAILED")
+    failures += 0 if ok else 1
 
-    sys.exit(1 if (contradictions or not ok) else 0)
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary

`verify/test_heuristic_distance.py` swept **every** exact cert at 2500 trials, so CI self-test time grew linearly with the board (29 certs, ~10 min) — while the expensive large-n runs mostly came back "inconclusive," which the test tolerated, contributing near-zero bug-catching power. The two jobs the sweep conflated are now split:

- **Validating the heuristic's logic** (this test): a fixed 6-code panel — topological k=1 (smallest and larger), toric k=2, generalized-bicycle low-k and high-k ([[126,28,8]]), and the BB gross code. Board growth no longer grows CI time.
- **Auditing the board's data** (bad certs): already covered by the weekly `refute_board.py` cron, which re-checks every entry with a fresh random seed each run — a bad exact cert is an over-claim, exactly what it hunts, at accumulating coverage the fixed-seed PR test never had.

## Strictly stronger per second spent

- Panel members must now **corroborate** (find exactly the certified d), not merely avoid finding lighter — previously the test passed even if the search found nothing at all. A weakened search now fails.
- Every panel member verified to corroborate at `trials=2500, seed=0` on **both** engines (pure-python RIS and gf2_fast), so a failed accelerator build in CI can't flake the test.
- A missing or no-longer-exact panel cert fails loudly with a "swap the member" message rather than silently shrinking coverage.
- `--all` keeps the old tolerant full-board sweep for manual audits (`--trials` adjustable).

## Measured

- Panel: 10.6 s with gf2_fast, 6.3 s pure-python (was ~10 min in CI).
- Full `run_tests.py` suite: 6/6 pass in ~29 s locally; the test leaves the `SLOW` set (comment updated).
- `--all` path smoke-tested; planted over-claim refutation unchanged and passing.

`test_heuristic_distance.py` is not in `validator_manifest.json`, so no re-pin is involved; the pinned trusted stack is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)