### PR TITLE
Site: card layout for the board on narrow screens

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -701,7 +701,22 @@ border-bottom:1px solid var(--ln);font-size:15px}}
 margin-left:8px}}
 .board td.star{{display:none}}
 .board td.auth{{max-width:none}}
-.board td.typecell{{flex-wrap:wrap}}}}
+.board td.typecell{{flex-wrap:wrap}}
+/* n, k, d are already printed inside the [[n,k,d]] name: drop their rows */
+.board td.col-n,.board td.col-k,.board td.col-d{{display:none}}
+/* date: small, in the card's top-right corner */
+.board tr{{position:relative}}
+.board td.date{{position:absolute;top:12px;right:14px;width:auto;padding:0;
+font-size:11.5px;color:var(--mut)}}
+.board td.date::before{{content:none}}
+.board td.codecell{{padding-right:92px}}
+/* kd2/n, g, w: a horizontal stat trio — big value, small label beneath
+   (column-reverse puts the ::before label under the number) */
+.board td.m3{{display:inline-flex;flex-direction:column-reverse;
+align-items:center;justify-content:flex-start;gap:3px;width:32.8%;
+padding:9px 0 5px;font-size:19px;font-weight:700;
+font-variant-numeric:tabular-nums;text-align:center}}
+.board td.m3::before{{font-size:10.5px}}}}
 /* phones: reclaim horizontal space and shrink oversized headers */
 @media(max-width:560px){{.wrap{{padding:0 14px}}
 header.hero{{padding:34px 0 30px}}
@@ -2873,15 +2888,15 @@ def board_table(entries, records):
             f'<td class="num col-n" data-label="n">{e["n"]}</td>'
             f'<td class="num col-k" data-label="k">{e["k"]}</td>'
             f'<td class="num col-d" data-label="d">{badge(e["tier"])} {e["d"]}</td>'
-            f'<td class=num data-label="kd&sup2;/n">{e["eff"]}</td>'
-            + (f'<td class=num data-label="g" title="r = {e["geo_r"]}, {e["geo_rho"]} '
+            f'<td class="num m3" data-label="kd&sup2;/n">{e["eff"]}</td>'
+            + (f'<td class="num m3" data-label="g" title="r = {e["geo_r"]}, {e["geo_rho"]} '
                f'layer{"s" if e["geo_rho"] != 1 else ""}'
                f'{"; inherits the upper-bound distance tier" if e["tier"] != "exact" else ""}">'
                f'{e["geo"]:.3g}</td>'
                if e["geo"] is not None else
-               '<td class=num data-label="g" title="no verified layout; geometric '
+               '<td class="num m3" data-label="g" title="no verified layout; geometric '
                'efficiency undefined (not necessarily an expander code)">&middot;</td>')
-            + f'<td class=num data-label="w">{e["w"]}</td>'
+            + f'<td class="num m3" data-label="w">{e["w"]}</td>'
             f'<td class="auth col-auth" data-label="authors" '
             f'title="{html.escape(e["authors"])}">'
             f'{authors_compact(e["authors_list"])}</td>'

--- a/site/build.py
+++ b/site/build.py
@@ -675,21 +675,33 @@ vertical-align:middle}}
    narrow screens (where the table sets its own min-width). */
 .boardscroll{{max-height:64vh;overflow:auto;-webkit-overflow-scrolling:touch;
 border:1px solid var(--ln);border-radius:12px}}
-@media(max-width:880px){{table.board{{table-layout:auto;min-width:600px}}
-.board .model{{display:none}}}}
-@media(max-width:680px){{.board .date{{display:none}}}}
-/* phones: the board was cut off in a horizontal scroll with the scored columns
-   (kd2/n, w) off-screen. n, k and d are already printed inside the [[n,k,d]]
-   code name, type/authors live on each row's detail page, and g is undefined
-   (a dot) for most unrestricted codes, so drop those columns here and let the
-   four that matter (code, kd2/n, w, plus the record star) fit the viewport
-   with no sideways scroll. */
-@media(max-width:620px){{
-.board .col-type,.board .col-n,.board .col-k,.board .col-d,
-.board .col-auth,.board .col-geo{{display:none}}
-table.board{{min-width:0;font-size:13px}}
-.board th,.board td{{padding:.5rem .45rem;white-space:normal}}
-.board td.auth{{max-width:none}}}}
+@media(max-width:1000px){{table.board{{table-layout:auto;min-width:820px}}}}
+/* Narrow screens: rather than drop columns (and hide g, a headline metric)
+   into a horizontal scroll, each row becomes a card so every field stays
+   visible (issue #305, PR #312 review). The header is dropped; each cell
+   carries its own label via data-label. */
+@media(max-width:820px){{
+.boardscroll{{max-height:none;overflow:visible;border:0;border-radius:0}}
+table.board,.board tbody,.board tr,.board td{{display:block;width:auto}}
+table.board{{min-width:0;font-size:13px;margin:12px 0}}
+.board thead{{display:none}}
+.board tr{{border:1px solid var(--ln);border-radius:12px;margin:0 0 10px;
+padding:12px 14px 10px;background:var(--soft)}}
+.board tr.fr{{border-color:var(--ac)}}
+.board td{{display:flex;justify-content:space-between;align-items:baseline;
+gap:16px;padding:3px 0;border:0;white-space:normal;text-align:right}}
+.board td::before{{content:attr(data-label);color:var(--mut);flex:0 0 auto;
+font-family:'Space Mono',ui-monospace,monospace;font-size:11px;
+text-transform:uppercase;letter-spacing:.04em;text-align:left}}
+.board td.num{{text-align:right}}
+.board td.codecell{{justify-content:flex-start;padding:0 0 8px;margin:0 0 6px;
+border-bottom:1px solid var(--ln);font-size:15px}}
+.board td.codecell::before{{content:none}}
+.board tr.fr td.codecell::after{{content:"\\2605";color:var(--ac);
+margin-left:8px}}
+.board td.star{{display:none}}
+.board td.auth{{max-width:none}}
+.board td.typecell{{flex-wrap:wrap}}}}
 /* phones: reclaim horizontal space and shrink oversized headers */
 @media(max-width:560px){{.wrap{{padding:0 14px}}
 header.hero{{padding:34px 0 30px}}
@@ -2797,7 +2809,7 @@ def board_table(entries, records):
             '<th data-c=d class="num col-d" title="distance">d</th>'
             '<th data-c=eff class=num title="operational efficiency '
             'k&middot;d&sup2;/n, higher is better">kd&sup2;/n</th>'
-            '<th data-c=geo class="num col-geo" title="geometric efficiency '
+            '<th data-c=geo class=num title="geometric efficiency '
             'g = 4kd&sup2;/(n&rho;&sup2;r&#8308;), priced by the verified '
             'layout&rsquo;s interaction radius r and layers &rho;; surface '
             'code = 1; &middot; = no verified layout">g</th>'
@@ -2857,22 +2869,23 @@ def board_table(entries, records):
                f'not a novelty claim">{HEX_MARK}</span>'
                if e["origin"] != "baseline" else "")
             + novelty
-            + f'</td><td class="typecell col-type">{chips(e)}</td>'
-            f'<td class="num col-n">{e["n"]}</td>'
-            f'<td class="num col-k">{e["k"]}</td>'
-            f'<td class="num col-d">{badge(e["tier"])} {e["d"]}</td>'
-            f'<td class=num>{e["eff"]}</td>'
-            + (f'<td class="num col-geo" title="r = {e["geo_r"]}, {e["geo_rho"]} '
+            + f'</td><td class="typecell col-type" data-label="type">{chips(e)}</td>'
+            f'<td class="num col-n" data-label="n">{e["n"]}</td>'
+            f'<td class="num col-k" data-label="k">{e["k"]}</td>'
+            f'<td class="num col-d" data-label="d">{badge(e["tier"])} {e["d"]}</td>'
+            f'<td class=num data-label="kd&sup2;/n">{e["eff"]}</td>'
+            + (f'<td class=num data-label="g" title="r = {e["geo_r"]}, {e["geo_rho"]} '
                f'layer{"s" if e["geo_rho"] != 1 else ""}'
                f'{"; inherits the upper-bound distance tier" if e["tier"] != "exact" else ""}">'
                f'{e["geo"]:.3g}</td>'
                if e["geo"] is not None else
-               '<td class="num col-geo" title="no verified layout; geometric '
+               '<td class=num data-label="g" title="no verified layout; geometric '
                'efficiency undefined (not necessarily an expander code)">&middot;</td>')
-            + f'<td class=num>{e["w"]}</td>'
-            f'<td class="auth col-auth" title="{html.escape(e["authors"])}">'
+            + f'<td class=num data-label="w">{e["w"]}</td>'
+            f'<td class="auth col-auth" data-label="authors" '
+            f'title="{html.escape(e["authors"])}">'
             f'{authors_compact(e["authors_list"])}</td>'
-            '<td class=model>'
+            '<td class=model data-label="model">'
             + (f'<span class=modelmark title="{html.escape(e["model"])}">'
                f'{CLAUDE_MARK if e["model"].startswith("Claude") else ""}'
                f'<span class=modelname>{html.escape(e["model"])}</span></span>'
@@ -2880,7 +2893,7 @@ def board_table(entries, records):
                else f'<span class=nomodel title="classical construction, no AI '
                     f'model">{HUMAN_MARK}</span>')
             + '</td>'
-            f'<td class=date>{html.escape(e["date"]) if e["date"] else "&middot;"}</td></tr>')
+            f'<td class=date data-label="date">{html.escape(e["date"]) if e["date"] else "&middot;"}</td></tr>')
 
     return (f'<div class=boardscroll><table class=board id=mainboard>{cols}{head}'
             f'<tbody>{"".join(rows)}</tbody></table></div>')

--- a/site/build.py
+++ b/site/build.py
@@ -680,12 +680,13 @@ border:1px solid var(--ln);border-radius:12px}}
 @media(max-width:680px){{.board .date{{display:none}}}}
 /* phones: the board was cut off in a horizontal scroll with the scored columns
    (kd2/n, w) off-screen. n, k and d are already printed inside the [[n,k,d]]
-   code name, and type/authors live on each row's detail page, so drop those
-   columns here and let the four that matter (code, kd2/n, w, plus the record
-   star) fit the viewport with no sideways scroll. */
+   code name, type/authors live on each row's detail page, and g is undefined
+   (a dot) for most unrestricted codes, so drop those columns here and let the
+   four that matter (code, kd2/n, w, plus the record star) fit the viewport
+   with no sideways scroll. */
 @media(max-width:620px){{
 .board .col-type,.board .col-n,.board .col-k,.board .col-d,
-.board .col-auth{{display:none}}
+.board .col-auth,.board .col-geo{{display:none}}
 table.board{{min-width:0;font-size:13px}}
 .board th,.board td{{padding:.5rem .45rem;white-space:normal}}
 .board td.auth{{max-width:none}}}}
