### PR TITLE
Add [[15,7,3]] quantum Hamming code with a single-layer 2D-local layout

### DIFF
--- a/codes/15-7-3.json
+++ b/codes/15-7-3.json
@@ -1,0 +1,195 @@
+{
+ "schema_version": "0.1",
+ "name": "[[15,7,3]] quantum Hamming code, single-layer 2D-local layout",
+ "code_type": "CSS",
+ "n": 15,
+ "k": 7,
+ "checks": {
+  "X": [
+   [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14
+   ],
+   [
+    1,
+    2,
+    5,
+    6,
+    9,
+    10,
+    13,
+    14
+   ],
+   [
+    3,
+    4,
+    5,
+    6,
+    11,
+    12,
+    13,
+    14
+   ],
+   [
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14
+   ]
+  ],
+  "Z": [
+   [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14
+   ],
+   [
+    1,
+    2,
+    5,
+    6,
+    9,
+    10,
+    13,
+    14
+   ],
+   [
+    3,
+    4,
+    5,
+    6,
+    11,
+    12,
+    13,
+    14
+   ],
+   [
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14
+   ]
+  ]
+ },
+ "distance": {
+  "d": 3,
+  "X": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    6,
+    8,
+    13
+   ]
+  },
+  "Z": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    6,
+    8,
+    13
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@FarLab"
+  ],
+  "construction": "CSS quantum Hamming code (Steane construction) from the classical [15,11,3] Hamming code: H_X = H_Z = the 4x15 Hamming parity-check matrix, which is self-orthogonal over GF(2). The submitted artifact is the LAYOUT: 15 qubits placed in the plane by direct minimization of the maximum check diameter subject to unit minimum site spacing, reaching r = sqrt(7) = 2.6458.",
+  "origin": "submission",
+  "date": "2026-07-25",
+  "model": "Claude Opus 5",
+  "notes": "The CODE is textbook and its parameters are known (Steane 1996); provenance.novelty is known_parameters. The contribution is the verified single-layer 2D-local LAYOUT, which is what the board's geometric efficiency g = 4kd^2/(n rho^2 r^4) measures. At r = sqrt(7), rho = 1 this scores g = 0.3429 versus 0.0717 for the previous best qLDPC entry on the board, and it is the first native occupant of the weight-8 x local-2d-single cell. The radius appears optimal: the 11 qubits whose Hamming column has weight >= 2 form a core that alone requires sqrt(7), and two independent optimizers converged there. Distance is MILP-certified exact on both sides (verify/certify.py: no logical < 3 exists), though it is filed as upper_bound per board policy. Naive random multistart converges to a false optimum at r = 2.9093; basin hopping seeded from the incumbent is needed to reach sqrt(7).",
+  "novelty": "known_parameters",
+  "references": [
+   "quant-ph/9601029 (Steane, Multiple particle interference and quantum error correction, 1996)",
+   "errorcorrectionzoo.org/c/quantum_hamming"
+  ]
+ },
+ "family": "other",
+ "locality": {
+  "coordinates": [
+   [
+    -1.892907924063519,
+    -0.9951049389496877
+   ],
+   [
+    1.935611183739798,
+    0.16353419433775884
+   ],
+   [
+    -0.4803538317847173,
+    1.2420120308099387
+   ],
+   [
+    1.707899026075811,
+    -0.8101943988811228
+   ],
+   [
+    -0.2063605278258469,
+    -1.3895139655248459
+   ],
+   [
+    1.2061935644529553,
+    0.8476030042347801
+   ],
+   [
+    0.7507692491249821,
+    -1.099854182202985
+   ],
+   [
+    -1.4374836087355463,
+    0.952352247488078
+   ],
+   [
+    -1.665195766399533,
+    -0.021376345730804144
+   ],
+   [
+    0.476775945166112,
+    1.5316718141318
+   ],
+   [
+    0.02135162983813943,
+    -0.41578537230596424
+   ],
+   [
+    -0.9357781471126899,
+    -0.7054451556278257
+   ],
+   [
+    -0.7080659894487034,
+    0.2682834375910562
+   ],
+   [
+    0.978481406788968,
+    -0.12612558898410195
+   ],
+   [
+    0.24906378750212488,
+    0.557943220912918
+   ]
+  ],
+  "layers": 1
+ }
+}

