### PR TITLE
Show all leaderboard columns on mobile (horizontal scroll)

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -120,7 +120,13 @@ object-fit:cover;flex:0 0 auto}
 flex:0 0 auto}
 .lbm b{font-size:17px;font-variant-numeric:tabular-nums}
 .lbml{font-size:11px;color:var(--mut);margin-top:1px;white-space:nowrap}
-@media(max-width:680px){.lbm:nth-child(n+5){display:none}.lbm{width:64px}}
+/* phones: show every metric column (codes/frontier/exact/kd2n) instead of
+   hiding the right-hand ones. The list scrolls horizontally as one unit; rows
+   share a min-width so the columns stay aligned row-to-row while scrolling. */
+@media(max-width:680px){.lbm{width:64px}
+.lblist{overflow-x:auto}
+.lbrow{min-width:520px}
+.lbname{min-width:96px}}
 .how{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin:40px 0}
 .how .card{border:1px solid var(--ln);border-radius:12px;padding:20px;
 background:var(--soft)}

--- a/site/build.py
+++ b/site/build.py
@@ -421,7 +421,13 @@ object-fit:cover;flex:0 0 auto}}
 flex:0 0 auto}}
 .lbm b{{font-size:17px;font-variant-numeric:tabular-nums}}
 .lbml{{font-size:11px;color:var(--mut);margin-top:1px;white-space:nowrap}}
-@media(max-width:680px){{.lbm:nth-child(n+5){{display:none}}.lbm{{width:64px}}}}
+/* phones: show every metric column (codes/frontier/exact/kd2n) instead of
+   hiding the right-hand ones. The list scrolls horizontally as one unit; rows
+   share a min-width so the columns stay aligned row-to-row while scrolling. */
+@media(max-width:680px){{.lbm{{width:64px}}
+.lblist{{overflow-x:auto}}
+.lbrow{{min-width:520px}}
+.lbname{{min-width:96px}}}}
 .how{{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin:40px 0}}
 .how .card{{border:1px solid var(--ln);border-radius:12px;padding:20px;
 background:var(--soft)}}


### PR DESCRIPTION
Fixes the contributor leaderboard on phones. In portrait, only the first metric column (codes) was visible; on-frontier, exact, and best kd²/n were hidden by a `display:none` rule, so you had to rotate to landscape to see them.

Change: stop hiding those columns. The leaderboard list now scrolls horizontally as one unit in portrait, and all rows share a min-width so the columns stay aligned row-to-row while scrolling. Verified at 390px that all four metric columns are reachable by horizontal scroll. Desktop is unchanged (the rule is scoped to ≤680px).

One UX note: when you scroll right, the rank/avatar/name scroll off with the row (simple, robust). If you'd prefer the name pinned while only the metrics scroll, that's a small follow-up with a sticky left column; say the word and I'll add it.