### PR TITLE
fix: use per-code seed in distance_rand sweep (#127)

### DIFF
--- a/research/kit/search.py
+++ b/research/kit/search.py
@@ -73,7 +73,7 @@ def screen(candidates, *, min_k=1, min_d=1, trials=400, seed=0,
         if fp in seen:
             continue
         n = int(HX.shape[1])
-        d = distance_rand(HX, HZ, trials=trials, seed=seed)
+        d = distance_rand(HX, HZ, trials=trials, seed=seed + int(fp, 16))
         if d == float("inf") or d < min_d:
             continue
         w = int(max((HX.shape[0] and max((int(r.sum()) for r in HX), default=0)),


### PR DESCRIPTION
Closes #127.

Currently every candidate in a sweep shares the same RNG seed for `distance_rand`, so structurally similar codes get correlated random draws. This biases the screening ranking and Pareto frontier.

Fix: derive each code's seed from `seed + int(fingerprint, 16)`. The base `seed` is preserved as an offset, so runs remain reproducible.