### PR TITLE
Add [[18-4-4]] twisted-torus BB baseline (arXiv:2503.03827)

### DIFF
--- a/codes/18-4-4.json
+++ b/codes/18-4-4.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": "0.1",
+  "name": "[[18,4,4]] twisted-torus BB code (arXiv:2503.03827)",
+  "code_type": "CSS",
+  "n": 18,
+  "k": 4,
+  "checks": {
+    "X": [
+      [
+        0,
+        1,
+        4,
+        9,
+        11,
+        13
+      ],
+      [
+        1,
+        3,
+        6,
+        10,
+        13,
+        15
+      ],
+      [
+        2,
+        4,
+        7,
+        11,
+        14,
+        16
+      ],
+      [
+        0,
+        2,
+        3,
+        11,
+        12,
+        15
+      ],
+      [
+        4,
+        6,
+        8,
+        13,
+        16,
+        17
+      ],
+      [
+        1,
+        5,
+        7,
+        9,
+        10,
+        14
+      ],
+      [
+        2,
+        5,
+        6,
+        14,
+        15,
+        17
+      ],
+      [
+        3,
+        7,
+        8,
+        10,
+        12,
+        16
+      ],
+      [
+        0,
+        5,
+        8,
+        9,
+        12,
+        17
+      ]
+    ],
+    "Z": [
+      [
+        0,
+        5,
+        8,
+        9,
+        12,
+        17
+      ],
+      [
+        1,
+        5,
+        7,
+        9,
+        10,
+        14
+      ],
+      [
+        0,
+        2,
+        3,
+        11,
+        12,
+        15
+      ],
+      [
+        3,
+        7,
+        8,
+        10,
+        12,
+        16
+      ],
+      [
+        0,
+        1,
+        4,
+        9,
+        11,
+        13
+      ],
+      [
+        2,
+        5,
+        6,
+        14,
+        15,
+        17
+      ],
+      [
+        1,
+        3,
+        6,
+        10,
+        13,
+        15
+      ],
+      [
+        2,
+        4,
+        7,
+        11,
+        14,
+        16
+      ],
+      [
+        4,
+        6,
+        8,
+        13,
+        16,
+        17
+      ]
+    ]
+  },
+  "distance": {
+    "d": 4,
+    "X": {
+      "value": 4,
+      "confidence": "upper_bound",
+      "witness": [
+        3,
+        7,
+        14,
+        15
+      ]
+    },
+    "Z": {
+      "value": 4,
+      "confidence": "upper_bound",
+      "witness": [
+        3,
+        6,
+        12,
+        17
+      ]
+    }
+  },
+  "provenance": {
+    "authors": [
+      "Zijian Liang",
+      "Ke Liu",
+      "Hao Song",
+      "Yu-An Chen"
+    ],
+    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+xy, g(x,y)=1+y+xy on the abelian quotient group Z^2/L with twist basis a_1=[0, 3], a_2=[3, 0] (n=2|det[a_1,a_2]|=2*9). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+    "references": [
+      "arXiv:2503.03827"
+    ],
+    "date": "2025",
+    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
+    "origin": "baseline",
+    "novelty": "known_parameters"
+  },
+  "family": "bivariate-bicycle"
+}


### PR DESCRIPTION
## Summary
- Seeds one twisted-torus bivariate-bicycle baseline, `[[18-4-4]]`, reconstructed from Liang-Liu-Song-Chen, _Generalized toric codes on twisted tori for quantum error correction_ (PRX Quantum 6, 020357, 2025), arXiv:2503.03827.
- Fills a board coverage gap. The `[[n,k,d]]` parameters and stabilizer polynomials are published in the paper; this entry reproduces them. Distance is the paper's upper bound (probabilistic for d>20); the surrogate witness corroborates.
- `provenance.origin: "baseline"` -> authorship-exempt (no @handle authors required).

## Scope
Single new code file (`codes/18-4-4.json`). No verifier/schema/workflow changes, so it satisfies the one-new-code-per-PR rule and the submission-scope guard. (The TRACKS.md family mention landed separately in PR #176.)

## Validation
Local `verify/qldpc_verify.py codes/18-4-4.json` passes (schema + n/k/CSS + witnesses; distance tier `upper_bound`). Full refutation gate runs in CI.
