### PR TITLE
Sort the leaderboard by best kd^2/n

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1354,9 +1354,10 @@ def progress_panel(entries, n_exact, best_eff):
 
 def contributors_panel(entries):
     """A leaderboard of who submitted the codes on the board. Ranks GitHub-handle
-    authors of contributed (non-baseline) codes by how many they have on the
-    board, then by how many sit on a track frontier, then by best kd2/n. The
-    seeded literature authors are not contributors and are excluded."""
+    authors of contributed (non-baseline) codes by the best kd2/n among their
+    codes, then by how many sit on a track frontier, then by how many they have
+    on the board. The seeded literature authors are not contributors and are
+    excluded."""
     front_slugs = {entries[i]["slug"] for i in compute_records(entries)}
     stats = {}
     for e in entries:
@@ -1375,8 +1376,8 @@ def contributors_panel(entries):
     if not stats:
         return ""
     order = sorted(stats.items(),
-                   key=lambda kv: (-kv[1]["codes"], -kv[1]["front"],
-                                   -kv[1]["eff"], kv[0]))
+                   key=lambda kv: (-kv[1]["eff"], -kv[1]["front"],
+                                   -kv[1]["codes"], kv[0]))
     n_codes = sum(1 for e in entries if e["origin"] != "baseline")
 
     def metric(v, lab):


### PR DESCRIPTION
Ranks contributors on the leaderboard by the best kd²/n among their codes, with frontier count and code count as tiebreakers — previously code count was the primary key.

Note: with the current board data the rendered order is unchanged (@FarLab leads on both code count and best kd²/n), so this PR only touches `site/build.py`; the built `docs/` are identical. The new key takes effect as soon as a contributor with fewer codes posts a higher score.

Stacked on #139 (branched from it); retarget to `main` after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)