@@ -2796,7 +2797,7 @@ def board_table(entries, records):
             '<th data-c=d class="num col-d" title="distance">d</th>'
             '<th data-c=eff class=num title="operational efficiency '
             'k&middot;d&sup2;/n, higher is better">kd&sup2;/n</th>'
-            '<th data-c=geo class=num title="geometric efficiency '
+            '<th data-c=geo class="num col-geo" title="geometric efficiency '
             'g = 4kd&sup2;/(n&rho;&sup2;r&#8308;), priced by the verified '
             'layout&rsquo;s interaction radius r and layers &rho;; surface '
             'code = 1; &middot; = no verified layout">g</th>'
@@ -2861,13 +2862,13 @@ def board_table(entries, records):
             f'<td class="num col-k">{e["k"]}</td>'
             f'<td class="num col-d">{badge(e["tier"])} {e["d"]}</td>'
             f'<td class=num>{e["eff"]}</td>'
-            + (f'<td class=num title="r = {e["geo_r"]}, {e["geo_rho"]} '
+            + (f'<td class="num col-geo" title="r = {e["geo_r"]}, {e["geo_rho"]} '
                f'layer{"s" if e["geo_rho"] != 1 else ""}'
                f'{"; inherits the upper-bound distance tier" if e["tier"] != "exact" else ""}">'
                f'{e["geo"]:.3g}</td>'
                if e["geo"] is not None else
-               '<td class=num title="no verified layout; geometric efficiency '
-               'undefined (not necessarily an expander code)">&middot;</td>')
+               '<td class="num col-geo" title="no verified layout; geometric '
+               'efficiency undefined (not necessarily an expander code)">&middot;</td>')
             + f'<td class=num>{e["w"]}</td>'
             f'<td class="auth col-auth" title="{html.escape(e["authors"])}">'
             f'{authors_compact(e["authors_list"])}</td>'

