### PR TITLE
Add [[14-6-2]] twisted-torus BB baseline (arXiv:2503.03827)

### DIFF
--- a/codes/14-6-2.json
+++ b/codes/14-6-2.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": "0.1",
+  "name": "[[14,6,2]] twisted-torus BB code (arXiv:2503.03827)",
+  "code_type": "CSS",
+  "n": 14,
+  "k": 6,
+  "checks": {
+    "X": [
+      [
+        0,
+        1,
+        2,
+        7,
+        8,
+        9
+      ],
+      [
+        1,
+        3,
+        4,
+        8,
+        10,
+        11
+      ],
+      [
+        2,
+        4,
+        5,
+        9,
+        11,
+        12
+      ],
+      [
+        2,
+        3,
+        6,
+        9,
+        10,
+        13
+      ],
+      [
+        0,
+        4,
+        6,
+        7,
+        11,
+        13
+      ],
+      [
+        0,
+        3,
+        5,
+        7,
+        10,
+        12
+      ],
+      [
+        1,
+        5,
+        6,
+        8,
+        12,
+        13
+      ]
+    ],
+    "Z": [
+      [
+        0,
+        4,
+        5,
+        7,
+        11,
+        12
+      ],
+      [
+        0,
+        1,
+        6,
+        7,
+        8,
+        13
+      ],
+      [
+        0,
+        2,
+        3,
+        7,
+        9,
+        10
+      ],
+      [
+        1,
+        3,
+        5,
+        8,
+        10,
+        12
+      ],
+      [
+        1,
+        2,
+        4,
+        8,
+        9,
+        11
+      ],
+      [
+        2,
+        5,
+        6,
+        9,
+        12,
+        13
+      ],
+      [
+        3,
+        4,
+        6,
+        10,
+        11,
+        13
+      ]
+    ]
+  },
+  "distance": {
+    "d": 2,
+    "X": {
+      "value": 2,
+      "confidence": "upper_bound",
+      "witness": [
+        2,
+        9
+      ]
+    },
+    "Z": {
+      "value": 2,
+      "confidence": "upper_bound",
+      "witness": [
+        3,
+        10
+      ]
+    }
+  },
+  "provenance": {
+    "authors": [
+      "Zijian Liang",
+      "Ke Liu",
+      "Hao Song",
+      "Yu-An Chen"
+    ],
+    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+y, g(x,y)=1+y+x on the abelian quotient group Z^2/L with twist basis a_1=[0, 7], a_2=[1, 2] (n=2|det[a_1,a_2]|=2*7). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+    "references": [
+      "arXiv:2503.03827"
+    ],
+    "date": "2025",
+    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
+    "origin": "baseline",
+    "novelty": "known_parameters"
+  },
+  "family": "bivariate-bicycle"
+}


### PR DESCRIPTION
## Summary
- Seeds one twisted-torus bivariate-bicycle baseline, `[[14-6-2]]`, reconstructed from Liang-Liu-Song-Chen, _Generalized toric codes on twisted tori for quantum error correction_ (PRX Quantum 6, 020357, 2025), arXiv:2503.03827.
- Fills a board coverage gap. The `[[n,k,d]]` parameters and stabilizer polynomials are published in the paper; this entry reproduces them. Distance is the paper's upper bound (probabilistic for d>20); the surrogate witness corroborates.
- `provenance.origin: "baseline"` -> authorship-exempt (no @handle authors required).

## Scope
Single new code file (`codes/14-6-2.json`). No verifier/schema/workflow changes, so it satisfies the one-new-code-per-PR rule and the submission-scope guard. (The TRACKS.md family mention landed separately in PR #176.)

## Validation
Local `verify/qldpc_verify.py codes/14-6-2.json` passes (schema + n/k/CSS + witnesses; distance tier `upper_bound`). Full refutation gate runs in CI.
