### PR TITLE
Add single-layer 2D-local layout to [[18,4,4]]

### DIFF
--- a/codes/18-4-4.json
+++ b/codes/18-4-4.json
@@ -1,197 +1,275 @@
 {
-  "schema_version": "0.1",
-  "name": "[[18,4,4]] twisted-torus BB code (arXiv:2503.03827)",
-  "code_type": "CSS",
-  "n": 18,
-  "k": 4,
-  "checks": {
-    "X": [
-      [
-        0,
-        1,
-        4,
-        9,
-        11,
-        13
-      ],
-      [
-        1,
-        3,
-        6,
-        10,
-        13,
-        15
-      ],
-      [
-        2,
-        4,
-        7,
-        11,
-        14,
-        16
-      ],
-      [
-        0,
-        2,
-        3,
-        11,
-        12,
-        15
-      ],
-      [
-        4,
-        6,
-        8,
-        13,
-        16,
-        17
-      ],
-      [
-        1,
-        5,
-        7,
-        9,
-        10,
-        14
-      ],
-      [
-        2,
-        5,
-        6,
-        14,
-        15,
-        17
-      ],
-      [
-        3,
-        7,
-        8,
-        10,
-        12,
-        16
-      ],
-      [
-        0,
-        5,
-        8,
-        9,
-        12,
-        17
-      ]
-    ],
-    "Z": [
-      [
-        0,
-        5,
-        8,
-        9,
-        12,
-        17
-      ],
-      [
-        1,
-        5,
-        7,
-        9,
-        10,
-        14
-      ],
-      [
-        0,
-        2,
-        3,
-        11,
-        12,
-        15
-      ],
-      [
-        3,
-        7,
-        8,
-        10,
-        12,
-        16
-      ],
-      [
-        0,
-        1,
-        4,
-        9,
-        11,
-        13
-      ],
-      [
-        2,
-        5,
-        6,
-        14,
-        15,
-        17
-      ],
-      [
-        1,
-        3,
-        6,
-        10,
-        13,
-        15
-      ],
-      [
-        2,
-        4,
-        7,
-        11,
-        14,
-        16
-      ],
-      [
-        4,
-        6,
-        8,
-        13,
-        16,
-        17
-      ]
-    ]
+ "schema_version": "0.1",
+ "name": "[[18,4,4]] twisted-torus BB code (arXiv:2503.03827)",
+ "code_type": "CSS",
+ "n": 18,
+ "k": 4,
+ "checks": {
+  "X": [
+   [
+    0,
+    1,
+    4,
+    9,
+    11,
+    13
+   ],
+   [
+    1,
+    3,
+    6,
+    10,
+    13,
+    15
+   ],
+   [
+    2,
+    4,
+    7,
+    11,
+    14,
+    16
+   ],
+   [
+    0,
+    2,
+    3,
+    11,
+    12,
+    15
+   ],
+   [
+    4,
+    6,
+    8,
+    13,
+    16,
+    17
+   ],
+   [
+    1,
+    5,
+    7,
+    9,
+    10,
+    14
+   ],
+   [
+    2,
+    5,
+    6,
+    14,
+    15,
+    17
+   ],
+   [
+    3,
+    7,
+    8,
+    10,
+    12,
+    16
+   ],
+   [
+    0,
+    5,
+    8,
+    9,
+    12,
+    17
+   ]
+  ],
+  "Z": [
+   [
+    0,
+    5,
+    8,
+    9,
+    12,
+    17
+   ],
+   [
+    1,
+    5,
+    7,
+    9,
+    10,
+    14
+   ],
+   [
+    0,
+    2,
+    3,
+    11,
+    12,
+    15
+   ],
+   [
+    3,
+    7,
+    8,
+    10,
+    12,
+    16
+   ],
+   [
+    0,
+    1,
+    4,
+    9,
+    11,
+    13
+   ],
+   [
+    2,
+    5,
+    6,
+    14,
+    15,
+    17
+   ],
+   [
+    1,
+    3,
+    6,
+    10,
+    13,
+    15
+   ],
+   [
+    2,
+    4,
+    7,
+    11,
+    14,
+    16
+   ],
+   [
+    4,
+    6,
+    8,
+    13,
+    16,
+    17
+   ]
+  ]
+ },
+ "distance": {
+  "d": 4,
+  "X": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    3,
+    7,
+    14,
+    15
+   ]
   },
-  "distance": {
-    "d": 4,
-    "X": {
-      "value": 4,
-      "confidence": "upper_bound",
-      "witness": [
-        3,
-        7,
-        14,
-        15
-      ]
-    },
-    "Z": {
-      "value": 4,
-      "confidence": "upper_bound",
-      "witness": [
-        3,
-        6,
-        12,
-        17
-      ]
-    }
-  },
-  "provenance": {
-    "authors": [
-      "Zijian Liang",
-      "Ke Liu",
-      "Hao Song",
-      "Yu-An Chen"
-    ],
-    "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+xy, g(x,y)=1+y+xy on the abelian quotient group Z^2/L with twist basis a_1=[0, 3], a_2=[3, 0] (n=2|det[a_1,a_2]|=2*9). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
-    "references": [
-      "arXiv:2503.03827"
-    ],
-    "date": "2025",
-    "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery.",
-    "origin": "baseline",
-    "novelty": "known_parameters"
-  },
-  "family": "bivariate-bicycle"
+  "Z": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    3,
+    6,
+    12,
+    17
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "Zijian Liang",
+   "Ke Liu",
+   "Hao Song",
+   "Yu-An Chen"
+  ],
+  "construction": "Twisted-torus bivariate-bicycle code from Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025). Stabilizers f(x,y)=1+x+xy, g(x,y)=1+y+xy on the abelian quotient group Z^2/L with twist basis a_1=[0, 3], a_2=[3, 0] (n=2|det[a_1,a_2]|=2*9). Reconstructed from the published polynomials and twist; CSS form H_X=[f|g], H_Z=[gbar|fbar].",
+  "references": [
+   "arXiv:2503.03827"
+  ],
+  "date": "2025",
+  "notes": "Reconstructed baseline from Liang, Liu, Song, Chen, Generalized toric codes on twisted tori for quantum error correction (PRX Quantum 6, 020357, 2025), arXiv:2503.03827. The [[n,k,d]] parameter set and stabilizer polynomials are published in that paper; this entry reproduces them. Distance is an upper bound per the paper (probabilistic for d>20); the witness is the surrogate logical of that weight. Seeded to fill a board coverage gap at this block size, not a discovery. 2D-local layout added 2026-07-27: simulated annealing over qubit-to-site assignments on a unit-spaced triangular grid (1 layer, capacity 1 per site per layer); measured interaction radius 3.464102 (single-layer); same code, same check matrices.",
+  "origin": "baseline",
+  "novelty": "known_parameters"
+ },
+ "family": "bivariate-bicycle",
+ "locality": {
+  "coordinates": [
+   [
+    -1.5,
+    -0.8660254037844386
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    0.0,
+    0.0
+   ],
+   [
+    -1.0,
+    0.0
+   ],
+   [
+    -1.0,
+    -1.7320508075688772
+   ],
+   [
+    -2.0,
+    1.7320508075688772
+   ],
+   [
+    0.5,
+    0.8660254037844386
+   ],
+   [
+    -2.0,
+    -1.7320508075688772
+   ],
+   [
+    -2.5,
+    0.8660254037844386
+   ],
+   [
+    -1.5,
+    0.8660254037844386
+   ],
+   [
+    -0.5,
+    0.8660254037844386
+   ],
+   [
+    0.0,
+    -1.7320508075688772
+   ],
+   [
+    -3.0,
+    0.0
+   ],
+   [
+    -0.5,
+    -0.8660254037844386
+   ],
+   [
+    -2.0,
+    0.0
+   ],
+   [
+    0.0,
+    1.7320508075688772
+   ],
+   [
+    -2.5,
+    -0.8660254037844386
+   ],
+   [
+    -1.0,
+    1.7320508075688772
+   ]
+  ],
+  "interaction_radius": 3.4641016151377544,
+  "layers": 1
+ }
 }


### PR DESCRIPTION
Layout-only change (#277 pattern). **[[18,4,4]] twisted-torus BB earns `local-2d-single`**: measured radius **3.4641 ≤ 4.0**, unit spacing, one qubit per site. Frontier point in `weight-6 × local-2d-single` (k = 4 at d = 4); g = 0.099, second-highest qLDPC g on the single-layer board after this batch's [[12,4,2]].

Found with the annealer in #292 (`research/local2d/fold_layout.py`). Verified locally: `qldpc_verify.py` → ok, `local-2d-single`, min spacing 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)