### PR TITLE
Re-pin the board scatter plots while scrolling the table

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -202,6 +202,12 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}
 .tcount{color:var(--mut);font-size:14px;font-weight:400}
 .plots{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}
+/* Pin the scatters to the top while the table scrolls beneath, so the
+   point<->row hover highlight stays visible. The table header sticks within
+   its own scroll box (a separate scroll context), so no header offset needed.
+   Desktop only; on phones the plots scroll away to save vertical space. */
+@media(min-width:760px){.explorer .plots{position:sticky;top:0;z-index:5;
+background:var(--bg);padding:8px 0 6px;margin-top:0}}
 .plot{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}
 .chartlegend{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;

--- a/site/build.py
+++ b/site/build.py
@@ -503,6 +503,12 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}}
 .tcount{{color:var(--mut);font-size:14px;font-weight:400}}
 .plots{{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px}}
+/* Pin the scatters to the top while the table scrolls beneath, so the
+   point<->row hover highlight stays visible. The table header sticks within
+   its own scroll box (a separate scroll context), so no header offset needed.
+   Desktop only; on phones the plots scroll away to save vertical space. */
+@media(min-width:760px){{.explorer .plots{{position:sticky;top:0;z-index:5;
+background:var(--bg);padding:8px 0 6px;margin-top:0}}}}
 .plot{{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}}
 .chartlegend{{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;


### PR DESCRIPTION
Regression from the July 7 redesign (commit 17524ad): making the codes table an internally-scrolling box dropped the sticky positioning on the two scatter plots. Now when you scroll down to the table the plots scroll off-screen, so the point-to-row hover highlight (hover a data point, the matching row highlights, and vice versa) is no longer visible, which is the whole point of having the plots next to the table.

Restores `position:sticky; top:0` on the plots, desktop only (phones keep them scrolling to save vertical space). No header-offset machinery needed this time because the table header sticks within its own scroll box, a separate scroll context, and the hover-reveal already scrolls that box to bring the row into view. Verified: computed position is sticky at desktop width, static at phone width.