### PR TITLE
Add [[12,4,2]] twisted-torus BB baseline (arXiv:2503.03827)

### DIFF
--- a/TRACKS.md
+++ b/TRACKS.md
@@ -124,11 +124,12 @@ attributed to their authors, so a submission is measured against known codes
 rather than an empty board: the bivariate-bicycle codes of Bravyi et al
 (arXiv:2308.07915), the planar codes of Liang, Eberhardt, Chen (arXiv:2504.08887),
 the generalized-bicycle codes of Panteleev-Kalachev (arXiv:1904.02703) and
-Wang-Pryadko (arXiv:2203.17216), and the Kitaev surface / toric and Steane codes.
+Wang-Pryadko (arXiv:2203.17216), the twisted-torus / generalized-toric codes of
+Liang, Liu, Song, Chen (arXiv:2503.03827), and the Kitaev surface / toric and
+Steane codes.
 
 This seed set is not an exhaustive snapshot of the literature. Notable families
-not yet seeded include the twisted-torus / generalized-toric codes
-(arXiv:2503.03827), the LLM-search CSS catalog of arXiv:2606.02418, and the
+not yet seeded include the LLM-search CSS catalog of arXiv:2606.02418 and the
 two-block group-algebra database (arXiv:2306.16400). So the on-board frontier is
 a repo-local frontier, and a code that leads a cell here may still be matched or
 beaten by a published code that has not been seeded yet. Seeding these is tracked

--- a/codes/12-4-2.json
+++ b/codes/12-4-2.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": "0.1",
+  "name": "[[12,4,2]] twisted-torus BB code (arXiv:2503.03827)",
+  "code_type": "CSS",
+  "n": 12,
+  "k": 4,
+  "checks": {
+    "X": [
+      [
+        0,
+        1,
+        4,
+        6,
+        8,
+        10
+      ],
+      [
+        0,
+        1,
+        3,
+        6,
+        7,
+        10
+      ],
+      [
+        2,
+        4,
+        5,
+        8,
+        9,
+        11
+      ],
+      [
+        1,
+        3,
+        5,
+        6,
+        7,
+        9
+      ],
+      [
+        0,
+        2,
+        4,
+        8,
+        10,
+        11
+      ],
+      [
+        2,
+        3,
+        5,
+        7,
+        9,
+        11
+      ]
+    ],
+    "Z": [
+      [
+        0,
+        1,
+        3,
+        6,
+        7,
+        10
+      ],
+      [
+        1,
+        3,
+        5,
+        6,
+        7,
+        9
+      ],
+      [
+        0,
+        2,
+        4,
+        8,
+        10,
+        11
+      ],
+      [
+        2,
+        3,
+        5,
+        7,
+        9,
+        11
+      ],
+      [
+        0,
+        1,
+        4,
+        6,
+        8,
+        10
+      ],
+      [
+        2,
+        4,
+        5,
+        8,
+        9,
+        11
+      ]
+    ]
+  },
+  "distance": {
+    "d": 2,
+    "X": {
+      "value": 2,
+      "confidence": "upper_bound",
+      "witness": [
+        4,
+        8
+      ]
+    },
+    "Z": {
+      "value": 2,
+      "confidence": "upper_bound",
+      "witness": [
+        5,
+        9
+      ]
+    }
+  },
+  "provenance": {
+    "authors": [
+      "Zijian Liang",
+      "Ke Liu",
+      "Hao Song",
+      "Yu-An Chen"
+    ],
+    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+xy, g(x,y)=1+y+xy on the abelian quotient group Z^2/L with twist basis a_1=[0, 3], a_2=[2, 1] (n=2|det[a_1,a_2]|=2*6). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+    "references": [
+      "arXiv:2503.03827"
+    ],
+    "date": "2025",
+    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
+    "origin": "baseline",
+    "novelty": "known_parameters"
+  },
+  "family": "bivariate-bicycle"
+}


### PR DESCRIPTION
## Summary
- Seeds one twisted-torus bivariate-bicycle baseline, `[[12,4,2]]`, reconstructed from Liang–Liu–Song–Chen, _Generalized toric codes on twisted tori for quantum error correction_ (PRX Quantum 6, 020357, 2025), arXiv:2503.03827.
- Fills a board coverage gap at n=12. The `[[n,k,d]]` parameters and stabilizer polynomials are published in the paper; this entry reproduces them. Distance is the paper's upper bound (probabilistic for d>20); the surrogate witness corroborates.
- `provenance.origin: "baseline"` → authorship-exempt (no @handle authors required).
- `TRACKS.md` updated to name the twisted-torus / generalized-toric family among the seeded baselines.

## Scope
Single new code file (`codes/12-4-2.json`) + a markdown-only `TRACKS.md` edit. No verifier/schema/workflow changes, so it satisfies the one-new-code-per-PR rule and the submission-scope guard.

## Validation
Local `verify/qldpc_verify.py codes/12-4-2.json` passes (schema + n/k/CSS + witnesses; distance tier `upper_bound`). Full refutation gate runs in CI.