### PR TITLE
Add [[19,1,5]] triangular 6.6.6 colour code with a single-layer 2D-local layout

### DIFF
--- a/codes/19-1-5.json
+++ b/codes/19-1-5.json
@@ -1,0 +1,256 @@
+{
+ "schema_version": "0.1",
+ "name": "[[19,1,5]] triangular 6.6.6 colour code, single-layer 2D-local layout",
+ "code_type": "CSS",
+ "n": 19,
+ "k": 1,
+ "checks": {
+  "X": [
+   [
+    1,
+    2,
+    5,
+    6
+   ],
+   [
+    3,
+    4,
+    7,
+    8
+   ],
+   [
+    0,
+    1,
+    5,
+    9
+   ],
+   [
+    2,
+    3,
+    6,
+    7,
+    10,
+    11
+   ],
+   [
+    5,
+    6,
+    9,
+    10,
+    12,
+    13
+   ],
+   [
+    7,
+    8,
+    11,
+    14
+   ],
+   [
+    10,
+    11,
+    13,
+    14,
+    15,
+    16
+   ],
+   [
+    12,
+    13,
+    15,
+    17
+   ],
+   [
+    15,
+    16,
+    17,
+    18
+   ]
+  ],
+  "Z": [
+   [
+    1,
+    2,
+    5,
+    6
+   ],
+   [
+    3,
+    4,
+    7,
+    8
+   ],
+   [
+    0,
+    1,
+    5,
+    9
+   ],
+   [
+    2,
+    3,
+    6,
+    7,
+    10,
+    11
+   ],
+   [
+    5,
+    6,
+    9,
+    10,
+    12,
+    13
+   ],
+   [
+    7,
+    8,
+    11,
+    14
+   ],
+   [
+    10,
+    11,
+    13,
+    14,
+    15,
+    16
+   ],
+   [
+    12,
+    13,
+    15,
+    17
+   ],
+   [
+    15,
+    16,
+    17,
+    18
+   ]
+  ]
+ },
+ "distance": {
+  "d": 5,
+  "X": {
+   "value": 5,
+   "confidence": "upper_bound",
+   "witness": [
+    1,
+    5,
+    13,
+    16,
+    17
+   ]
+  },
+  "Z": {
+   "value": 5,
+   "confidence": "upper_bound",
+   "witness": [
+    1,
+    5,
+    13,
+    16,
+    17
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@FarLab"
+  ],
+  "construction": "Triangular 6.6.6 (hexagonal) colour code, m=2, d=2m+1=5, n=3m^2+3m+1=19. Self-dual CSS: H_X = H_Z = the face-incidence matrix of a triangular patch of the hexagonal lattice. The submitted artifact is the LAYOUT: a non-affine embedding reaching interaction radius r = 2*cos(15 deg) = sqrt(2+sqrt(3)) = 1.9318517, versus 2.0 for the natural hexagonal-lattice drawing.",
+  "origin": "submission",
+  "date": "2026-07-26",
+  "model": "Claude Opus 5",
+  "notes": "The CODE is textbook (Bombin & Martin-Delgado 2D colour codes); provenance.novelty is known_parameters. The contribution is the verified single-layer 2D-local LAYOUT, which is what the board's geometric efficiency g = 4kd^2/(n rho^2 r^4) measures. At r = 1.9318517, rho = 1 this scores g = 0.378, versus 0.329 for the same code on the hexagonal lattice at r = 2.0 and 0.0717 for the best qLDPC entry previously on the board. WHY THE LATTICE LAYOUT WAS STUCK AT EXACTLY 2.0, AND WHY THIS IS NOT: in a regular hexagonal face with vertices v_0..v_5 in cyclic order, v_3 - v_0 = 2 (v_2 - v_1) exactly -- a main diagonal is twice one of the face's own edges, and both pairs lie inside the same weight-6 check. So for ANY affine map M, r >= |M(v_3-v_0)| = 2|M(v_2-v_1)| >= 2 * (min site spacing) = 2. No shear, squeeze or rescale can beat 2.0; the previous layouts were class-optimal, not lazy. The improvement therefore requires leaving the lattice entirely. The optimum found is a 30-degree-quantized (snub-square / elongated-triangular) motif whose forced diameter is 2*cos(15 deg); it was reached by basin hopping seeded from the lattice layout, and independently by a separate agent optimizing a bilayer weight-8 code, which converged on the same constant. LOWER BOUND: the packing floor for a weight-6 check is D_6 = 2*sin(72 deg) = 1.9021130 (attained by a regular pentagon of circumradius 1 plus its centre -- notably not a hexagon), but 5-fold symmetry cannot tile a plane with shared face vertices, so 1.9021 is believed unreachable and 1.9318517 the true optimum for a tileable weight-6 layout. That is a well-supported conjecture, not a proof. Distance is filed as upper_bound; the witness is the CLI's own RIS search.",
+  "novelty": "known_parameters",
+  "references": [
+   "arXiv:quant-ph/0605138 (Bombin & Martin-Delgado, Topological quantum distillation)",
+   "arXiv:1108.5738",
+   "errorcorrectionzoo.org/c/triangular_color"
+  ]
+ },
+ "family": "topological",
+ "locality": {
+  "coordinates": [
+   [
+    0.0,
+    1.461326780058224
+   ],
+   [
+    1.2513999275115582,
+    0.0
+   ],
+   [
+    2.645633609970326,
+    0.2369650583893439
+   ],
+   [
+    3.641280540085509,
+    0.14365272987798017
+   ],
+   [
+    5.208345087154212,
+    0.13357847446973903
+   ],
+   [
+    0.8343873094310867,
+    0.9089116989354201
+   ],
+   [
+    1.8300342395462699,
+    0.8155993704240562
+   ],
+   [
+    3.734592868596873,
+    1.139299659993163
+   ],
+   [
+    4.921525993680798,
+    1.587740182044174
+   ],
+   [
+    0.9276996379424514,
+    1.9045586290506027
+   ],
+   [
+    2.73894593848169,
+    1.2326119885045268
+   ],
+   [
+    3.3175802505164014,
+    2.048211358928583
+   ],
+   [
+    1.5063339499771629,
+    2.720157999474659
+   ],
+   [
+    2.321933320401219,
+    2.1415236874399466
+   ],
+   [
+    4.226491949451821,
+    2.4652239770090545
+   ],
+   [
+    2.415245648912583,
+    3.13717061755513
+   ],
+   [
+    3.4108925790277658,
+    3.043858289043766
+   ],
+   [
+    1.6116761205367411,
+    3.7334090549449033
+   ],
+   [
+    2.9313937888438164,
+    4.127071239341035
+   ]
+  ],
+  "layers": 1
+ }
+}

--- a/notes/19-1-5.md
+++ b/notes/19-1-5.md
@@ -1,0 +1,57 @@
+# [[19,1,5]] — triangular 6.6.6 colour code, non-affine layout at r = 2·cos 15°
+
+## Direction & hypothesis
+
+Target: push `local-2d-single` geometric efficiency past the hexagonal
+lattice. Every prior lattice-derived colour-code layout read exactly r = 2.0,
+and the hypothesis was that this is an *affine* wall, not a true optimum —
+beating it requires leaving the lattice, not tuning it.
+
+## What was searched
+
+- First, a proof that the wall is real: in a regular hexagonal face with
+  vertices v₀…v₅ in cyclic order, v₃ − v₀ = 2(v₂ − v₁) exactly — a main
+  diagonal is twice one of the face's own edges, both pairs inside the same
+  weight-6 check. So for any affine map, r ≥ 2 × min-spacing = 2. Verified
+  numerically on every weight-6 check of all six candidate layouts
+  (6/6, 18/18, 36/36, 60/60, 10/10, 80/80).
+- Then non-affine optimization: basin hopping over free point positions,
+  seeded from the lattice layout. Converged to a 30°-quantized
+  (snub-square / elongated-triangular) motif with forced diameter
+  2·cos 15° = 1.9318517.
+
+## Evidence trail
+
+- Radius 1.9319 reached from two independent seeds on this code; four seeds
+  across three codes (including the [[37,1,7]] sibling and a bilayer weight-8
+  code optimized by a separate agent) converged on the same constant —
+  evidence it is structural, not incidental.
+- Distance: filed `upper_bound` with the submission CLI's 60k-trial RIS
+  witness; d = 5 matches the design distance 2m+1 at m = 2. Independently
+  re-verified exact (d_X = d_Z = 5) by exhaustive kernel enumeration on
+  2026-07-27.
+- Packing floor honesty: the weight-6 per-check floor is D₆ = 2·sin 72° =
+  1.9021130, attained by a regular pentagon plus centre — not a hexagon. But
+  5-fold symmetry cannot tile with shared face vertices, so 1.9319 is
+  conjectured (not proven) optimal for tileable weight-6 layouts.
+
+## Dead ends
+
+- Fresh annealing (not seeded from the lattice) is *worse* than the lattice
+  layout at this size and diverges outright at larger n. Seeding from the
+  incumbent lattice drawing was essential.
+- Affine preprocessing (shear/squeeze search) provably cannot beat 2.0 — see
+  the identity above; don't spend compute there.
+
+## Tools
+
+Claude Opus 5 (matches `provenance.model`), layout campaign of 2026-07-25/26;
+basin-hopping optimizer over free positions; `verify/qldpc_verify.py` for
+locality verification.
+
+## Reproduction
+
+Triangular 6.6.6 colour code, m = 2: n = 3m²+3m+1 = 19, d = 2m+1 = 5,
+H_X = H_Z = face-incidence matrix of the triangular patch (supports in
+`codes/19-1-5.json`); layout in `locality.coordinates`. Verify with
+`uv run python verify/qldpc_verify.py codes/19-1-5.json`.


### PR DESCRIPTION
## The code is textbook — the **layout** is the contribution

`provenance.novelty: known_parameters`. The triangular 6.6.6 colour code is textbook (Bombin & Martin-Delgado, quant-ph/0605138). **Nothing about the code is claimed as new.**

What is new is a **non-affine single-layer 2D-local layout** at interaction radius

> **r = 2·cos(15°) = √(2+√3) = 1.9318517**, against 2.0 for the natural hexagonal-lattice drawing.

Under the board's geometric efficiency `g = 4kd²/(n ρ² r⁴)`:

| | r | ρ | kd²/n | **g** |
|---|---|---|---|---|
| **this entry** | **1.93185** | 1 | 1.316 | **0.3779** |
| same code on the hexagonal lattice | 2.000 | 1 | 1.316 | 0.3289 |
| previous best qLDPC on the board `[[392,8,15]]` | 2.828 | 2 | 4.59 | 0.0717 |
| `[[64,2,8]]` rotated toric | 2.828 | 1 | 2.00 | 0.1250 |

It also has the **same k and d as the board's `[[25,1,5]]` surface code at n = 19 < 25** (higher w, so undominated) — a frontier point in `local-2d-single`.

## Why the lattice layout was stuck at exactly 2.0 — and why this isn't

The previous layouts were **class-optimal, not lazy**, and there is a one-line proof. In a regular hexagonal face with vertices `v₀…v₅` in cyclic order,

> `v₃ − v₀ = 2(v₂ − v₁)` **exactly**

— a main diagonal is precisely twice one of the face's own edges, and *both pairs lie inside the same weight-6 check*. So for **any** affine map `M`:

`r ≥ |M(v₃−v₀)| = 2·|M(v₂−v₁)| ≥ 2 × (min site spacing) = 2`

No shear, squeeze or rescale can beat 2.0. The identity was verified numerically on every weight-6 check of all six candidate layouts (6/6, 18/18, 36/36, 60/60, 10/10, 80/80). **The improvement therefore requires leaving the lattice entirely** — which is why every prior lattice-derived layout read exactly 2.0.

The optimum found is a **30°-quantized** (snub-square / elongated-triangular) motif, whose forced diameter is `2·cos(15°)`. It was reached by basin hopping seeded from the lattice layout — never by fresh annealing, which is *worse* than the lattice at this size. Independently, a separate agent optimizing a bilayer weight-8 code converged on the **same constant**, which is some evidence it is structural rather than incidental.

## Lower bound, and an honest limit

The packing floor for a weight-6 check is `D₆ = 2·sin(72°) = 1.9021130`, attained by a **regular pentagon of circumradius 1 plus its centre** — notably *not* a hexagon (verified: min spacing exactly 1.0, diameter exactly 1.9021). But 5-fold symmetry cannot tile a plane with shared face vertices, so `1.9021` is believed unreachable and `1.9318517` the true optimum for any tileable weight-6 layout, capping this family at `g ≈ 0.383`.

**That is a well-supported conjecture, not a proof** — four independent seeds across three different codes all converged there, but no lower-bound argument rules out `(1.9021, 1.9319)`.

## Distance

Filed as `upper_bound`; the witness is the submission CLI's own RIS search (60k trials), and `d = 5` matches the construction's design distance `2m+1` at `m=2`. The staged source additionally carried an MILP-exact certification, but the trustless verifier does not re-run it, so the `upper_bound` tier is what this PR claims.

Verified locally: `uv run python verify/qldpc_verify.py codes/19-1-5.json` → exit 0, `local-2d-single`, `weight-6`, `layers 1`, `max_qubits_per_site 1`, `min_site_spacing 1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)