### PR TITLE
Add [[16,6,4]] quantum Reed-Muller code with a single-layer 2D-local layout

### DIFF
--- a/codes/16-6-4.json
+++ b/codes/16-6-4.json
@@ -1,0 +1,221 @@
+{
+ "schema_version": "0.1",
+ "name": "[[16,6,4]] quantum Reed-Muller code, single-layer 2D-local layout",
+ "code_type": "CSS",
+ "n": 16,
+ "k": 6,
+ "checks": {
+  "X": [
+   [
+    1,
+    3,
+    5,
+    7,
+    9,
+    11,
+    13,
+    15
+   ],
+   [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14
+   ],
+   [
+    2,
+    3,
+    6,
+    7,
+    10,
+    11,
+    14,
+    15
+   ],
+   [
+    4,
+    5,
+    6,
+    7,
+    12,
+    13,
+    14,
+    15
+   ],
+   [
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
+   ]
+  ],
+  "Z": [
+   [
+    1,
+    3,
+    5,
+    7,
+    9,
+    11,
+    13,
+    15
+   ],
+   [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14
+   ],
+   [
+    2,
+    3,
+    6,
+    7,
+    10,
+    11,
+    14,
+    15
+   ],
+   [
+    4,
+    5,
+    6,
+    7,
+    12,
+    13,
+    14,
+    15
+   ],
+   [
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
+   ]
+  ]
+ },
+ "distance": {
+  "d": 4,
+  "X": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    1,
+    6,
+    8,
+    15
+   ]
+  },
+  "Z": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    1,
+    6,
+    8,
+    15
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@FarLab"
+  ],
+  "construction": "CSS code from Reed-Muller RM(1,4): H_X = H_Z = the RM(1,4) generator with the all-ones row dropped, which halves the check weight from 16 to 8 while generating the same stabilizer group. The submitted artifact is the LAYOUT: 16 qubits placed in the plane by direct minimization of the maximum check diameter subject to unit minimum site spacing, reaching r = 2.8586.",
+  "origin": "submission",
+  "date": "2026-07-25",
+  "model": "Claude Opus 5",
+  "notes": "The CODE is textbook and its parameters are known (Steane 1996 / Reed-Muller CSS constructions); provenance.novelty is known_parameters. The contribution is the verified single-layer 2D-local LAYOUT, which is what the board's geometric efficiency g = 4kd^2/(n rho^2 r^4) measures. At r = 2.8586, rho = 1 this scores g = 0.3594 versus 0.0717 for the previous best qLDPC entry on the board. Distance is MILP-certified exact on both sides (verify/certify.py: no logical < 4 exists), filed as upper_bound per board policy. CAVEAT: this radius is NOT converged - independent seeds landed at 2.8586 / 2.8593 / 2.8693 / 2.8773 / 2.8794, so a better layout very likely exists. The per-check packing floor for weight-8 is 2.2470, which would give g = 0.944; the gap is open. RM(1,4) also has basis freedom (its stabilizer in GL(5,2) is only AGL(4,2), giving four basis classes with different check-pair graphs), worth roughly 0.09 of radius and not fully explored.",
+  "novelty": "known_parameters",
+  "references": [
+   "quant-ph/9601029 (Steane, 1996)",
+   "errorcorrectionzoo.org/c/quantum_reed_muller"
+  ]
+ },
+ "family": "other",
+ "locality": {
+  "coordinates": [
+   [
+    1.526186417870993,
+    1.875053809410772
+   ],
+   [
+    -1.706985296555345,
+    -1.7633888914964146
+   ],
+   [
+    1.6987073819076643,
+    0.890047861729303
+   ],
+   [
+    1.0301873695280366,
+    -0.9401755089901863
+   ],
+   [
+    1.5762404938979484,
+    -0.1024248388228215
+   ],
+   [
+    -0.7074250817467929,
+    -1.821844133165135
+   ],
+   [
+    -0.16133328892713275,
+    0.8429663838916743
+   ],
+   [
+    0.26340767797545434,
+    -1.5820860203720597
+   ],
+   [
+    -0.3228671677909354,
+    1.83047398201544
+   ],
+   [
+    -1.7019146340563,
+    -0.09925350716605838
+   ],
+   [
+    0.7594067263184114,
+    1.2331432980288985
+   ],
+   [
+    -1.1598732135144645,
+    0.8969869263281995
+   ],
+   [
+    0.09088671393878306,
+    -0.5970800726905909
+   ],
+   [
+    -1.114177524472045,
+    -0.9083056006789288
+   ],
+   [
+    0.6369398383086948,
+    0.24067059747677375
+   ],
+   [
+    -0.7073864132970443,
+    0.005215713724309461
+   ]
+  ],
+  "layers": 1
+ }
+}

