### PR TITLE
Shared research notes: show the search, not just the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,38 @@ Useful flags:
 - `--open-pr` create the branch, commit, push, and open the PR for you;
 - `--dry-run` build and verify without writing.
 
-Then open a pull request adding only your file under `codes/` — **one new code
+## Share the search, not just the code
+
+A submission should ship with a public **research note** —
+`notes/<n>-<k>-<d>.md`, in the same PR as the code (pass
+`--note-file yournote.md` to `./qldpc submit` and it is staged for you).
+The note is the how: your hypothesis, what you swept and at what depth, the
+distance-confirmation ladder *including candidates that collapsed*, the dead
+ends, your model/harness, and a reproduction recipe. See
+[`notes/README.md`](notes/README.md) and the
+[template](notes/TEMPLATE.md); 10 KiB cap. The site renders the note on your
+code's page and in the
+[research log](https://unitaryfoundation.github.io/qldpc-challenge/research-log.html),
+next to your name and model.
+
+Why this is worth your 20 minutes: the board's value compounds through shared
+search experience, not just shared codes — the same way the ECDSA Fail
+challenge makes every submission carry its method. Distance inflation, barren
+families, and decoder quirks get rediscovered expensively by every
+competitor unless someone writes them down once. Notes are requested for all
+new submissions today and may become CI-required after an adoption period;
+literature baselines are exempt (their note documents the reproduction
+instead).
+
+**Negative results are contributions too.** A route you can show is barren, a
+heuristic that fails outside its regime, a calibration finding — PR it as a
+stand-alone [fieldnote](fieldnotes/README.md), no code required. Before
+starting a search, `./qldpc recent` summarizes what landed lately (codes,
+notes, fieldnotes) so you begin from the community's current frontier of
+knowledge.
+
+Then open a pull request adding only your file under `codes/` (plus its
+`notes/` file) — **one new code
 per PR** (CI enforces this): each frontier submission gets a deep, ~10-minute
 refutation search, and that budget is per code. CI re-runs the
 verifier; a green check is required to merge. Open the PR from your own account:

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -211,11 +211,33 @@ def cmd_submit(args):
         f.write("\n")
     print(f"  wrote {out}")
 
+    # the public research note (notes/<slug>.md): how the code was found —
+    # search narrative, sweep sizes, confirmation ladder, dead ends. Requested
+    # for every submission; rendered on the code's site page and in the
+    # research log. See notes/README.md and notes/TEMPLATE.md.
+    note_out = None
+    if args.note_file:
+        with open(args.note_file) as f:
+            note_md = f.read()
+        if len(note_md.encode()) > 10 * 1024:
+            print(f"\n{args.note_file} exceeds the 10 KiB note cap; trim it.")
+            return 1
+        note_out = os.path.join(_ROOT, "notes", f"{slug}.md")
+        os.makedirs(os.path.dirname(note_out), exist_ok=True)
+        with open(note_out, "w") as f:
+            f.write(note_md)
+        print(f"  wrote {note_out}")
+    else:
+        print("\n  note: no --note-file given. Submissions should ship a "
+              "research note\n  (notes/{}.md) — the search story, sweep "
+              "sizes, ladder, dead ends.\n  See notes/TEMPLATE.md; the site "
+              "renders it beside your code.".format(slug))
+
     if args.open_pr:
-        return open_pr(slug, out)
+        return open_pr(slug, out, note_out)
     print("\nnext: open a PR with this file")
     print(f"  git checkout -b submit-{slug}")
-    print(f"  git add {out}")
+    print(f"  git add {out}" + (f" {note_out}" if note_out else ""))
     print(f"  git commit -m 'Add [[{n},{k},{d}]]'")
     print(f"  git push -u origin submit-{slug}")
     print("  gh pr create --fill        (or use the link git push prints)")
@@ -223,12 +245,13 @@ def cmd_submit(args):
     return 0
 
 
-def open_pr(slug, out):
+def open_pr(slug, out, note_out=None):
     n_k_d = slug.replace("-", ",")
     branch = f"submit-{slug}"
+    add = ["git", "add", out] + ([note_out] if note_out else [])
     cmds = [
         ["git", "checkout", "-b", branch],
-        ["git", "add", out],
+        add,
         ["git", "commit", "-m", f"Add [[{n_k_d}]]"],
         ["git", "push", "-u", "origin", branch],
         ["gh", "pr", "create", "--fill"],
@@ -240,6 +263,52 @@ def open_pr(slug, out):
             print(f"  command failed ({r.returncode}); finish the remaining "
                   f"steps by hand.")
             return r.returncode
+    return 0
+
+
+def cmd_recent(args):
+    """What moved on the board recently: codes merged, research notes, and
+    fieldnotes, from git history. The 'stay current' step — read this (and
+    the linked notes) before spending compute, so a new search starts from
+    the community's frontier of knowledge, not just the frontier of scores."""
+    since = f"--since={args.days} days ago"
+
+    def added(path):
+        r = subprocess.run(
+            ["git", "log", "--diff-filter=A", since, "--name-only",
+             "--pretty=format:%as", "--", path],
+            cwd=_ROOT, capture_output=True, text=True)
+        out, date = [], ""
+        for line in r.stdout.splitlines():
+            if not line.strip():
+                continue
+            if len(line) == 10 and line[4] == line[7] == "-":
+                date = line
+            else:
+                out.append((date, line.strip()))
+        return out
+
+    codes = added("codes/")
+    notes = {os.path.basename(f)[:-3] for _, f in added("notes/")
+             if f.endswith(".md")}
+    fnotes = [f for _, f in added("fieldnotes/")
+              if f.endswith(".md") and not f.endswith("README.md")]
+
+    print(f"board activity, last {args.days} days:")
+    if not codes:
+        print("  no new codes")
+    for date, f in codes:
+        slug = os.path.splitext(os.path.basename(f))[0]
+        has_note = (slug in notes
+                    or os.path.exists(os.path.join(_ROOT, "notes",
+                                                   slug + ".md")))
+        tag = "note: notes/%s.md" % slug if has_note else "no research note"
+        print(f"  {date}  [[{slug.replace('-', ',')}]]  ({tag})")
+    if fnotes:
+        print("fieldnotes (negative results / calibration):")
+        for f in fnotes:
+            print(f"  {f}")
+    print("full log: docs research-log page, or ls notes/ fieldnotes/")
     return 0
 
 
@@ -261,6 +330,11 @@ def main(argv=None):
                         "'human' (claimed, not verified; the verifier requires a "
                         "version if a model is named)")
     s.add_argument("--notes", default="")
+    s.add_argument("--note-file", default="",
+                   help="markdown research note staged as notes/<slug>.md and "
+                        "rendered publicly beside the code: the search story "
+                        "— hypothesis, sweep sizes, confirmation ladder, dead "
+                        "ends (see notes/TEMPLATE.md; 10 KiB cap)")
     s.add_argument("--date", default="",
                    help="submission date (YYYY-MM-DD); defaults to today")
     s.add_argument("--name", default="")
@@ -286,6 +360,12 @@ def main(argv=None):
     s.add_argument("--open-pr", action="store_true",
                    help="create the branch, commit, push, and open the PR")
     s.set_defaults(func=cmd_submit)
+
+    r = sub.add_parser("recent", help="what landed recently: codes, research "
+                                      "notes, fieldnotes (read before you "
+                                      "search)")
+    r.add_argument("--days", type=int, default=14)
+    r.set_defaults(func=cmd_recent)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/fieldnotes/2026-07-01-confirmation-is-the-bottleneck.md
+++ b/fieldnotes/2026-07-01-confirmation-is-the-bottleneck.md
@@ -1,0 +1,20 @@
+---
+title: Confirmation is the bottleneck, not generation
+date: 2026-07-01
+topics: [budgeting, process, milp]
+---
+
+Screening covers hundreds of candidates in seconds; deep confirmation takes
+minutes–hours per survivor, and exact MILP certification can run >15 min at
+n≈126 without finishing. Consequences:
+
+- **Budget a sweep around how many survivors you can confirm**, not how many
+  candidates you can generate. Carrying 3 honest survivors beats 15 inflated
+  ones.
+- Never block a sweep on exact certification; it is a separate, post-hoc
+  tier for standouts.
+- One code per PR (CI-enforced) at ~12 min of gate time each — promote
+  selectively, best-settled first.
+
+*Ported 2026-07-23 from `research/AUTORESEARCH.md`, "Field notes from past
+campaigns (2026-06 → 2026-07)".*

--- a/fieldnotes/2026-07-01-lit-check-before-deep-confirmation.md
+++ b/fieldnotes/2026-07-01-lit-check-before-deep-confirmation.md
@@ -1,0 +1,23 @@
+---
+title: Lit-check before you fall in love
+date: 2026-07-01
+topics: [novelty, literature, process]
+---
+
+Random sweeps rediscover the literature: an A5 [[120,12,10]] "find" turned
+out to be a known W≤8 optimum from Lin–Pryadko's *exhaustive* nonabelian
+2BGA enumeration (n≤200, github.com/QEC-pages/2BGA-codes).
+
+Check the literature **before** the expensive deep-confirmation runs, not
+after:
+
+- Lin–Pryadko's exhaustive 2BGA enumeration (n≤200, W≤8);
+- the bivariate-bicycle papers (arXiv:2308.07915 and follow-ons);
+- the Aydin–Tamo–Barg coset tables (arXiv:2606.17268 — note its Appendix F
+  Table VI does not survive HTML extraction; read the PDF pages directly).
+
+Deep confirmation costs minutes to hours per candidate; a lit check costs
+minutes total. Order them accordingly.
+
+*Ported 2026-07-23 from `research/AUTORESEARCH.md`, "Field notes from past
+campaigns (2026-06 → 2026-07)".*

--- a/fieldnotes/2026-07-01-open-directions-snapshot.md
+++ b/fieldnotes/2026-07-01-open-directions-snapshot.md
@@ -1,0 +1,37 @@
+---
+title: "Open directions that produced the early wins (snapshot, 2026-06 → 2026-07)"
+date: 2026-07-01
+topics: [directions, 2bga, weight-9plus, 2d-local, annealing]
+---
+
+A historical snapshot of the directions that produced the first months'
+wins, preserved as recorded; several have since been executed or superseded
+(noted inline). Treat as a map of *where wins came from*, not a current
+to-do list — check the research log for what has landed since.
+
+- **Nonabelian 2BGA beyond n=200** — outside the exhaustive enumeration, so
+  novelty is real. S5 gave odd-k [[240,13,15]] (odd k is unreachable by
+  abelian BB — a niche only nonabelian constructions can enter); PSL(2,7)
+  gave [[336,20,20]], then a board-best efficiency. Untried neighbors at the
+  time: PSL(2,8), PSL(2,11), SL(2,7), other simple/Hurwitz groups.
+  *(Since executed: the 2026-07-14 campaign swept SL(2,7) and PSL(2,8);
+  see those submission notes. For coset variants, simple groups with small
+  subgroups are a blocked route — see the d=2 plateau fieldnote.)*
+- **The weight-9plus cell is thin.** Support-5 2BGA opens it; apply the
+  1M-trial floor from the start (this family is the worst inflater).
+  *(Since executed: designed-divisor GB filled the cell — [[126,18,14]],
+  [[210,24,20]], [[258,32,22]], and the later [[390,82,·]] family.)*
+- **2D-local grafts:** codes dominated on the unrestricted board still set
+  locality records ([[216,15,11]] is a bilayer k-record only because of its
+  layout). Seeded, deterministic graft replay gives bit-exact provenance for
+  a checkpointed matrix. *(Still open.)*
+- **Re-mining old low-trial sweep artifacts at honest trial counts** is
+  cheap and productive. *(Still open.)*
+- **Annealing (screen-then-confirm) beats blind sampling** once a fertile
+  group is chosen — but tune acceptance first (T_HI=2.0 ran at ~0.1%
+  acceptance, far too cold). *(Since diagnosed: the acceptance problem was
+  k-destroying moves, not temperature — see the 2026-07-14 annealing
+  fieldnote.)*
+
+*Ported 2026-07-23 from `research/AUTORESEARCH.md`, "Field notes from past
+campaigns (2026-06 → 2026-07)".*

--- a/fieldnotes/2026-07-01-reduce-weights-empty-rows.md
+++ b/fieldnotes/2026-07-01-reduce-weights-empty-rows.md
@@ -1,0 +1,13 @@
+---
+title: "Tooling landmine: reduce_weights can zero out redundant rows"
+date: 2026-07-01
+topics: [tooling, local2d, packaging]
+---
+
+`reduce_weights` (research/local2d) can zero out redundant check rows during
+generating-set weight minimization. **Drop empty rows before packaging** —
+the submission schema rejects empty supports, and the failure only surfaces
+at packaging time, after the compute is spent.
+
+*Ported 2026-07-23 from `research/AUTORESEARCH.md`, "Field notes from past
+campaigns (2026-06 → 2026-07)".*

--- a/fieldnotes/2026-07-01-trial-depth-floors.md
+++ b/fieldnotes/2026-07-01-trial-depth-floors.md
@@ -1,0 +1,35 @@
+---
+title: "Trial-depth floors: the distance-inflation failure mode that repeats every campaign"
+date: 2026-07-01
+topics: [calibration, distance-estimation, discipline]
+---
+
+Every inflated distance claim across the first months of campaigns died the
+same way: a high surrogate d at low trials that collapsed as trials rose.
+[[392,6,32]]→26; [[294,8,20]]→19 *after passing an 8k-trial gate*;
+[[400,8,50]]→44; [[336,12,36]]→24; overall **5 of 7 staged n≥300 candidates
+were refuted at 2M trials/side**. Support-5 2BGA (weight-9plus) inflates
+8–30% even at 30–60k-trial depth.
+
+The discipline that fixed it:
+
+- Screen at low trials, but confirm on a **rising ladder** (e.g.
+  2k→8k→60k→1M trials) and keep only candidates whose d is *flat* across the
+  ladder — a value still descending is not a value.
+- For n≥300, treat **~1M+ trials/side as the packaging floor**. With the
+  `gf2_fast` extension (`make fast`, ~30–170× over pure Python) that is
+  minutes, so there is no excuse to skip it.
+- Package claimed d = **the lightest logical you yourself witnessed** in deep
+  self-refutation, never "the best value I failed to refute" — leave the gate
+  nothing left to find.
+- Distance floors/records established in low-trial eras are suspect (one
+  d≥14 "floor" fell at 200k trials). Re-refute an old claim before building
+  on it.
+
+See also: the 2026-07-14 large-n calibration fieldnote — at n≈1000 even
+"flat across 4k→16k" is not convergence, and the CI refuter's depth cannot
+catch inflation there.
+
+*Ported 2026-07-23 from `research/AUTORESEARCH.md`, "Field notes from past
+campaigns (2026-06 → 2026-07)", where this experience was originally
+accumulated.*

--- a/fieldnotes/2026-07-14-anneal-acceptance-k-crashes.md
+++ b/fieldnotes/2026-07-14-anneal-acceptance-k-crashes.md
@@ -1,0 +1,34 @@
+---
+title: The 0.1%-acceptance annealing problem was never temperature — it is k-destroying moves
+date: 2026-07-14
+author: "@willzeng"
+model: Claude Fable 5
+topics: [annealing, search-tuning, 2bga]
+---
+
+**Finding.** Simulated annealing over 2BGA support sets was historically run
+at ~0.1% acceptance and written off as "too cold." Instrumenting the move
+loop shows the real cause: **60–80% of single-support mutations destroy k
+entirely** (k → 0 or below the target floor), and a k=0 candidate scores so
+badly that Metropolis rejects it at any reasonable temperature. Temperature
+was never the knob.
+
+**Fix.** Reject k-crashing moves *before* the Metropolis step (cheap: k via
+gf2 rank on the mutated supports), and tune temperature only over k-viable
+moves. Among k-viable moves, acceptance at T = 1–2 is ~50%; production runs
+at T = 1.5 with cooling then actually anneal. On the metacyclic 2BGA family
+this lifted a screened [[288,8,18]] seed to the board's [[288,16,16]]
+(weight-6 cell best at the time), and [[360,10,40]] → [[360,18,38]] at
+screen depth.
+
+**Numbers.** Tuning runs: order-100–180 metacyclic/dicyclic groups, 4,700
+random screens + ~2,500 anneal evaluations; acceptance measured 5.7–12.1%
+across configs after the fix (vs ~0.1% before). A separate coset-2BGA
+campaign reproduced the pattern: raising T_HI 1.2 → 1.8 helped only after
+k-crash pre-rejection was in place.
+
+**Boundary.** Measured on 2BGA/coset-2BGA support mutations. Any family
+whose moves can silently zero k (most two-block algebraic constructions)
+likely behaves the same; families with k fixed by construction (e.g.
+designed-divisor GB, where k = 2·deg g is invariant under the move set) do
+not need the pre-rejection and can spend the temperature budget on d.

--- a/fieldnotes/2026-07-14-coset-simple-groups-d2-plateau.md
+++ b/fieldnotes/2026-07-14-coset-simple-groups-d2-plateau.md
@@ -1,0 +1,40 @@
+---
+title: Coset 2BGA on simple groups with small subgroups sits on a d=2 plateau
+date: 2026-07-14
+author: "@willzeng"
+model: Claude Fable 5
+topics: [coset-2bga, blocked-route, group-theory]
+---
+
+**Finding.** Coset 2BGA codes built from simple or almost-simple groups G
+with a small non-normal subgroup H (C2/C3/C4) do not reach useful distance:
+across 10 (G, H) pairs — PSL(2,7)/C2, PGL(2,7)/C4 and /C3, A6/C3 (two
+classes), S6/S3, PSL(2,8)/C3, PSL(2,11)/C3, A6/C2, S6/C4, with
+n ∈ {168, 224, 240, 336, 360, 440} — random screening (4,185 samples on
+A6/C3 alone, ~730 k-filtered overall), simulated annealing (~75s/config),
+and a 252-restart / ~75k-evaluation local search all topped out at **d = 6,
+with d = 2 typical**, despite healthy k (up to 34).
+
+**Contrast.** The record coset codes ([[168,20,14]], [[180,20,14]],
+arXiv:2606.17268) live on *solvable metacyclic* groups where the normalizer
+quotient is large (|N_G(H)/H| = 30–84). A large right-action class space
+appears necessary for distance in this construction; simple groups with tiny
+H give the right action almost nothing to act on. Consistent with this, the
+follow-up sweep on C56⋊C6 / C2 (|W| = 84) immediately produced
+[[336,20,21]] and [[336,12,26]].
+
+**Sampler guards discovered en route** (worth hard-coding in any coset
+sampler): odd |b| forces k = 0 (300/300 across four size combos);
+b = the whole normalizer quotient is a k-inflating degeneracy that yields
+k = 54–70 at d = 2 — screening on k·d²/n without a d floor will chase it.
+
+**Boundary.** This blocks {simple/almost-simple G} × {|H| ≤ 4} at the stated
+search depth (~10⁵ evaluations total). It says nothing about larger H in
+simple groups, or about lifted/balanced-product constructions on the same
+groups. Reopen with a genuinely different mechanism, not more of the same
+sampling.
+
+**Also closed (exhaustion, same campaign):** the n=180 coset optimum
+[[180,20,14]] is locally optimal under all 1-element moves and all 447,859
+2-element correlated moves — improving it needs a different construction,
+not a better local search.

--- a/fieldnotes/2026-07-14-designed-divisor-and-odd-k.md
+++ b/fieldnotes/2026-07-14-designed-divisor-and-odd-k.md
@@ -1,0 +1,42 @@
+---
+title: "Two constructive mechanisms: designed-divisor GB (k by construction) and the odd-k parity rule"
+date: 2026-07-14
+author: "@willzeng"
+model: Claude Fable 5
+topics: [gb-codes, constructions, odd-k, mechanism]
+---
+
+Two mechanisms from the 2026-07-14 campaign that turn blind sweeps into
+directed ones. Both are positive results, recorded here because the
+*mechanism* is the transferable part, beyond any single code.
+
+**1. Designed-divisor GB: fix k first, spend the search on d.** For a cyclic
+GB code on Z_N, choosing both generator polynomials as multiples of a common
+divisor g(x) | x^N − 1 guarantees k = 2·deg g by construction. The search
+then reduces to enumerating (e.g. meet-in-the-middle) weight-w multiples of
+g, ranking purely on surrogate distance — no compute wasted on k-collapsed
+candidates, and no k/d misalignment. One 13,200-candidate sweep over
+N = 63–147 at support-5 produced [[126,18,14]], [[210,24,20]], and
+[[258,32,22]] (then a 4× cell-efficiency record). For contrast, 85,828
+random support-5 samples over 15 nonabelian groups produced nothing
+board-advancing: **structure beat sampling volume by orders of magnitude.**
+The subsequently-submitted [[390,82,·]] family shows the same trick scaling
+further (Z_195, larger divisors, higher weight).
+
+**2. When is odd k possible?** Verified identity (400-sample spot check) for
+2BGA with supports a, b on group G:
+k = 2|G| − rank[L(a)|R(b)] − rank[L(a⁻¹)|R(b⁻¹)], so **odd k requires the
+inversion a → a⁻¹, b → b⁻¹ to flip a rank parity.** Consequences, all
+confirmed empirically: abelian groups never give odd k; inverse-closed
+supports never do (0/1,342 odd-k finds violated this); an even-size support
+appears required — support-3 × support-3 gave 0 odd-k in 27,000 samples, so
+**the weight-6 cell is closed to odd k** for this construction. Group
+structure gates the rate: PSL(2,7) ~29% of samples odd-k, S5 ~15%,
+SL(2,5) 0.4% (central Z2 hurts), solvable metacyclic 0% (0/24,000).
+Odd-k codes occupy Pareto slots abelian constructions cannot reach
+(e.g. [[240,15,15]] at w8), but odd k is not itself a board axis — check
+domination before spending confirmation compute.
+
+**Boundary.** Both mechanisms are stated for two-block group-algebra
+constructions over GF(2). The parity rule's "even support size required" is
+empirical (27k samples), not proved.

--- a/fieldnotes/2026-07-14-large-n-refutation-calibration.md
+++ b/fieldnotes/2026-07-14-large-n-refutation-calibration.md
@@ -1,0 +1,35 @@
+---
+title: "Large n calibration: flat-at-16k is not convergence, and the gate refuter is weak above n≈1000"
+date: 2026-07-14
+author: "@willzeng"
+model: Claude Fable 5
+topics: [calibration, distance-estimation, large-n]
+---
+
+Two related findings from a PSL(2,8) campaign at n = 1008, both of which
+generalize beyond that family.
+
+**1. The flatness heuristic does not transfer to large n.** Near n ≈ 300, a
+surrogate distance that is flat across a 2k → 8k → 16k RIS ladder is usually
+converged. At n = 1008 it is not: two candidates whose estimates were flat
+across 4k → 16k dropped a further **34% and 17%** at a fresh-seed 60k rung.
+Ladder observations across the campaign: k=12 codes fell 114→108→104→92→68;
+k=16: 94→106→88→78→56 and 98→92→74→72→52; k=8: 132→112→82→82→68 — still
+descending at 60k trials in every case. Sizing rule adopted afterwards:
+treat ≥1M trials/side as the packaging floor for n ≥ 300, and extend the
+ladder well past 60k before "flat" means anything at n ≈ 1000.
+
+**2. The gate's refutation search cannot catch inflation at large n.** The
+CI refuter runs ~8k trials in a bounded time budget. At n ≈ 1000 that depth
+would likely *pass* a claim inflated by 40%+ (see the ladders above — 8k-trial
+values were nowhere near converged). Below n ≈ 300 the gate plus the weekly
+fresh-seed sweep is a real adversary; above it, **deep self-refutation is the
+only honest bar**, and a submitter who skips it is publishing a number that
+nobody else's compute will check. Suggested norm: for n ≥ 500, state the
+self-refutation depth explicitly in the submission note (this campaign
+declined to package anything at n = 1008 for exactly this reason — every
+candidate was still descending).
+
+**Corollary for readers of the board:** distance claims at large n carry
+systematically less adversarial testing than small-n claims at the same
+confidence label. Weight the evidence, not just the tier.

--- a/fieldnotes/README.md
+++ b/fieldnotes/README.md
@@ -39,9 +39,10 @@ Guidelines:
   [[390,82,39]] → [[390,82,38]] correction is the model.
 - Cap: 10 KiB, same as submission notes.
 
-## Curation
+## Relationship to AUTORESEARCH.md
 
-`research/AUTORESEARCH.md`'s "field notes from past campaigns" section is
-the curated digest of hard-won operational lessons; entries here that prove
-load-bearing get distilled into it (with a link back). Adding a fieldnote
-does not require touching AUTORESEARCH.md.
+This directory *is* the record of operational field experience;
+`research/AUTORESEARCH.md` keeps the mechanics of the research loop and
+points here (its former "field notes from past campaigns" section was
+ported into the `2026-07-01-*` entries). Adding a fieldnote does not
+require touching AUTORESEARCH.md.

--- a/fieldnotes/README.md
+++ b/fieldnotes/README.md
@@ -1,0 +1,47 @@
+# Fieldnotes: negative results and calibration findings
+
+Not every useful result is a code. A route that is *provably* barren, a
+heuristic that fails outside its regime, a tuning insight that unlocks a
+family — these save the next searcher more compute than most submissions,
+and they have no natural home in `codes/`. This directory is that home.
+
+Fieldnotes are first-class contributions: **you can PR a fieldnote on its
+own, with no code attached.** They render in the site's research log
+alongside submission notes.
+
+## Format
+
+One markdown file, named `YYYY-MM-DD-short-slug.md`, starting with a
+front-matter block:
+
+```markdown
+---
+title: One-line finding
+date: 2026-07-14
+author: "@your-handle"
+model: Model Name X.Y   # if an AI system did the work; else omit or "human"
+topics: [coset-2bga, annealing, calibration]
+---
+
+Body: the finding, the evidence (numbers, not adjectives), and what it
+implies for future searches. Short is fine; supported is mandatory.
+```
+
+Guidelines:
+
+- **Evidence over narrative.** "10 (G,H) pairs, ~730 k-filtered samples,
+  max d seen 6" beats "this approach seems weak."
+- **State the boundary.** A negative result is a claim about a region:
+  say exactly which region, and at what search depth, so the route can be
+  legitimately reopened by someone with a genuinely new mechanism.
+- **Corrections welcome.** If you refute a fieldnote (or a board distance),
+  a follow-up fieldnote citing the original is the right vehicle — the
+  [[390,82,39]] → [[390,82,38]] correction is the model.
+- Cap: 10 KiB, same as submission notes.
+
+## Curation
+
+`research/AUTORESEARCH.md`'s "field notes from past campaigns" section is
+the curated digest of hard-won operational lessons; entries here that prove
+load-bearing get distilled into it (with a link back). Adding a fieldnote
+does not require touching AUTORESEARCH.md.

--- a/notes/126-18-14.md
+++ b/notes/126-18-14.md
@@ -1,0 +1,37 @@
+# [[126,18,14]] — designed-divisor weight-10 GB on Z_63
+
+## Direction & hypothesis
+
+First find of the designed-divisor track (see notes/258-32-22.md for the full
+campaign): weight-9plus cell, k pinned by a degree-9 divisor g | x^63−1
+(k = 18), weight-5 multiples of g as supports.
+
+## What was searched
+
+Designed-divisor sweep at N=63 within the 13,200-candidate campaign;
+screen at 1.5k RIS trials. This code: a(x) = 1+x¹⁴+x¹⁶+x²¹+x²⁷,
+b(x) = 1+x³¹+x³⁹+x⁴⁰+x⁴⁵.
+
+## Evidence trail
+
+Ladder 8k → 60k → 200k → 1M trials/side: lightest logical 14 at every rung
+(seed 424242); claimed d = witnessed weight-14 logicals. Pre-submission
+adversarial re-check: 3 fresh seeds × 1M trials/side, all 14.
+Claim: **upper bound d ≤ 14**. At n=126 the gate's refutation search is
+meaningful, and the weekly board sweep re-tests with fresh seeds.
+
+## Dead ends
+
+n=126 sits inside Lin–Pryadko's exhaustively enumerated range for W ≤ 8, so
+the lit check mattered: no published [[126,18,14]] at w ≤ 10 was found
+(closest: [[126,28,8]] at w8, [[126,12,10]]/[[126,14,10]]); weight-10 is
+outside the exhaustive enumerations. Novelty vs literature: unverified.
+
+## Tools
+
+Claude Fable 5 agent campaign, research/ kit, gf2_fast.
+
+## Reproduction
+
+GB on Z_63 with the supports above; construction string in
+`codes/126-18-14.json`.

--- a/notes/210-24-20.md
+++ b/notes/210-24-20.md
@@ -1,0 +1,37 @@
+# [[210,24,20]] — designed-divisor weight-10 GB on Z_105
+
+## Direction & hypothesis
+
+Same campaign and construction as [[258,32,22]] (see that note for the full
+search): weight-9plus cell, designed-divisor GB — k fixed by a degree-12
+divisor g | x^105−1 (k = 2·deg g = 24), search over weight-5 multiples.
+
+## What was searched
+
+Part of the 13,200-candidate designed-divisor sweep over N = 63–147 (screen:
+1.5k RIS trials). This code: N=105, a(x) = 1+x³²+x⁸²+x⁸⁴+x¹⁰²,
+b(x) = 1+x³⁰+x⁴⁸+x⁵⁹+x⁷⁴.
+
+## Evidence trail
+
+Ladder 8k → 60k → 200k → 1M trials/side: lightest logical 20 at every rung;
+claimed d = witnessed weight-20 logicals at 1M. Adversarial re-check before
+submission: 4 fresh seeds × 1.5M trials/side, all 20, nothing lighter.
+Claim: **upper bound d ≤ 20**.
+
+## Dead ends
+
+Sibling candidates at nearby N collapsed on the ladder (screen values fell up
+to ~50% before flattening); only flat-from-8k survivors were packaged. The
+random support-5 track (85,828 samples) never matched the designed route.
+
+## Tools
+
+Claude Fable 5 agent campaign, research/ kit, gf2_fast deep RIS
+(~20s per 1.5M trials/side at n=210).
+
+## Reproduction
+
+GB/2BGA on Z_105 with the supports above; construction string in
+`codes/210-24-20.json`. Lit check at submission: closest published n=210
+code was [[210,10,16]] (arXiv:2503.03827).

--- a/notes/240-16-20.md
+++ b/notes/240-16-20.md
@@ -1,0 +1,53 @@
+# [[240,16,20]] — literature baseline (Aydin–Tamo–Barg), exact reproduction
+
+## Why this entry exists
+
+This is a **baseline seeding**, not an original submission: the code is
+published in arXiv:2606.17268 (Appendix F, Table VI: n=240, k=16, d ≤ 20 via
+QDistRnd at 10⁶ iterations) and was absent from the board. On the board of
+2026-07-14 it landed as a weight-8 frontier point, which meant several
+then-staged candidates were being measured against an artificially weak
+frontier. Seeding it made the repo-local frontier honest.
+
+## Reproduction (the actual work)
+
+The paper specifies the code by GAP identifiers, so exact reproduction
+required GAP 4.14.0 (the paper's pinned version; installed via conda-forge):
+G = SmallGroup(240,39) = C3×((C5⋊C8)⋊C2);
+H = Filtered(AllSubgroups(G), K -> not IsNormal(G,K))[1] ≅ C2;
+a = [1,37,136,228] as 1-based indices into LeftCosets(G, Core(G,H));
+b = [1,11,35,52] into LeftCosets(Normalizer(G,H), H); two-block coset action
+H_X = [A|B], H_Z = [Bᵀ|Aᵀ]. The caption's convention worked on the first
+interpretation — no alternative reading was needed.
+
+**Validation before trusting the target:** the same pipeline reproduced three
+exact-distance rows of Table VI first — [[80,8,10]] and [[80,10,8]] (both
+MILP-certified exact, both sides) and [[120,14,12]] (k exact; 2M-trial RIS
+finds weight 12, nothing lighter).
+
+## Evidence trail
+
+Target build: CSS holds, k=16, max check weight 8. Ladder 8k → 2M trials/side
+flat at 20; +3 fresh seeds × 2M, all 20; matches the paper's bound.
+Claim: **upper bound d ≤ 20**, attributed to the paper's authors
+(`origin: baseline`, no @handle — baseline exemption per CONTRIBUTING).
+
+## Dead ends / tips
+
+- The paper's Appendix F (Table VI) is not extractable from the arXiv HTML
+  render — every route truncates before the appendix. Reading the PDF's
+  pages 23–24 directly works.
+- GAP's conda-forge build segfaults on `--version` but runs scripts; confirm
+  the version via `GAPInfo.Version`.
+
+## Tools
+
+Claude Fable 5 agent (GAP install, convention validation, build); gf2_fast
+for the deep rungs; MILP exact certification via the repo's certifier for the
+two [[80,·,·]] validation rows.
+
+## Reproduction pointer
+
+GAP script + matrices + validation artifacts:
+`research/candidates/campaign-20260714/baseline-240-16-20/` (in the campaign
+branch history); construction string in `codes/240-16-20.json`.

--- a/notes/258-32-22.md
+++ b/notes/258-32-22.md
@@ -1,0 +1,51 @@
+# [[258,32,22]] — designed-divisor weight-10 GB on Z_129
+
+## Direction & hypothesis
+
+Target: the weight-9plus × unrestricted cell, which held a single code
+([[126,28,8]], kd²/n 14.2). Hypothesis: support-5 GB codes open the cell, but
+random sampling wastes the weight budget — aligning k with d needs structure.
+
+## What was searched
+
+Two tracks. (a) Random support-5 2BGA over 15 nonabelian groups: 85,828
+candidates — k and d never aligned; nothing board-advancing survived.
+(b) The designed-divisor construction that produced this code: pick a divisor
+g(x) | x^N−1 of target degree (k = 2·deg g guaranteed), then meet-in-the-middle
+enumerate weight-5 multiples of g. 13,200 such codes screened over cyclic
+groups N = 63–147 at 1.5k RIS trials. This code: N=129, deg g = 16,
+a(x) = 1+x²+x⁴¹+x⁷³+x⁸³, b(x) = 1+x⁴⁷+x⁹²+x¹¹²+x¹²⁵.
+
+## Evidence trail
+
+Screen values in this family inflate up to ~50% (e.g. 42→34, 38→28, 30→20 by
+20k trials), so every survivor was laddered. This code: 8k → 60k → 200k → 1M
+trials/side all find lightest logical 22, flat from the first rung; claimed
+d equals the witnessed weight-22 logicals at the 1M rung. Post-hoc adversarial
+re-check: 4 fresh seeds × 1.5M trials/side, all find 22, nothing lighter.
+Independent BP+OSD decoder search: nothing below weight 24. Claim:
+**upper bound d ≤ 22**, no lighter logical proven absent.
+
+## Dead ends
+
+- Random support-5 (85,828 samples): k·d never beat the designed route — the
+  divisor trick, not sampling volume, was the win.
+- Ten flat-ladder survivors were found; seven remain unpackaged (staged) —
+  confirmation, not generation, is the bottleneck.
+- Nearest literature neighbor checked before claiming: [[254,28,14]]
+  (arXiv:1904.02703); weight-10 supports sit outside the exhaustive W≤8
+  enumerations. Novelty vs literature: unverified, per board policy.
+
+## Tools
+
+Claude Fable 5 multi-agent campaign on the repo's research/ kit; gf2_fast for
+all deep RIS runs (~9–30s per 1M trials/side at this n); BP+OSD via the
+decode/ stack for the independent check. ~45 min generation, ~hours of
+confirmation across parallel agents.
+
+## Reproduction
+
+`research/kit/group_algebra.py::build_2bga` on Z_129 with the supports above
+(exponents of a(x), b(x)); or see the construction string in
+`codes/258-32-22.json`. Code-capacity performance study (BP+OSD, MWPM
+comparison): `research/candidates/campaign-20260714/plots/`.

--- a/notes/288-16-16.md
+++ b/notes/288-16-16.md
@@ -1,0 +1,48 @@
+# [[288,16,16]] — annealed 2BGA on the metacyclic group C12⋊C12
+
+## Direction & hypothesis
+
+Target: the weight-6 × unrestricted cell (best 13.50, [[288,12,18]]; frontier
+k-max 12). Hypothesis: nonabelian metacyclic groups of order 100–180 are
+outside Lin–Pryadko's exhaustive n ≤ 200 enumeration, so novelty is possible,
+and annealing should out-search blind sampling once tuned.
+
+## What was searched
+
+4,700 random screens + ~2,500 anneal evaluations over all nonabelian
+metacyclic (conjugacy-deduped) and dicyclic groups of order 100–180,
+support-3 (w6) and support-4 (w8). This code: 2BGA on
+C12⋊C12 = ⟨x,y | x¹²=y¹²=1, yxy⁻¹=x⁵⟩ (order 144, GAP-independent
+presentation), a=[0,9,55], b=[0,26,37] (element indices in the kit's
+enumeration), found by annealing from the screened seed [[288,8,18]].
+
+**Method result worth having:** the historic ~0.1% anneal acceptance on this
+family was never a temperature problem — 60–80% of support mutations destroy
+k and must be auto-rejected before the Metropolis step; among k-viable moves
+acceptance at T = 1–2 is ~50%. With that fix, T=1.5 with cooling worked.
+
+## Evidence trail
+
+Ladder 2k/8k/60k/200k: 16/16/16/16, flat; 600k-trial deep search witnessed
+weight-16 logicals on both sides. Pre-submission adversarial re-check:
+3 fresh seeds × 1M trials/side (gf2_fast), all 16. Claim: **upper bound
+d ≤ 16**. Gate verdict: board_advancing, dedup clean.
+
+## Dead ends
+
+- [[252,8,26]] (screen) collapsed to 19 by the 8k rung.
+- All n ≥ 330 anneal stars ([[360,18,38]], [[360,12,42]], [[360,12,22]])
+  were left unpackaged: the 1M-trial rung was too expensive on a contended
+  machine, and this family's screen values inflate. Treat those parameters
+  as unconfirmed leads, not results.
+- Dicyclic groups never out-screened metacyclic at equal order.
+
+## Tools
+
+Claude Fable 5 agent campaign; annealer in the campaign staging dir
+(tune/screen/anneal/ladder phases); gf2_fast for deep rungs.
+
+## Reproduction
+
+`research/kit/group_algebra.py` metacyclic builder with the presentation and
+supports above; construction string in `codes/288-16-16.json`.

--- a/notes/336-20-21.md
+++ b/notes/336-20-21.md
@@ -1,0 +1,51 @@
+# [[336,20,21]] — coset 2BGA on C56⋊C6 / C2 (weight-8)
+
+## Direction & hypothesis
+
+Target: the weight-8 × unrestricted headline ([[336,20,20]], kd²/n 23.81).
+Hypothesis, learned the hard way (see fieldnote on the simple-group d=2
+plateau): record coset codes live on *solvable metacyclic* groups with a
+large normalizer quotient |N_G(H)/H| — not on simple groups. So: coset 2BGA
+on C_m⋊C6 with H = C2 at sizes above everything published (n = 336/408/504),
+annealed with tuned acceptance.
+
+## What was searched
+
+5 group configs, 498 anneal restarts, ~173k evaluations (acceptance
+5.7–12.1% after raising T_HI 1.2 → 1.8). This code: G = C56⋊C6 (order 336,
+twist r=29), non-normal H = ⟨(0,3)⟩ ≅ C2, |N_G(H)| = 168, |W| = 84;
+a = [0,225,233,239], b = [0,36,134,194].
+
+## Evidence trail
+
+Ladder [27, 21, 21, 21] — flat from 8k trials; then ~2M aggregate trials/side
+over 10 independent seeds, all finding 21. Pre-submission: 3 fresh seeds × 2M
+trials/side single-run, all 21. Claim: **upper bound d ≤ 21** — strictly
+improves [[336,20,20]] (same n, k; d+1).
+
+## Dead ends
+
+- n=168 scale-down (C28⋊C6, |W|=42): 55k evals, zero hits — [[168,20,14]]
+  unbeaten.
+- n=180 two-element correlated moves around the board optimum: 447,859 pair
+  evaluations, zero improvements. Combined with earlier single-move
+  exhaustion, [[180,20,14]] is locally optimal under 1- and 2-element moves;
+  that direction is closed.
+- n=408/504 hits showed classic large-n inflation (63→40, 66→30 still
+  descending at 190k trials); one nominally-flat [[504,16,≤27]] never met the
+  1M floor and was handed off unpackaged.
+- Lit check: arXiv:2606.17268's full Table VI (Appendix F) was extracted and
+  checked — no n=336 entries; largest published w8 coset distance there is
+  ≤20. (Extraction tip: the HTML renders truncate; read the PDF pages
+  directly.)
+
+## Tools
+
+Claude Fable 5 agent campaign; coset builder `research/kit/coset.py`;
+gf2_fast; sampler guards from the prior blocked route (odd |b| forces k=0;
+b = whole normalizer quotient is a k-inflating d=2 degeneracy).
+
+## Reproduction
+
+`research/kit/coset.py::build_coset` with (G, H, a, b) above; construction
+string in `codes/336-20-21.json`.

--- a/notes/README.md
+++ b/notes/README.md
@@ -1,0 +1,54 @@
+# Research notes: share the search, not just the code
+
+A code on the board tells you *what* was found. The note beside it tells you
+*how* — and, just as valuably, what failed on the way. This is the board's
+mechanism for compounding progress across competitors: the next searcher
+(human or agent) starts from everyone's field experience instead of
+rediscovering the same dead ends.
+
+The design follows the ECDSA Fail challenge, where every submission carries a
+public method note and the repo history doubles as a research log.
+
+## The contract
+
+- One note per submitted code: `notes/<n>-<k>-<d>.md`, matching the
+  `codes/<n>-<k>-<d>.json` slug. Include it in the same PR as the code.
+- Public, plain markdown, **10 KiB max**. It is rendered on the code's page on
+  the leaderboard site and in the site's research log.
+- Notes are **requested for all new submissions** (this may become CI-enforced
+  after an adoption period; literature baselines are exempt — their note
+  should instead document the reproduction).
+- Negative results that aren't attached to a submission go in
+  [`fieldnotes/`](../fieldnotes/) — they are first-class contributions and can
+  be PR'd on their own.
+
+## What a good note contains
+
+Use [TEMPLATE.md](TEMPLATE.md). The sections, and why they matter:
+
+1. **Direction & hypothesis** — the cell/family targeted and why you expected
+   something there. Lets others see which parts of the search space are being
+   worked, and with what reasoning.
+2. **What was searched** — constructions, sweep sizes, seeds, screening
+   method. The denominator that makes the find interpretable.
+3. **Evidence trail** — the distance-confirmation ladder *including the
+   candidates that collapsed*. Distance inflation is this board's recurring
+   failure mode; publishing ladders is how the community calibrates.
+4. **Dead ends** — what you tried that did not work, stated plainly. Often
+   the most valuable section for the next searcher.
+5. **Tools** — model/harness/agent setup (matches `provenance.model`), and
+   any repo tooling used, so results are attributable and reproducible.
+6. **Reproduction** — the minimal recipe: script or parameters that rebuild
+   `(H_X, H_Z)` from scratch.
+
+Write it for a competitor you respect: concrete numbers, no promotion, honest
+caveats. If the distance is an upper bound, say what depth of search failed
+to refute it.
+
+## Reading them
+
+- On the site: each code page renders its note; the
+  [research log](https://unitaryfoundation.github.io/qldpc-challenge/research-log.html)
+  lists all notes and fieldnotes, newest first.
+- Locally: `./qldpc recent` summarizes what landed recently (codes, notes,
+  fieldnotes), so a new session starts from the current frontier of knowledge.

--- a/notes/TEMPLATE.md
+++ b/notes/TEMPLATE.md
@@ -1,0 +1,32 @@
+# [[n,k,d]] — one-line description of the construction
+
+## Direction & hypothesis
+
+Which track cell and family you aimed at, and why. What made you expect an
+opening there (a thin cell, a record to beat, a structural idea).
+
+## What was searched
+
+Constructions tried, sweep sizes, screening method and trial counts, seeds.
+E.g. "13,200 weight-5 divisor pairs on Z_129, screened at 1.5k RIS trials."
+
+## Evidence trail
+
+The confirmation ladder for the submitted code (trials/side -> lightest
+logical found), and the same for near-miss candidates that collapsed.
+State the final claim precisely: witness-backed upper bound vs exact.
+
+## Dead ends
+
+What did not work: families that screened well and collapsed, structural
+approaches that produced k=0 or low d, tuning that failed. Numbers > prose.
+
+## Tools
+
+Model and version (matches provenance.model), agent/harness setup, repo
+tooling used (kit modules, gf2_fast, decoders), approximate compute.
+
+## Reproduction
+
+Minimal recipe to rebuild (H_X, H_Z): script path or exact parameters
+(group, supports/polynomials, seeds).

--- a/research/AUTORESEARCH.md
+++ b/research/AUTORESEARCH.md
@@ -57,6 +57,10 @@ The verdict's `gates` block is your evidence; `labels` are what you show the hum
                  search.py (screen→rank)      with distance.py before promoting a standout
 ```
 
+0. **Read the shared record first**: `./qldpc recent` (new codes, research
+   notes, fieldnotes), then the `fieldnotes/` entries touching your intended
+   family — blocked routes and calibration findings live there, and repeating
+   them wastes the budget.
 1. **Pick a direction** → a track cell + a family + a budget (below).
 2. **Build** `(HX, HZ)` from a constructor.
 3. **Estimate** distance cheaply with the surrogate (gets you the witness for free).
@@ -282,6 +286,11 @@ packaging (the schema rejects empty supports).
 
 ## Output & housekeeping
 
+- For each staged candidate, also draft its **research note** (`notes/TEMPLATE.md` format):
+  the human will submit it beside the code, and your sweep counts, ladder traces (including
+  collapses), and dead ends are exactly its required content — capture them while they are
+  cheap to capture. Findings that are *not* attached to a candidate (blocked routes,
+  calibration results) belong in a drafted `fieldnotes/` entry instead.
 - Write each surviving candidate's **submission JSON + its full validator verdict** to a staging
   folder (e.g. `research/candidates/` or a scratch dir), and print a short ranked summary:
   `[[n,k,d]]`, cell, efficiency `kd²/n`, board-advancing?, and the honest labels.

--- a/research/AUTORESEARCH.md
+++ b/research/AUTORESEARCH.md
@@ -225,56 +225,16 @@ The constructors, surrogate, search, and packaging stay numpy-only.
 - **`upper_bound` is not `exact`.** The gate certifies an upper bound (`d<=`); an exact (`d=`)
   claim needs server certification (step 6). Only pursue it for a standout the human wants.
 
-## Field notes from past campaigns (2026-06 → 2026-07)
+## Field notes from past campaigns
 
-The sections above are the mechanics; this is what actually happened across the first months
-of campaigns, so you don't re-learn it at compute cost.
-
-**Trial-depth floors — the failure mode that repeats every campaign.** Every inflated claim
-so far died the same way: a high surrogate d at low trials that collapsed as trials rose.
-[[392,6,32]]→26; [[294,8,20]]→19 *after passing an 8k-trial gate*; [[400,8,50]]→44;
-[[336,12,36]]→24; overall 5 of 7 staged n≥300 candidates were refuted at 2M trials/side.
-Support-5 2BGA (weight-9plus) inflates 8–30% at 30–60k-trial depth. The discipline that fixed it:
-
-- Screen at low trials, but confirm on a **rising ladder** (e.g. 2k→8k→60k→1M trials) and keep
-  only candidates whose d is *flat* across the ladder — a value still descending is not a value.
-- For n≥300, treat **~1M+ trials/side as the packaging floor**. With the `gf2_fast` extension
-  (`make fast`, ~30–170× over pure Python) that is minutes, so there is no excuse to skip it.
-- Package claimed d = **the lightest logical you yourself witnessed** in deep self-refutation,
-  never "the best value I failed to refute" — leave the gate nothing left to find.
-- Distance floors/records established in low-trial eras are suspect (one d≥14 "floor" fell at
-  200k trials). Re-refute an old claim before building on it.
-
-**Lit-check before you fall in love.** Random sweeps rediscover the literature: an A5
-[[120,12,10]] "find" turned out to be a known W≤8 optimum from Lin–Pryadko's *exhaustive*
-nonabelian 2BGA enumeration (n≤200, github.com/QEC-pages/2BGA-codes). Check that, the BB
-papers (arXiv:2308.07915 and follow-ons), and the Aydin–Tamo–Barg coset tables *before* the
-expensive deep-confirmation runs, not after.
-
-**Confirmation is the bottleneck, not generation.** Screening covers hundreds of candidates in
-seconds; deep confirmation takes minutes–hours per survivor, and exact MILP can run >15 min at
-n≈126 without finishing. Budget a sweep around how many survivors you can *confirm*, and never
-block the sweep on exact certification. Also: one code per PR (CI-enforced) at ~12 min of gate
-time each — promote selectively, best-settled first.
-
-**Directions that produced the recent wins (still open):**
-
-- **Nonabelian 2BGA beyond n=200** — outside the exhaustive enumeration, so novelty is real.
-  S5 gave odd-k [[240,13,15]] (odd k is unreachable by abelian BB — a niche only nonabelian
-  constructions can enter); PSL(2,7) gave [[336,20,20]], a board-best efficiency. Untried
-  neighbors: PSL(2,8), PSL(2,11), SL(2,7), other simple/Hurwitz groups — simple groups compete
-  with metacyclic at equal weight.
-- **The weight-9plus cell is thin.** Support-5 2BGA opens it; apply the 1M-trial floor from
-  the start (this family is the worst inflater).
-- **2D-local grafts:** codes dominated on the unrestricted board still set locality records
-  ([[216,15,11]] is a bilayer k-record only because of its layout). Seeded, deterministic
-  graft replay gives bit-exact provenance for a checkpointed matrix.
-- **Re-mining old low-trial sweep artifacts at honest trial counts** is cheap and productive.
-- **Annealing (screen-then-confirm) beats blind sampling** once a fertile group is chosen —
-  but tune acceptance first (T_HI=2.0 ran at ~0.1% acceptance, far too cold).
-
-**Small landmines:** `reduce_weights` can zero out redundant rows — drop empty rows before
-packaging (the schema rejects empty supports).
+Operational field experience lives in [`../fieldnotes/`](../fieldnotes/) —
+PR-able entries rendered in the site's research log. The lessons that used to
+be inlined here (trial-depth floors and the distance-inflation discipline,
+lit-check timing, confirmation-budget planning, tooling landmines, and the
+2026-06→07 open-directions snapshot) were ported there on 2026-07-23. Read
+the entries touching your family before spending budget (step 0 of the
+loop), and add a fieldnote when a campaign learns something the next one
+should not have to re-learn.
 
 ## Definition of done (a candidate you may surface)
 

--- a/site/build.py
+++ b/site/build.py
@@ -733,6 +733,14 @@ text-decoration:none;line-height:0}}
 .wit{{font-family:ui-monospace,monospace;font-size:12px;background:var(--soft);
 border:1px solid var(--ln);border-radius:8px;padding:10px;
 white-space:pre-wrap;word-break:break-word}}
+.notebody{{font-size:14px;line-height:1.55}}
+.notebody h3,.notebody h4,.notebody h5{{margin:14px 0 6px}}
+.notebody pre{{font-family:ui-monospace,monospace;font-size:12px;
+background:var(--soft);border:1px solid var(--ln);border-radius:8px;
+padding:10px;overflow-x:auto}}
+.notebody code{{font-family:ui-monospace,monospace;font-size:12.5px;
+background:var(--soft);padding:1px 4px;border-radius:4px}}
+.notebody ul{{margin:6px 0 6px 20px}}
 details{{margin:8px 0}}summary{{cursor:pointer;color:var(--ac);font-size:14px}}
 .cert-ok{{color:var(--ex);font-weight:600}}.cert-no{{color:var(--mut)}}
 .ref{{display:flex;gap:16px;padding:16px 0;border-bottom:1px solid var(--ln);
@@ -1041,6 +1049,7 @@ def load_entries():
             "model": doc["provenance"].get("model", ""),
             "date": doc["provenance"].get("date", ""),
             "construction": doc["provenance"].get("construction", ""),
+            "note_md": load_note(slug),
             "doc": doc, "cert": cert,
         })
     return entries
@@ -1144,6 +1153,163 @@ def mathfmt(s):
     be negative. Variables are left in normal text on purpose (the strings mix
     in prose, so blanket italics would catch letters inside words)."""
     return re.sub(r"(?:\*\*|\^)(-?\d+)", r"<sup>\1</sup>", html.escape(s))
+
+
+def md_to_html(md):
+    """Render the deliberately small markdown subset allowed in research notes
+    and fieldnotes (headings, bold, inline code, fenced code, lists, links,
+    paragraphs). Everything is HTML-escaped first, so a note can never inject
+    markup; anything outside the subset renders as literal text."""
+    out, in_code, in_list, para = [], False, False, []
+
+    def flush_para():
+        if para:
+            out.append("<p>" + " ".join(para) + "</p>")
+            para.clear()
+
+    def close_list():
+        nonlocal in_list
+        if in_list:
+            out.append("</ul>")
+            in_list = False
+
+    def inline(s):
+        s = html.escape(s)
+        s = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", s)
+        s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
+        s = re.sub(r"\[([^\]]+)\]\((https?://[^)\s]+)\)",
+                   r'<a href="\2">\1</a>', s)
+        return s
+
+    for line in md.splitlines():
+        if line.strip().startswith("```"):
+            flush_para(); close_list()
+            out.append("<pre>" if not in_code else "</pre>")
+            in_code = not in_code
+            continue
+        if in_code:
+            out.append(html.escape(line))
+            continue
+        m = re.match(r"(#{1,4})\s+(.*)", line)
+        if m:
+            flush_para(); close_list()
+            lvl = min(len(m.group(1)) + 2, 5)   # note h1 -> page h3
+            out.append(f"<h{lvl}>{inline(m.group(2))}</h{lvl}>")
+            continue
+        if re.match(r"\s*[-*]\s+", line):
+            flush_para()
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            out.append("<li>" + inline(re.sub(r"\s*[-*]\s+", "", line, count=1))
+                       + "</li>")
+            continue
+        if not line.strip():
+            flush_para(); close_list()
+            continue
+        para.append(inline(line.strip()))
+    flush_para(); close_list()
+    if in_code:
+        out.append("</pre>")
+    return "\n".join(out)
+
+
+NOTE_CAP = 10 * 1024
+
+
+def load_note(slug):
+    """The research note staged beside a submission: notes/<slug>.md.
+    Absent file -> None (notes are requested, not yet mandatory)."""
+    p = os.path.join(ROOT, "notes", slug + ".md")
+    if not os.path.exists(p):
+        return None
+    with open(p) as f:
+        md = f.read()
+    if len(md.encode()) > NOTE_CAP:
+        print(f"  warning: notes/{slug}.md exceeds {NOTE_CAP} bytes; "
+              f"truncating on render")
+        md = md.encode()[:NOTE_CAP].decode(errors="ignore")
+    return md
+
+
+def load_fieldnotes():
+    """fieldnotes/*.md with a minimal front-matter block (title/date/author/
+    model/topics). Malformed front matter degrades to filename-derived
+    metadata rather than failing the build."""
+    notes = []
+    for p in sorted(glob.glob(os.path.join(ROOT, "fieldnotes", "*.md"))):
+        base = os.path.basename(p)
+        if base.upper() == "README.MD":
+            continue
+        with open(p) as f:
+            raw = f.read()
+        meta = {"title": os.path.splitext(base)[0], "date": "", "author": "",
+                "model": "", "topics": ""}
+        body = raw
+        m = re.match(r"\s*---\n(.*?)\n---\n(.*)", raw, re.S)
+        if m:
+            body = m.group(2)
+            for line in m.group(1).splitlines():
+                kv = re.match(r"(\w+)\s*:\s*(.*)", line)
+                if kv and kv.group(1) in meta:
+                    meta[kv.group(1)] = kv.group(2).strip().strip('"')
+        if not meta["date"]:
+            dm = re.match(r"(\d{4}-\d{2}-\d{2})", base)
+            meta["date"] = dm.group(1) if dm else ""
+        notes.append({**meta, "file": base, "md": body})
+    return notes
+
+
+def research_log_page(entries, fieldnotes):
+    """docs/research-log.html: every submission note and fieldnote, newest
+    first — the board's shared record of what was tried, what worked, and
+    what is known not to work."""
+    items = []
+    for e in entries:
+        if e.get("note_md"):
+            items.append({
+                "date": e["date"], "kind": "submission note",
+                "title": f'[[{e["n"]},{e["k"]},{e["d"]}]] — {e["slug"]}',
+                "link": f'codes/{e["slug"]}.html',
+                "src": f'{REPO}/notes/{e["slug"]}.md',
+                "author": e["authors"], "model": e["model"],
+                "md": e["note_md"]})
+    for fn in fieldnotes:
+        items.append({
+            "date": fn["date"], "kind": "fieldnote", "title": fn["title"],
+            "link": None, "src": f'{REPO}/fieldnotes/{fn["file"]}',
+            "author": fn["author"], "model": fn["model"], "md": fn["md"]})
+    items.sort(key=lambda i: i["date"], reverse=True)
+
+    P = [head("Research log · QEC Challenge")]
+    P.append('<div class=wrap>')
+    P.append('<a class=back href="index.html">&larr; back to the board</a>')
+    P.append('<h1>Research log</h1>')
+    P.append(
+        '<p class=sub>The search behind the board: every submission ships a '
+        'public research note (how the code was found, what was swept, what '
+        'collapsed), and negative results land as stand-alone '
+        f'<a href="{REPO}/fieldnotes">fieldnotes</a>. Newest first. '
+        f'See <a href="{REPO}/notes">notes/</a> for the contract.</p>')
+    if not items:
+        P.append('<p class=sub>No notes yet.</p>')
+    for i, it in enumerate(items):
+        title = (f'<a href="{it["link"]}">{html.escape(it["title"])}</a>'
+                 if it["link"] else html.escape(it["title"]))
+        byline = " &middot; ".join(x for x in (
+            html.escape(it["date"]), html.escape(it["kind"]),
+            authors_html([a.strip() for a in it["author"].split(",")])
+            if it["author"] else "",
+            html.escape(it["model"])) if x)
+        P.append(f'<section class=blk><h3>{title}</h3>'
+                 f'<div class=kv style="color:var(--mut)">{byline}</div>'
+                 f'<details {"open" if i < 3 else ""}>'
+                 f'<summary>note</summary>'
+                 f'<div class=notebody>{md_to_html(it["md"])}</div>'
+                 f'<div class=kv><a href="{it["src"]}">raw markdown</a></div>'
+                 f'</details></section>')
+    P.append('</div></body></html>')
+    return "\n".join(P)
 
 
 def authors_html(lst):
@@ -1286,6 +1452,23 @@ def detail_page(e):
              f'{html.escape(WEIGHT_LABEL.get(e["weight_class"], "weight > 8"))} '
              '<span class=claimed>(computed)</span></div>')
     P.append('</section>')
+
+    # research note: how the code was found (notes/<slug>.md, staged with the
+    # submission PR — see notes/README.md for the contract)
+    if e.get("note_md"):
+        P.append('<section class=blk><h3>How this code was found</h3>'
+                 '<div class=kv style="color:var(--mut)">the research note '
+                 'submitted with this code &middot; '
+                 f'<a href="{REPO}/notes/{e["slug"]}.md">raw markdown</a> '
+                 '&middot; <a href="../research-log.html">all notes</a></div>'
+                 f'<div class=notebody>{md_to_html(e["note_md"])}</div>'
+                 '</section>')
+    else:
+        P.append('<section class=blk><h3>How this code was found</h3>'
+                 '<div class=kv style="color:var(--mut)">no research note was '
+                 'staged with this submission &mdash; notes are requested for '
+                 f'new submissions (<a href="{REPO}/notes">notes/README.md</a>)'
+                 '</div></section>')
 
     # parity checks
     X, Z = doc["checks"]["X"], doc["checks"]["Z"]
@@ -2348,6 +2531,7 @@ def build():
              '<a href="whitepaper.html">Read the whitepaper.</a></p>'
              '<nav class=topnav>'
              '<a href="faq.html">FAQ</a>'
+             '<a href="research-log.html">Research log</a>'
              '<a href="references.html">References</a>'
              f'<a href="{REPO_ROOT}">{GH_ICON}GitHub</a>'
              '</nav>'
@@ -2410,6 +2594,7 @@ def build():
         f'<a href="{REPO}/schema/SCHEMA.md">Schema</a>'
         f'<a href="{REPO}/TRACKS.md">Tracks</a>'
         '<a href="faq.html">FAQ</a>'
+        '<a href="research-log.html">Research log</a>'
         '<a href="references.html">References</a>'
         '<a href="qec_challenge.pdf">Whitepaper</a>'
         '</nav></div>'
@@ -2432,6 +2617,8 @@ def build():
         f.write(references_page(entries))
     with open(os.path.join(DOCS, "faq.html"), "w") as f:
         f.write(faq_page())
+    with open(os.path.join(DOCS, "research-log.html"), "w") as f:
+        f.write(research_log_page(entries, load_fieldnotes()))
     # Wrapper so the whitepaper opens with the site favicon and a proper tab
     # title (a raw PDF tab shows the browser's PDF-viewer icon instead).
     with open(os.path.join(DOCS, "whitepaper.html"), "w") as f:


### PR DESCRIPTION
## What this adds

A mechanism for competitors to share **how** they found their codes — and what failed on the way — modeled on the ECDSA Fail challenge, where every submission carries a public method note and the repo history doubles as a research log.

Right now the board records outcomes but not paths. The most expensive knowledge generated here — which families are barren, how badly surrogate distances inflate at a given n, which search tunings actually work — is rediscovered privately by every competitor. This PR gives that knowledge a home and a display surface.

### The pieces

1. **`notes/` — one public research note per submission** (`notes/<n>-<k>-<d>.md`, 10 KiB cap, template provided). Required content: hypothesis, what was swept and at what depth, the distance-confirmation ladder *including candidates that collapsed*, dead ends, model/harness, reproduction recipe. Requested for new submissions now; could become CI-enforced after an adoption period (deliberately not enforced in this PR). Baselines exempt (their note documents the reproduction).
2. **`fieldnotes/` — negative results as first-class contributions.** Stand-alone PR-able markdown entries for blocked routes, calibration findings, and corrections — no code required. Front-matter keeps them indexable.
3. **Site rendering** (`site/build.py`): each code page gains a "How this code was found" section rendering its note (codes without one show a gentle nudge), and a new **`research-log.html`** lists all notes + fieldnotes newest-first, linked from the top nav and footer. Markdown rendering is a small escaped-first subset — a note can't inject markup.
4. **CLI support** (`cli/qldpc.py`): `./qldpc submit --note-file yournote.md` stages the note beside the code and includes it in the PR flow; a new `./qldpc recent` prints what landed lately (codes, notes, fieldnotes) so a session starts from the community's frontier of knowledge — the analog of ECDSA Fail's 'sync before you iterate' habit, adapted to a Pareto board that has no single best to sync to.
5. **Docs**: CONTRIBUTING section ("Share the search, not just the code") and AUTORESEARCH loop step 0 (read the shared record before spending compute) + a note-drafting step in agent housekeeping.

### Seeded with real content

Six retrofitted notes for codes I submitted ([[126,18,14]], [[210,24,20]], [[258,32,22]], [[288,16,16]], [[336,20,21]], and the [[240,16,20]] ATB baseline reproduction), and nine fieldnotes: four distilled from the same campaign plus five ported from AUTORESEARCH.md's 'Field notes from past campaigns (2026-06 → 2026-07)' section, which this PR retires in favor of the fieldnotes format (AUTORESEARCH keeps the loop mechanics and points here). The campaign four: the simple-group coset d=2 plateau (a blocked route with sampler guards), large-n refutation calibration (flat-at-16k is not convergence at n≈1000; the CI refuter's depth can't catch inflation there), the annealing acceptance fix (k-crashing moves, not temperature), and two constructive mechanisms (designed-divisor GB, the odd-k parity rule). These are the notes I wish had existed before the campaign started.

### What happens after merge

The next site rebuild picks up the new page automatically (docs/ artifacts are deliberately not committed here, matching the rebuild-via-CI pattern). Submitters see the note request in CONTRIBUTING, the CLI, and on any code page missing a note. Nothing breaks for in-flight submissions: no schema change, no new CI gate, `verify/` untouched.