### PR TITLE
Set provenance.model on [[390,82,27]] (metadata fix)

### DIFF
--- a/codes/390-82-27.json
+++ b/codes/390-82-27.json
@@ -7111,6 +7111,7 @@
   "authors": [
    "@seunomonije"
   ],
+  "model": "Claude Fable 5",
   "construction": "Generalized bicycle (two-block) code on the cyclic group Z_195: H_X = [A|B], H_Z = [B^T|A^T] with A, B circulants; a(x) support {0,36,84,86,91,100,139,177}, b(x) support {24,30,82,102,133,169,175,185}. Both a and b are sparse multiples of a degree-37 divisor g of x^195-1 (product of the degree-1 factor x+1 and three degree-12 irreducible factors), giving k = 2*deg gcd(a,b,x^195-1) = 82 at n = 390 with weight-16 checks. Distance evidence: rising RIS ladder to 20M trials/side plus three independent 8M-trial refutation passes (seeds 777/888/999) all bottoming at d<=27; BP+OSD decoder search found nothing lighter than 46.",
   "references": [
    "arXiv:1904.02703",


### PR DESCRIPTION
One-field metadata fix: the [[390,82,27]] submission (#160) self-reported its model in `provenance.notes` but never set the schema's optional `provenance.model` field, so the board's MODEL column renders empty for this entry.

This PR sets `provenance.model` = "Claude Fable 5". The diff against main is exactly one line.

**Validation performed**: to be sure the fix matches what the official pipeline produces, the document was regenerated end-to-end with `./qldpc submit g195deep1.npz --model "Claude Fable 5" ...` from the original matrices. The tool-built `checks` block is bit-identical to the merged entry (verified programmatically), the tool re-confirmed CSS/k/weight, and `verify/validate_candidate.py` re-verified the entry's weight-27/35 witnesses on the final file (verify gate ok, refutation found nothing lighter; the only failing label is the expected "identical to board entry 390-82-27.json" self-duplicate, which is what an in-place metadata edit should look like). The final file keeps the merged entry byte-for-byte except the added model field, preserving the original references, notes, and date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)