--- a/notes/16-6-4.md
+++ b/notes/16-6-4.md
@@ -1,0 +1,53 @@
+# [[16,6,4]] — CSS Reed–Muller RM(1,4), single-layer layout at r = 2.8586
+
+## Direction & hypothesis
+
+Target: the `weight-8 × local-2d-single` cell (empty before this and the
+sibling [[15,7,3]] submission). Same hypothesis as the sibling: under
+`g = 4kd²/(nρ²r⁴)`, a small textbook code with an optimized layout beats
+large qLDPC entries. The code is Steane's [[16,6,4]]; only the layout is new.
+
+## What was searched
+
+- Check basis first: H_X = H_Z = the RM(1,4) generator **with the all-ones
+  row dropped**, halving check weight 16 → 8 while generating the same
+  stabilizer group. Without this reduction no small-radius layout exists.
+- Layout: minimize max check diameter subject to unit min site spacing over
+  free point positions (lattice-constrained layouts were measurably worse).
+  Multiple independent optimizer seeds; basin hopping from incumbents.
+
+## Evidence trail
+
+- Distance: MILP-certified exact via `verify/certify.py` ("no logical < 4
+  exists"); filed `upper_bound` per board policy. Independently re-verified
+  exact (d_X = d_Z = 4) by exhaustive kernel enumeration on 2026-07-27.
+- Radius: **not converged.** Independent seeds landed at 2.8586 / 2.8593 /
+  2.8693 / 2.8773 / 2.8794 — a genuine spread, unlike the sibling's clean
+  convergence to √7. Read g = 0.3594 as a floor, not a limit.
+
+## Dead ends
+
+- Same multistart trap as [[15,7,3]]: random restarts return a consistent
+  false optimum; only seeded basin hopping made progress.
+- The weight-8 per-check packing floor (2.2470, worth g ≈ 0.944) was not
+  approached; it may not be simultaneously satisfiable across overlapping
+  checks.
+
+## Open leads
+
+RM(1,4) has basis freedom: its stabilizer in GL(5,2) is only AGL(4,2), giving
+four check-basis classes with different check-pair graphs (90/90/93/93
+constrained pairs). Edge count does not predict the winner, so all four need
+laying out — plausibly worth ~0.09 of radius.
+
+## Tools
+
+Claude Opus 5 (matches `provenance.model`), layout-optimization campaign of
+2026-07-25; `verify/certify.py`, `verify/qldpc_verify.py`. Minutes per
+optimizer run at n = 16.
+
+## Reproduction
+
+H_X = H_Z = RM(1,4) generator minus the all-ones row; supports in
+`codes/16-6-4.json`, layout in `locality.coordinates`. Verify with
+`uv run python verify/qldpc_verify.py codes/16-6-4.json`.


### PR DESCRIPTION
## The code is textbook — the **layout** is the contribution

`provenance.novelty: known_parameters`. `[[16,6,4]]` is the CSS Reed–Muller code and its parameters are long known (Steane 1996 and the standard RM CSS constructions). **Nothing about the code is claimed as new.**

What is new is a **verified single-layer 2D-local layout**, which is exactly what the board's geometric efficiency measures:

> `g = 4kd²/(n ρ² r⁴)`, normalized so the planar surface code scores 1.

| | r | ρ | kd²/n | **g** |
|---|---|---|---|---|
| **this entry** | **2.8586** | **1** | 6.00 | **0.3594** |
| previous best qLDPC on the board `[[392,8,15]]` | 2.828 | 2 | 4.59 | 0.0717 |
| `[[64,2,8]]` rotated toric | 2.828 | 1 | 2.00 | 0.1250 |
| `[[7,1,3]]` Steane | 2.000 | 1 | 1.29 | 0.3214 |

It is also the first native occupant of the `weight-8 × local-2d-single` cell, which held nothing.

## Construction

`H_X = H_Z =` the RM(1,4) generator **with the all-ones row dropped** — this halves the check weight from 16 to 8 while generating the same stabilizer group, which is what makes a small-radius layout possible at all.

The layout was found by minimizing the maximum check diameter subject to unit minimum site spacing, directly over free point positions (not an affine image of a lattice — lattice-constrained layouts were measurably worse for this code).

## Distance

MILP-certified **exact** on both sides via `verify/certify.py` ("no logical < 4 exists"), so `g` is exact given the layout rather than an upper bound. Filed as `upper_bound` per board policy, since only that tier is server-certified — a maintainer re-running the certifier will reproduce the exact result.

## Caveat: the radius is NOT converged

Independent optimizer seeds landed at **2.8586 / 2.8593 / 2.8693 / 2.8773 / 2.8794**, so a better layout very likely exists and this `g` should be read as a floor, not a limit. Two specific leads:

- The per-check packing floor for weight-8 is **2.2470** (minimum diameter of 8 points at pairwise spacing ≥ 1). At that radius `g` would be **0.944**. The gap is open; the floor may not be simultaneously satisfiable across overlapping checks.
- RM(1,4) has **basis freedom** — its stabilizer in GL(5,2) is only AGL(4,2), giving four basis classes with different check-pair graphs (90/90/93/93 constrained pairs). Edge count does not predict the winner, so all four need laying out. Worth roughly 0.09 of radius.

One methodological note for anyone who retries: **random multistart is a trap here.** On the sibling `[[15,7,3]]`, ~480 random restarts all returned the same value to six decimals — a convincing false optimum. Basin hopping seeded from the incumbent was needed to escape it.

Verified locally: `uv run python verify/qldpc_verify.py codes/16-6-4.json` → exit 0, `local-2d-single`, `weight-8`, `layers 1`, `max_qubits_per_site 1`, `min_site_spacing 1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)