### PR TITLE
adding a second rule to store witnesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@ The one rule, up front so it is never missed:
 Never write your own distance/quality check; never edit anything under `verify/` (the trusted,
 CI-hash-pinned stack); stage candidates for human review — never commit to `codes/` or open a PR.
 
+A second rule, equally non-negotiable:
+
+**A found low-weight logical (witness) is the most expensive data we produce — never lose it.**
+Never run an ad-hoc `python -c` that calls a witness/distance search and only prints the result; that discards the data. Always persist the candidate through the kit's own path: call
+`research/kit/submit.make_submission` (which computes and embeds the witness) and then `research/kit/submit.save_submission(doc, "research/candidates/<n>-<k>-<d>.json")`. 
+The `research/candidates/` directory is gitignored working output, so writes there are safe and never pollute the board. If a search finds a valid logical but the save fails, that is a hard
+error — stop and report it, do not just print.
+
 ## Working on the repo itself
 
 - `verify/` is the trust anchor and is hash-pinned in CI (`verify/check_validator_integrity.py`).


### PR DESCRIPTION
I took some time to evaluate the efficiency of non-frontier open source models (Hy3, Mimo-V2.5, Gemma 4, Nemotron 3, Laguna M.1, Laguna XS.1, North Mini Code). Most of them waste time in re-emitting witnesses because they do not properly store them. Adding a second rule that makes storing witnesses non-negotiable saves a lot of time in autosearch, and is valuable for participants who do not want to use frontier models.