### PR TITLE
Layout hover: click cycles through overlapping checks

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1560,7 +1560,9 @@ def layout_svg(doc):
         legend.append('<span><span class=rg></span>2 qubits stacked '
                       f'({loc.get("layers", 2)} layers)</span>')
     legend.append('<span>dashed: the pair setting the interaction radius</span>')
-    legend.append('<span>hover a check to isolate its qubits; click to pin</span>')
+    legend.append('<span>hover a check to isolate its qubits; click to pin '
+                  '&mdash; repeated clicks cycle through overlapping checks; '
+                  'click empty space to release</span>')
     legend.append('</div>')
     return '<div class=layoutfig>' + "".join(parts) + "".join(legend) + '</div>'
 
@@ -1754,8 +1756,16 @@ def detail_page(e):
              "svg.querySelectorAll('.lo-chk').forEach(el=>{"
              "el.addEventListener('mouseenter',()=>{if(!pin)show(el);});"
              "el.addEventListener('mouseleave',()=>{if(!pin)clear();});"
+             # click cycles through ALL checks under the cursor (topmost
+             # first), so a polygon buried under later-drawn ones is still
+             # reachable; click empty space to release
              "el.addEventListener('click',e=>{e.stopPropagation();"
-             "if(pin===el){pin=null;clear();}else{pin=el;show(el);}});});"
+             "const stack=document.elementsFromPoint(e.clientX,e.clientY)"
+             ".filter(x=>x.classList&&x.classList.contains('lo-chk')"
+             "&&svg.contains(x));"
+             "if(!stack.length)return;"
+             "const i=pin?stack.indexOf(pin):-1;"
+             "pin=stack[(i+1)%stack.length];show(pin);});});"
              "svg.addEventListener('click',()=>{if(pin){pin=null;clear();}});"
              "});"
              "</script>")


### PR DESCRIPTION
Follow-up fix to #310. A check drawn early sits at the bottom of the SVG stacking order, and on heavily overlapping figures its entire area can be covered by later-drawn polygons — hover only ever reaches the topmost element, so such a check was unreachable. Concrete case: on [[12,4,2]], the check {0,1,4,6,8,10} that attains r = 2.6458 could not be highlighted at all.

**Fix:** clicking now walks the full `document.elementsFromPoint` stack under the cursor (topmost first, wrapping), so repeated clicks cycle through every check covering that spot. Hover behavior is unchanged (topmost, instant); clicking empty space still releases the pin. Legend text updated to explain the cycling.

Validated on the [[12,4,2]] page (the buried radius-attaining check is now reachable in a few clicks), `make build` clean, `make test-fast` 6/6. `docs/` regenerates on merge as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)