### PR TITLE
Docs: route newcomers from the README to the paths that already exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,16 @@ machinery can vouch for today, and rises as the tooling improves.
 
 If you have an LLM or coding agent, it can do the whole loop: pick a target,
 search for a code, verify it, and open the PR. This is the lowest-effort way in.
-Paste the prompt below into your agent. The method follows IBM's LLM-guided
+Paste the prompt below into your agent.
+
+A note on scope: here your agent acts on *your* behalf, so it may open the PR
+from your account (you are the author of record and CI checks that the PR
+author is listed in the code's `authors`). This is different from the in-repo
+autoresearch manual, [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md),
+whose stage-only rule (never commit to `codes/`, never open a PR) governs
+autonomous research runs where no human has reviewed the candidate yet. If
+your agent reads both documents: this section wins for a contributor-driven
+submission; AUTORESEARCH.md wins for an unattended search. The method follows IBM's LLM-guided
 evolutionary search for these codes (arXiv:2606.02418): the model mutates the
 program that generates a code, rather than tweaking numbers by hand.
 
@@ -114,8 +123,9 @@ codes. Goal: find a CSS qLDPC code that advances a frontier, and submit it.
 
 1. Clone https://github.com/unitaryfoundation/qldpc-challenge. Read TRACKS.md
    (the tracks and the "Reference bars" section, which lists the live bars to
-   beat) and the research/ starter kit (code constructors, the RIS distance
-   surrogate, submission packaging). Pick one target from the reference bars.
+   beat) and research/AUTORESEARCH.md, the manual for the research/ starter
+   kit (code constructors, the RIS distance surrogate, submission packaging).
+   Pick one target from the reference bars.
 
 2. Search a construction family. Represent each candidate as a small Python
    program that generates (H_X, H_Z), and mutate that generator (its

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,8 @@ autoresearch manual, [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md),
 whose stage-only rule (never commit to `codes/`, never open a PR) governs
 autonomous research runs where no human has reviewed the candidate yet. If
 your agent reads both documents: this section wins for a contributor-driven
-submission; AUTORESEARCH.md wins for an unattended search. The method follows IBM's LLM-guided
+submission; AUTORESEARCH.md wins for an unattended search. 
+The method follows IBM's LLM-guided
 evolutionary search for these codes (arXiv:2606.02418): the model mutates the
 program that generates a code, rather than tweaking numbers by hand.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ against each other (physical qubits n, logical qubits k, distance d, check
 weight, geometric locality). So the boards are a computed grid of locality class
 by check weight (membership derived from the parity checks and the layout, not
 self-declared), and within each cell the ranking is a Pareto frontier rather than
-one winner. Construction family is a separate filter tag. See `TRACKS.md`.
+one winner. Construction family is a separate filter tag. See
+[`TRACKS.md`](TRACKS.md).
+
+## Start here
+
+| You want to... | Read |
+|---|---|
+| Submit a code you already have | [`CONTRIBUTING.md`](CONTRIBUTING.md) — one command: `./qldpc submit` |
+| Have an LLM find and submit a code | [Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) (a ready-to-paste prompt) and [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md) (the full research-loop manual) |
+| Understand the boards and the targets to beat | [`TRACKS.md`](TRACKS.md) — especially the "Reference bars" section |
+| Point a coding agent at this repo | [`AGENTS.md`](AGENTS.md) |
+
+Before starting a search, `./qldpc recent` summarizes what landed lately
+(codes, research notes, fieldnotes), so you begin from the community's current
+frontier of knowledge rather than rediscovering it.
 
 ## Installation
 
@@ -55,8 +69,20 @@ uv run python research/test_smoke.py   # the starter-kit loop, end to end
 
 ## Submitting
 
-A submission is one JSON file in `codes/`, following `schema/code.schema.json`
-(explained in `schema/SCHEMA.md`). Open a pull request adding it. CI runs the
+You bring parity checks `H_X` and `H_Z`; one command turns them into a
+verified, PR-ready submission:
+
+```bash
+./qldpc submit mycode.npz --authors @yourhandle
+```
+
+It computes n and k, finds the distance witness for you, assembles the
+schema-valid JSON, runs the full verifier locally (the same gate CI runs), and
+writes `codes/<n>-<k>-<d>.json`. If verification fails, nothing is written and
+you see exactly which check failed. [`CONTRIBUTING.md`](CONTRIBUTING.md) has
+all the flags (layouts, provenance, `--open-pr`) and the full walkthrough.
+
+A submission is one JSON file in `codes/`, one new code per PR. CI re-runs the
 verifier; a green check means the code's cheap, trustless properties are
 confirmed:
 
@@ -70,8 +96,21 @@ confirmed:
 Claiming a distance is exact (not just an upper bound) additionally requires
 server certification, a separate and more expensive step.
 
-Verify locally before opening a PR (uv handles the environment):
+Prefer to write the JSON yourself? Follow `schema/code.schema.json`
+(`schema/SCHEMA.md` documents each field — see the "By hand" section of
+[`CONTRIBUTING.md`](CONTRIBUTING.md)) and verify locally before opening a PR:
 
 ```
 uv run python verify/qldpc_verify.py codes/your-code.json
 ```
+
+## Bring your LLM
+
+If you have an LLM or coding agent, it can do the whole loop — pick a target
+from the reference bars, search a construction family, verify locally, and
+open the PR from your account. This is the lowest-effort way to participate:
+paste the ready-made prompt from
+[Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) into your
+agent. The tool-agnostic operating manual for the research loop (constructors,
+the distance surrogate, packaging, and the validation gate) is
+[`research/AUTORESEARCH.md`](research/AUTORESEARCH.md).

--- a/research/AUTORESEARCH.md
+++ b/research/AUTORESEARCH.md
@@ -242,7 +242,10 @@ should not have to re-learn.
 - Labeled honestly: `confidence: upper_bound`; novelty vs literature flagged unverified;
   "advances this board cell," not "discovery."
 - **Staged for review — never committed to `codes/`, never a PR.** The human decides what lands
-  (and opens any PR — see `../CONTRIBUTING.md`).
+  (and opens any PR — see `../CONTRIBUTING.md`). This stage-only rule governs unattended
+  autoresearch runs; a contributor driving their own agent interactively submits under
+  `../CONTRIBUTING.md` instead ("Contribute with an LLM"), where the agent may open the PR
+  from the contributor's account.
 
 ## Output & housekeeping
 


### PR DESCRIPTION
## Why

A fresh-eyes usability review of the onboarding docs found that the individual documents are strong (the one-command CLI in CONTRIBUTING.md, the paste-in LLM prompt, the AUTORESEARCH.md manual) but the README — the GitHub landing page — links to none of them. A newcomer saw only the hand-written-JSON path and had no discoverable route to the easy paths, in particular the "bring your LLM" path.

## What

**README.md**
- New **"Start here"** doc map right after the intro: four role-based rows (submit a code / have an LLM find one / understand the tracks and reference bars / point a coding agent at the repo), plus a pointer to `./qldpc recent`.
- **Submitting** now leads with `./qldpc submit mycode.npz --authors @yourhandle` (the path CONTRIBUTING.md already recommends); hand-written JSON is demoted to a pointer at CONTRIBUTING's "By hand" section. The trustless-verification bullets are kept unchanged.
- New short **"Bring your LLM"** section linking the paste-in prompt and `research/AUTORESEARCH.md`.
- `TRACKS.md` is now an actual link.

**CONTRIBUTING.md**
- The "Contribute with an LLM" section now states the PR-policy scope explicitly: a contributor's own agent acts on their behalf and may open the PR; unattended autoresearch runs are governed by AUTORESEARCH.md's stage-only rule. Previously the two docs gave an agent reading both contradictory instructions with no stated reason.
- Step 1 of the paste-in prompt now names `research/AUTORESEARCH.md` (the actual manual for the starter kit it tells the agent to read).

**research/AUTORESEARCH.md**
- Matching one-sentence scope note on the stage-only rule in "Definition of done".

No behavior, code, or policy changes — only routing and one clarification of an existing (implicit) policy boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)