### PR TITLE
fix: update author handle to @mathysrennela in codes/392-8-15.json

### DIFF
--- a/codes/392-8-15.json
+++ b/codes/392-8-15.json
@@ -2841,7 +2841,7 @@
   },
   "provenance": {
     "authors": [
-      "MathysRennela"
+      "@mathysrennela"
     ],
     "model": "Hy3",
     "construction": "Open-boundary planar bivariate-bicycle (Liang-Eberhardt-Chen / Liang-Yang-Iosue-Chen, arXiv:2504.08887) on a 14x14 grid; f = x + x^2 + y^2, g = 1 + x^2 y + x^2 y^2; built with the directional anyon-condensation truncation, corner-resolved, bilayer layout.",


### PR DESCRIPTION
## Summary
- Updates the author handle in `codes/392-8-15.json` from `MathysRennela` to `@mathysrennela`, matching the `@handle` convention required by CI (PR author must be one of the code's `@handle` authors).

Generated from the trusted board entry; no validation code (`verify/`, `schema/`, `site/`) changed.