--- a/notes/15-7-3.md
+++ b/notes/15-7-3.md
@@ -1,0 +1,54 @@
+# [[15,7,3]] — quantum Hamming code, single-layer layout at r = √7
+
+## Direction & hypothesis
+
+Target: the `weight-8 × local-2d-single` cell, which held nothing. The board's
+geometric-efficiency score `g = 4kd²/(nρ²r⁴)` is dominated by r⁻⁴, so the
+hypothesis was that small textbook codes with *optimized* layouts beat large
+qLDPC codes with lazy layouts. The code itself (Steane's CSS construction on
+the [15,11,3] Hamming code) is textbook; the layout is the contribution.
+
+## What was searched
+
+Layout only: minimize the maximum check diameter subject to unit minimum site
+spacing, directly over free point positions — not an affine image of a
+lattice. Optimizers: random multistart (~480 restarts) and basin hopping
+seeded from the incumbent. Two independently written optimizers were run to
+convergence.
+
+## Evidence trail
+
+- Distance: MILP-certified exact on both sides via `verify/certify.py`
+  ("no logical < 3 exists"); filed as `upper_bound` per board policy since
+  only that tier is server-certified. Independently re-verified exact
+  (d_X = d_Z = 3) by exhaustive kernel enumeration on 2026-07-27.
+- Radius: r = √7 = 2.6458, and probably optimal. The 11 qubits whose Hamming
+  column has weight ≥ 2 form a core that is pairwise check-sharing except for
+  3 complementary pairs; laying out that core alone gives exactly √7, and the
+  full 15-qubit layout achieves the same value with the four weight-1 qubits
+  unconstrained. So √7 is both achieved and the optimum of a subproblem that
+  lower-bounds the whole. Both optimizers converged there.
+
+## Dead ends
+
+- **Random multistart is a trap.** ~480 random restarts all returned
+  r = 2.909313 to six decimals — a convincing false optimum, 46% worse in g.
+  Only basin hopping seeded from the incumbent escaped it. Assume the same
+  trap on any layout optimization on this board.
+- The per-check packing floor for weight-8 (2.2470) is not attainable here:
+  the check-pair graph constrains 80 of 105 pairs and max clique is 8, so
+  clique bounds give nothing past the single-check floor.
+
+## Tools
+
+Claude Opus 5 (matches `provenance.model`), single-agent layout-optimization
+campaign of 2026-07-25; `verify/certify.py` for the MILP-exact distance;
+`verify/qldpc_verify.py` for the locality class. Compute: minutes per
+optimizer run at n = 15.
+
+## Reproduction
+
+H_X = H_Z = the 4×15 parity-check matrix of the classical [15,11,3] Hamming
+code (self-orthogonal over GF(2)); supports in `codes/15-7-3.json`. The layout
+is the `locality.coordinates` field; verify with
+`uv run python verify/qldpc_verify.py codes/15-7-3.json`.


### PR DESCRIPTION
## The code is textbook — the **layout** is the contribution

`provenance.novelty: known_parameters`. `[[15,7,3]]` is the CSS quantum Hamming code (Steane 1996), listed in the Error Correction Zoo. **Nothing about the code is claimed as new.**

What is new is a **verified single-layer 2D-local layout**, which is what the board's geometric efficiency measures:

> `g = 4kd²/(n ρ² r⁴)`, normalized so the planar surface code scores 1.

| | r | ρ | kd²/n | **g** |
|---|---|---|---|---|
| **this entry** | **√7 = 2.6458** | **1** | 4.20 | **0.3429** |
| previous best qLDPC on the board `[[392,8,15]]` | 2.828 | 2 | 4.59 | 0.0717 |
| `[[64,2,8]]` rotated toric | 2.828 | 1 | 2.00 | 0.1250 |
| `[[7,1,3]]` Steane | 2.000 | 1 | 1.29 | 0.3214 |

Together with `[[16,6,4]]` (separate PR) it opens the `weight-8 × local-2d-single` cell, which held nothing.

## Construction

`H_X = H_Z =` the 4×15 parity-check matrix of the classical [15,11,3] Hamming code, which is self-orthogonal over GF(2) — Steane's CSS construction.

The layout minimizes the maximum check diameter subject to unit minimum site spacing, over free point positions rather than an affine lattice image.

## Why √7 is probably optimal

Not just "the optimizer stopped there":

- The per-check packing floor for weight-8 is 2.2470, but that bound is weak because `r` is set by the **union** of checks — the check-pair graph constrains 80 of 105 pairs (76%), and max clique is 8, so clique bounds give nothing past 2.2470.
- The binding structure is a **core**: the 11 qubits whose Hamming column has weight ≥ 2 are pairwise check-sharing except for 3 complementary pairs. Laying out **that core alone** gives exactly **√7** — and the full 15-qubit layout achieves the same value, with the four weight-1 qubits free. So √7 is simultaneously the achieved radius and the optimum of a subproblem that lower-bounds the whole.
- Two independent optimizers, written separately, converged on √7.

## Distance

MILP-certified **exact** on both sides via `verify/certify.py` ("no logical < 3 exists"), so `g` is exact given the layout. Filed as `upper_bound` per board policy; a maintainer re-running the certifier will reproduce it.

## A warning worth recording

**Random multistart finds a convincing false optimum here.** ~480 random restarts all returned r = 2.909313 to six decimals. Only basin hopping seeded from the incumbent reached √7 — a 46% improvement in `g` that pure restarts never see. Anyone re-optimizing layouts on this board should assume the same trap.

Verified locally: `uv run python verify/qldpc_verify.py codes/15-7-3.json` → exit 0, `local-2d-single`, `weight-8`, `layers 1`, `max_qubits_per_site 1`, `min_site_spacing 1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)