### PR TITLE
Add bilayer 2D-local layout to [[24,6,4]] (dominates two bilayer entries, new best qLDPC g)

### DIFF
--- a/codes/24-6-4.json
+++ b/codes/24-6-4.json
@@ -237,7 +237,109 @@
    "arXiv:2306.16400",
    "arXiv:2203.17216"
   ],
-  "notes": "Parameters from the Lin-Pryadko 2BGA enumeration (arXiv:2306.16400, w=6 abelian/GB tier). Explicit polynomials reconstructed by exhaustive weight-6 GB search over C_12 with the repo research kit; distance proven exact by cutoff MILP (scipy/HiGHS). Seeded so the global frontier reflects the published state of the art (issue #52)."
+  "notes": "Parameters from the Lin-Pryadko 2BGA enumeration (arXiv:2306.16400, w=6 abelian/GB tier). Explicit polynomials reconstructed by exhaustive weight-6 GB search over C_12 with the repo research kit; distance proven exact by cutoff MILP (scipy/HiGHS). Seeded so the global frontier reflects the published state of the art (issue #52). 2D-local layout added 2026-07-27: simulated annealing over qubit-to-site assignments on a unit-spaced triangular grid (2 layers, capacity 1 per site per layer); measured interaction radius 2.645751 (bilayer); same code, same check matrices."
  },
- "family": "generalized-bicycle"
+ "family": "generalized-bicycle",
+ "locality": {
+  "coordinates": [
+   [
+    -0.5,
+    -0.8660254037844386
+   ],
+   [
+    -2.0,
+    0.0
+   ],
+   [
+    0.5,
+    0.8660254037844386
+   ],
+   [
+    0.0,
+    -1.7320508075688772
+   ],
+   [
+    0.0,
+    0.0
+   ],
+   [
+    -1.0,
+    0.0
+   ],
+   [
+    -1.0,
+    0.0
+   ],
+   [
+    -2.0,
+    0.0
+   ],
+   [
+    0.5,
+    0.8660254037844386
+   ],
+   [
+    0.0,
+    -1.7320508075688772
+   ],
+   [
+    -0.5,
+    0.8660254037844386
+   ],
+   [
+    0.5,
+    -0.8660254037844386
+   ],
+   [
+    -0.5,
+    0.8660254037844386
+   ],
+   [
+    -1.5,
+    0.8660254037844386
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    -1.0,
+    -1.7320508075688772
+   ],
+   [
+    -1.5,
+    0.8660254037844386
+   ],
+   [
+    0.5,
+    -0.8660254037844386
+   ],
+   [
+    -1.5,
+    -0.8660254037844386
+   ],
+   [
+    -0.5,
+    -0.8660254037844386
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    -1.0,
+    -1.7320508075688772
+   ],
+   [
+    -1.5,
+    -0.8660254037844386
+   ],
+   [
+    0.0,
+    0.0
+   ]
+  ],
+  "interaction_radius": 2.6457513110645907,
+  "layers": 2
+ }
 }


### PR DESCRIPTION
Layout-only change (#277 pattern). **[[24,6,4]] GB earns `local-2d-bilayer`**: measured radius **2.6458 ≤ 7.0**, 2 layers, unit spacing. On the bilayer weight-6 board it **strictly dominates [[45,5,4]] and [[50,6,4]]** (fewer qubits, ≥ k, ≥ d, same weight class), and its g = **0.0816** beats the previous best non-topological geometric efficiency on the board ([[392,8,15]] at 0.0717).

Found with the annealer in #292 (`research/local2d/fold_layout.py`). Verified locally: `qldpc_verify.py` → ok, `local-2d-bilayer`, min spacing 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)