### PR TITLE
heuristic_distance CLI: --fast-trials flag, auto-scaling, and a skip warning

### DIFF
--- a/verify/heuristic_distance.py
+++ b/verify/heuristic_distance.py
@@ -93,7 +93,15 @@ def ris_min_logical(HX, HZ, trials, seed, pair_depth=8, max_seconds=None):
 
 
 def estimate(doc, trials=20000, seed=0, fast_trials=400000, max_seconds=None):
-    """Heuristic distance verdict for a submission `doc`."""
+    """Heuristic distance verdict for a submission `doc`.
+
+    ``trials`` is the pure-Python RIS budget per side; ``fast_trials`` is the
+    gf2_fast accelerator's overall budget, used only when it exceeds ``trials``
+    (the fast path reports weights, not witnesses, so it must out-search the
+    Python pass to add anything). Pass ``fast_trials=0`` to disable the
+    accelerator explicitly (refute_check does: the CI gate is pure Python with
+    a fixed seed, so it stays deterministic). Any other skipped-accelerator
+    combination warns on stderr -- see issue #290."""
     n = doc["n"]
     HX = _matrix(doc["checks"]["X"], n)
     HZ = _matrix(doc["checks"]["Z"], n)
@@ -114,6 +122,11 @@ def estimate(doc, trials=20000, seed=0, fast_trials=400000, max_seconds=None):
     d_heur = min([w for w in (wX, wZ) if w is not None], default=None)
 
     method = "ris"
+    if _fast is not None and 0 < fast_trials <= trials:
+        print(f"warning: gf2_fast is available but skipped "
+              f"(fast_trials={fast_trials} <= trials={trials}); raise "
+              f"--fast-trials or lower --trials to use the accelerator "
+              f"(fast_trials=0 disables it deliberately)", file=sys.stderr)
     # Optional C++ accelerator: a larger overall search (min over both sides).
     if _fast is not None and fast_trials > trials:
         d_fast = int(_fast.distance_rand_parallel(HX, HZ, fast_trials, seed, 8, 8))
@@ -167,9 +180,14 @@ def refute_check(doc, seed=0, max_seconds=10.0, trials=None):
     return refuted, dh, witness, res["trials"]
 
 
-def main(path, trials, seed):
+def main(path, trials, seed, fast_trials=None):
     doc = json.load(open(path))
-    res = estimate(doc, trials=trials, seed=seed)
+    # A bigger --trials budget must never silently turn the accelerator off
+    # (issue #290): unless --fast-trials is given explicitly, scale the fast
+    # budget with the requested depth. --fast-trials 0 forces pure Python.
+    if fast_trials is None:
+        fast_trials = max(400000, 4 * trials)
+    res = estimate(doc, trials=trials, seed=seed, fast_trials=fast_trials)
     print(json.dumps(res, indent=2))
     return 2 if res["verdict"] == "refuted" else 0
 
@@ -177,7 +195,11 @@ def main(path, trials, seed):
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("path")
-    ap.add_argument("--trials", type=int, default=20000)
+    ap.add_argument("--trials", type=int, default=20000,
+                    help="pure-Python RIS trials per side (default 20000)")
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--fast-trials", type=int, default=None,
+                    help="gf2_fast overall trial budget (default: "
+                         "max(400000, 4*trials)); 0 disables the accelerator")
     args = ap.parse_args()
-    sys.exit(main(args.path, args.trials, args.seed))
+    sys.exit(main(args.path, args.trials, args.seed, args.fast_trials))

--- a/verify/test_heuristic_distance.py
+++ b/verify/test_heuristic_distance.py
@@ -92,6 +92,42 @@ def main(argv):
     print("  refutation", "OK" if ok else "FAILED")
     failures += 0 if ok else 1
 
+    print("\n=== fast-path gating (issue #290) ===")
+    import contextlib
+    import io
+    doc = json.load(open(os.path.join(ROOT, "codes", "16-2-4.json")))
+    # explicit fast_trials=0 is the deterministic-gate opt-out: no accelerator,
+    # and no warning (refute_check relies on this staying silent in CI logs)
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        res = H.estimate(doc, trials=200, seed=0, fast_trials=0)
+    ok = res["method"] == "ris" and err.getvalue() == ""
+    print(f"  fast_trials=0: method={res['method']} warned={bool(err.getvalue())}",
+          "OK" if ok else "  <<< explicit disable must stay silent")
+    failures += 0 if ok else 1
+    if H._fast is not None:
+        # accelerator importable but out-budgeted: must warn on stderr
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            res = H.estimate(doc, trials=200, seed=0, fast_trials=100)
+        ok = "gf2_fast is available but skipped" in err.getvalue()
+        print(f"  fast_trials<trials: warned={ok}",
+              "OK" if ok else "  <<< silent skip is issue #290")
+        failures += 0 if ok else 1
+        # CLI default must scale the fast budget with --trials instead of
+        # letting a deep --trials run silently drop to pure Python
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            H.main(os.path.join(ROOT, "codes", "16-2-4.json"),
+                   trials=200, seed=0)
+        method = json.loads(out.getvalue())["method"]
+        ok = method == "ris+gf2_fast"
+        print(f"  CLI default: method={method}",
+              "OK" if ok else "  <<< CLI no longer engages the accelerator")
+        failures += 0 if ok else 1
+    else:
+        print("  gf2_fast not importable here; accelerator cases skipped")
+
     print(f"\n{failures} failure(s)")
     sys.exit(1 if failures else 0)
 

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -3,7 +3,7 @@
   "files": {
     "validate_candidate.py": "ea4430bacb9c5e68b5bac66f56d9a82e83f0ba8823b1357288b26972ce8842b8",
     "qldpc_verify.py": "9556db914d3f4607c99c66afe66f7c6673bae513e0fa9c2f99614e018db2ad06",
-    "heuristic_distance.py": "25082a1ae6ae44a4c62eabd8670bea0d828da9173ed0b98968661562da2331d7",
+    "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",
     "check_validator_integrity.py": "36c248ca70d0a64fdad5548a36b15e326ee4b24e60a20e08d37499428882a195"
   }


### PR DESCRIPTION
Closes #290.

The footgun: the gf2_fast path only runs when `fast_trials > trials`, and the CLI exposed no way to raise `fast_trials` past its 400k default — so `--trials 2000000` (the natural way to ask for a deeper search) silently dropped to pure Python, ~100× slower, with `"method": "ris"` as the only trace.

**Changes** (both fixes suggested in the issue):

- **CLI**: new `--fast-trials` flag. When omitted, the fast budget scales as `max(400000, 4·trials)`, so a deeper `--trials` always engages the accelerator. `--fast-trials 0` forces pure Python explicitly.
- **estimate()**: warns on stderr when gf2_fast is importable but out-budgeted. An explicit `fast_trials=0` stays silent — that's `refute_check`'s deliberate configuration (the CI gate is pure Python with a fixed seed for determinism), and **gate behavior is byte-for-byte unchanged**.
- **Tests**: three new gating cases in `test_heuristic_distance.py` — explicit-0 is silent, a skipped accelerator warns, and the CLI default engages the fast path.
- **`validator_manifest.json` re-pinned** (`check_validator_integrity.py --update`) since `heuristic_distance.py` is in the trusted closure — the hash diff is the reviewable record of this change.

Full suite: `make test-fast` 6/6; the panel corroborates on both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)