### PR TITLE
Sort the contributor leaderboard by best kd^2/n

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1354,9 +1354,10 @@ def progress_panel(entries, n_exact, best_eff):
 
 def contributors_panel(entries):
     """A leaderboard of who submitted the codes on the board. Ranks GitHub-handle
-    authors of contributed (non-baseline) codes by how many they have on the
-    board, then by how many sit on a track frontier, then by best kd2/n. The
-    seeded literature authors are not contributors and are excluded."""
+    authors of contributed (non-baseline) codes by the best kd2/n among their
+    codes, then by how many sit on a track frontier, then by how many they have
+    on the board. The seeded literature authors are not contributors and are
+    excluded."""
     front_slugs = {entries[i]["slug"] for i in compute_records(entries)}
     stats = {}
     for e in entries:
@@ -1375,8 +1376,8 @@ def contributors_panel(entries):
     if not stats:
         return ""
     order = sorted(stats.items(),
-                   key=lambda kv: (-kv[1]["codes"], -kv[1]["front"],
-                                   -kv[1]["eff"], kv[0]))
+                   key=lambda kv: (-kv[1]["eff"], -kv[1]["front"],
+                                   -kv[1]["codes"], kv[0]))
     n_codes = sum(1 for e in entries if e["origin"] != "baseline")
 
     def metric(v, lab):


### PR DESCRIPTION
Ranks contributors on the bottom-of-page leaderboard by the best kd²/n among their codes, with frontier count and code count as tiebreakers — previously code count was the primary key.

This re-lands #146, which was accidentally merged into the `hero-participate-button` branch (its base) instead of `main` and never took effect. With the current board it changes the visible order: @willzeng (kd²/n = 28, from [[126,18,14]]) moves to #1 ahead of @FarLab (23.81).

Only `site/build.py` changes here — the `site.yml` workflow rebuilds and commits `docs/` automatically after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)