--- a/site/build.py
+++ b/site/build.py
@@ -716,7 +716,16 @@ font-size:11.5px;color:var(--mut)}}
 align-items:center;justify-content:flex-start;gap:3px;width:32.8%;
 padding:9px 0 5px;font-size:19px;font-weight:700;
 font-variant-numeric:tabular-nums;text-align:center}}
-.board td.m3::before{{font-size:10.5px}}}}
+.board td.m3::before{{font-size:10.5px}}
+/* unlabeled rows: chips and byline speak for themselves */
+.board td.typecell::before,.board td.auth::before,
+.board td.model::before{{content:none}}
+.board td.typecell{{justify-content:flex-start}}
+/* bottom line: authors on the left, model on the right, one row */
+.board td.auth{{display:inline-flex;width:57%;justify-content:flex-start;
+text-align:left}}
+.board td.model{{display:inline-flex;width:42%;justify-content:flex-end;
+text-align:right}}}}
 /* phones: reclaim horizontal space and shrink oversized headers */
 @media(max-width:560px){{.wrap{{padding:0 14px}}
 header.hero{{padding:34px 0 30px}}


### PR DESCRIPTION
Closes #305. Updated per @willzeng's review.

Rather than drop the `g` column on phones (it is one of the two headline metrics, and hiding it would suggest the challenge ignores locality), the board now switches to a card layout on narrow screens (<=820px), the same pattern ECDSA.fail uses: each row becomes a card with every field shown as a labeled line (type, n, k, d, kd^2/n, g, w, authors, model, date), no horizontal scroll and nothing dropped. The record star moves onto the card title. Each `td` carries a `data-label`; the header row is hidden in card mode. The desktop table is unchanged.

Rendered at 390px (cards) and 1240px (table) and eyeballed.