### PR TITLE
Add [[30-4-6]] twisted-torus BB baseline (arXiv:2503.03827)

### DIFF
--- a/codes/30-4-6.json
+++ b/codes/30-4-6.json
@@ -1,0 +1,297 @@
+{
+  "schema_version": "0.1",
+  "name": "[[30,4,6]] twisted-torus BB code (arXiv:2503.03827)",
+  "code_type": "CSS",
+  "n": 30,
+  "k": 4,
+  "checks": {
+    "X": [
+      [
+        0,
+        1,
+        3,
+        15,
+        17,
+        18
+      ],
+      [
+        1,
+        3,
+        6,
+        16,
+        19,
+        21
+      ],
+      [
+        2,
+        4,
+        7,
+        17,
+        20,
+        22
+      ],
+      [
+        3,
+        6,
+        9,
+        18,
+        22,
+        24
+      ],
+      [
+        4,
+        7,
+        10,
+        19,
+        23,
+        25
+      ],
+      [
+        5,
+        8,
+        11,
+        15,
+        20,
+        26
+      ],
+      [
+        5,
+        6,
+        9,
+        20,
+        21,
+        25
+      ],
+      [
+        7,
+        10,
+        12,
+        22,
+        26,
+        27
+      ],
+      [
+        8,
+        11,
+        13,
+        16,
+        23,
+        28
+      ],
+      [
+        5,
+        8,
+        9,
+        23,
+        24,
+        27
+      ],
+      [
+        0,
+        10,
+        12,
+        15,
+        25,
+        28
+      ],
+      [
+        11,
+        13,
+        14,
+        18,
+        26,
+        29
+      ],
+      [
+        0,
+        1,
+        12,
+        16,
+        27,
+        29
+      ],
+      [
+        2,
+        13,
+        14,
+        17,
+        21,
+        28
+      ],
+      [
+        2,
+        4,
+        14,
+        19,
+        24,
+        29
+      ]
+    ],
+    "Z": [
+      [
+        0,
+        5,
+        10,
+        15,
+        25,
+        27
+      ],
+      [
+        1,
+        8,
+        12,
+        15,
+        16,
+        27
+      ],
+      [
+        0,
+        2,
+        13,
+        17,
+        28,
+        29
+      ],
+      [
+        0,
+        3,
+        11,
+        15,
+        16,
+        18
+      ],
+      [
+        1,
+        4,
+        14,
+        17,
+        19,
+        29
+      ],
+      [
+        2,
+        5,
+        6,
+        20,
+        21,
+        24
+      ],
+      [
+        1,
+        6,
+        13,
+        16,
+        18,
+        21
+      ],
+      [
+        2,
+        3,
+        7,
+        17,
+        19,
+        22
+      ],
+      [
+        4,
+        8,
+        9,
+        20,
+        23,
+        24
+      ],
+      [
+        3,
+        9,
+        14,
+        18,
+        21,
+        24
+      ],
+      [
+        4,
+        6,
+        10,
+        19,
+        22,
+        25
+      ],
+      [
+        5,
+        7,
+        11,
+        20,
+        23,
+        26
+      ],
+      [
+        7,
+        9,
+        12,
+        22,
+        25,
+        27
+      ],
+      [
+        8,
+        10,
+        13,
+        23,
+        26,
+        28
+      ],
+      [
+        11,
+        12,
+        14,
+        26,
+        28,
+        29
+      ]
+    ]
+  },
+  "distance": {
+    "d": 6,
+    "X": {
+      "value": 6,
+      "confidence": "upper_bound",
+      "witness": [
+        1,
+        7,
+        12,
+        13,
+        17,
+        26
+      ]
+    },
+    "Z": {
+      "value": 6,
+      "confidence": "upper_bound",
+      "witness": [
+        3,
+        13,
+        14,
+        16,
+        18,
+        29
+      ]
+    }
+  },
+  "provenance": {
+    "authors": [
+      "Zijian Liang",
+      "Ke Liu",
+      "Hao Song",
+      "Yu-An Chen"
+    ],
+    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+x^2, g(x,y)=1+y+x^2 on the abelian quotient group Z^2/L with twist basis a_1=[0, 3], a_2=[5, 1] (n=2|det[a_1,a_2]|=2*15). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+    "references": [
+      "arXiv:2503.03827"
+    ],
+    "date": "2025",
+    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
+    "origin": "baseline",
+    "novelty": "known_parameters"
+  },
+  "family": "bivariate-bicycle"
+}


### PR DESCRIPTION
## Summary
- Seeds one twisted-torus bivariate-bicycle baseline, `[[30-4-6]]`, reconstructed from Liang-Liu-Song-Chen, _Generalized toric codes on twisted tori for quantum error correction_ (PRX Quantum 6, 020357, 2025), arXiv:2503.03827.
- Fills a board coverage gap. The `[[n,k,d]]` parameters and stabilizer polynomials are published in the paper; this entry reproduces them. Distance is the paper's upper bound (probabilistic for d>20); the surrogate witness corroborates.
- `provenance.origin: "baseline"` -> authorship-exempt (no @handle authors required).

## Scope
Single new code file (`codes/30-4-6.json`). No verifier/schema/workflow changes, so it satisfies the one-new-code-per-PR rule and the submission-scope guard. (The TRACKS.md family mention landed separately in PR #176.)

## Validation
Local `verify/qldpc_verify.py codes/30-4-6.json` passes (schema + n/k/CSS + witnesses; distance tier `upper_bound`). Full refutation gate runs in CI.
