### PR TITLE
Add single-layer 2D-local layout to [[14,6,2]]

### DIFF
--- a/codes/14-6-2.json
+++ b/codes/14-6-2.json
@@ -1,161 +1,223 @@
 {
-  "schema_version": "0.1",
-  "name": "[[14,6,2]] twisted-torus BB code (arXiv:2503.03827)",
-  "code_type": "CSS",
-  "n": 14,
-  "k": 6,
-  "checks": {
-    "X": [
-      [
-        0,
-        1,
-        2,
-        7,
-        8,
-        9
-      ],
-      [
-        1,
-        3,
-        4,
-        8,
-        10,
-        11
-      ],
-      [
-        2,
-        4,
-        5,
-        9,
-        11,
-        12
-      ],
-      [
-        2,
-        3,
-        6,
-        9,
-        10,
-        13
-      ],
-      [
-        0,
-        4,
-        6,
-        7,
-        11,
-        13
-      ],
-      [
-        0,
-        3,
-        5,
-        7,
-        10,
-        12
-      ],
-      [
-        1,
-        5,
-        6,
-        8,
-        12,
-        13
-      ]
-    ],
-    "Z": [
-      [
-        0,
-        4,
-        5,
-        7,
-        11,
-        12
-      ],
-      [
-        0,
-        1,
-        6,
-        7,
-        8,
-        13
-      ],
-      [
-        0,
-        2,
-        3,
-        7,
-        9,
-        10
-      ],
-      [
-        1,
-        3,
-        5,
-        8,
-        10,
-        12
-      ],
-      [
-        1,
-        2,
-        4,
-        8,
-        9,
-        11
-      ],
-      [
-        2,
-        5,
-        6,
-        9,
-        12,
-        13
-      ],
-      [
-        3,
-        4,
-        6,
-        10,
-        11,
-        13
-      ]
-    ]
+ "schema_version": "0.1",
+ "name": "[[14,6,2]] twisted-torus BB code (arXiv:2503.03827)",
+ "code_type": "CSS",
+ "n": 14,
+ "k": 6,
+ "checks": {
+  "X": [
+   [
+    0,
+    1,
+    2,
+    7,
+    8,
+    9
+   ],
+   [
+    1,
+    3,
+    4,
+    8,
+    10,
+    11
+   ],
+   [
+    2,
+    4,
+    5,
+    9,
+    11,
+    12
+   ],
+   [
+    2,
+    3,
+    6,
+    9,
+    10,
+    13
+   ],
+   [
+    0,
+    4,
+    6,
+    7,
+    11,
+    13
+   ],
+   [
+    0,
+    3,
+    5,
+    7,
+    10,
+    12
+   ],
+   [
+    1,
+    5,
+    6,
+    8,
+    12,
+    13
+   ]
+  ],
+  "Z": [
+   [
+    0,
+    4,
+    5,
+    7,
+    11,
+    12
+   ],
+   [
+    0,
+    1,
+    6,
+    7,
+    8,
+    13
+   ],
+   [
+    0,
+    2,
+    3,
+    7,
+    9,
+    10
+   ],
+   [
+    1,
+    3,
+    5,
+    8,
+    10,
+    12
+   ],
+   [
+    1,
+    2,
+    4,
+    8,
+    9,
+    11
+   ],
+   [
+    2,
+    5,
+    6,
+    9,
+    12,
+    13
+   ],
+   [
+    3,
+    4,
+    6,
+    10,
+    11,
+    13
+   ]
+  ]
+ },
+ "distance": {
+  "d": 2,
+  "X": {
+   "value": 2,
+   "confidence": "upper_bound",
+   "witness": [
+    2,
+    9
+   ]
   },
-  "distance": {
-    "d": 2,
-    "X": {
-      "value": 2,
-      "confidence": "upper_bound",
-      "witness": [
-        2,
-        9
-      ]
-    },
-    "Z": {
-      "value": 2,
-      "confidence": "upper_bound",
-      "witness": [
-        3,
-        10
-      ]
-    }
-  },
-  "provenance": {
-    "authors": [
-      "Zijian Liang",
-      "Ke Liu",
-      "Hao Song",
-      "Yu-An Chen"
-    ],
-    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+y, g(x,y)=1+y+x on the abelian quotient group Z^2/L with twist basis a_1=[0, 7], a_2=[1, 2] (n=2|det[a_1,a_2]|=2*7). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
-    "references": [
-      "arXiv:2503.03827"
-    ],
-    "date": "2025",
-    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
-    "origin": "baseline",
-    "novelty": "known_parameters"
-  },
-  "family": "bivariate-bicycle"
+  "Z": {
+   "value": 2,
+   "confidence": "upper_bound",
+   "witness": [
+    3,
+    10
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "Zijian Liang",
+   "Ke Liu",
+   "Hao Song",
+   "Yu-An Chen"
+  ],
+  "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+y, g(x,y)=1+y+x on the abelian quotient group Z^2/L with twist basis a_1=[0, 7], a_2=[1, 2] (n=2|det[a_1,a_2]|=2*7). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+  "references": [
+   "arXiv:2503.03827"
+  ],
+  "date": "2025",
+  "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery. 2D-local layout added 2026-07-27: simulated annealing over qubit-to-site assignments on a unit-spaced triangular grid (1 layer, capacity 1 per site per layer); measured interaction radius 3.605551 (single-layer); same code, same check matrices.",
+  "origin": "baseline",
+  "novelty": "known_parameters"
+ },
+ "family": "bivariate-bicycle",
+ "locality": {
+  "coordinates": [
+   [
+    -1.0,
+    0.0
+   ],
+   [
+    1.5,
+    0.8660254037844386
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    0.5,
+    2.598076211353316
+   ],
+   [
+    1.5,
+    -0.8660254037844386
+   ],
+   [
+    1.5,
+    2.598076211353316
+   ],
+   [
+    -0.5,
+    0.8660254037844386
+   ],
+   [
+    -1.5,
+    0.8660254037844386
+   ],
+   [
+    0.5,
+    -0.8660254037844386
+   ],
+   [
+    0.5,
+    0.8660254037844386
+   ],
+   [
+    -1.0,
+    1.7320508075688772
+   ],
+   [
+    2.0,
+    0.0
+   ],
+   [
+    2.0,
+    1.7320508075688772
+   ],
+   [
+    1.0,
+    1.7320508075688772
+   ]
+  ],
+  "interaction_radius": 3.605551275463989,
+  "layers": 1
+ }
 }


### PR DESCRIPTION
Layout-only change (#277 pattern). **[[14,6,2]] twisted-torus BB earns `local-2d-single`**: measured radius **3.6056 ≤ 4.0**, unit spacing, one qubit per site. k = 6 becomes the highest k on the `weight-6 × local-2d-single` board. g = 0.041.

Found with the annealer in #292 (`research/local2d/fold_layout.py`). Verified locally: `qldpc_verify.py` → ok, `local-2d-single`, min spacing 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)