### PR TITLE
Site: fit the explorer to one viewport instead of pinning the plots

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -519,12 +519,11 @@ border-top:1px solid var(--ln);scroll-margin-top:16px}}
 .plots{{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
 gap:16px;margin:14px 0 4px;position:relative}}
 .geotabs{{position:absolute;top:2px;right:2px;z-index:6;display:flex;gap:6px}}
-/* Pin the scatters to the top while the table scrolls beneath, so the
-   point<->row hover highlight stays visible. The table header sticks within
-   its own scroll box (a separate scroll context), so no header offset needed.
-   Desktop only; on phones the plots scroll away to save vertical space. */
-@media(min-width:760px){{.explorer .plots{{position:sticky;top:0;z-index:5;
-background:var(--bg);padding:8px 0 6px;margin-top:0}}}}
+/* The plots were position:sticky here (#273) so the point<->row hover
+   highlight stayed visible while the table scrolled. But the opaque pinned
+   plots covered the table and leaderboard whenever plots + legend + table
+   outgrew the viewport (issue #302). The both-on-screen effect now comes from
+   fitting the explorer to one viewport instead; see .explorer by .boardscroll. */
 .plot{{min-width:0;border:1px solid var(--ln);border-radius:12px;
 background:#fff;padding:8px}}
 .chartlegend{{display:flex;flex-wrap:wrap;gap:10px 20px;margin:10px 0 4px;
@@ -678,6 +677,18 @@ vertical-align:middle}}
    narrow screens (where the table sets its own min-width). */
 .boardscroll{{max-height:64vh;overflow:auto;-webkit-overflow-scrolling:touch;
 border:1px solid var(--ln);border-radius:12px}}
+/* On screens tall enough to fit plots + legend + a useful slice of the table,
+   size the explorer to exactly one viewport: plots and legend keep their
+   natural height and the board's scroll box absorbs the remainder, so plots
+   and table are on screen together (the row-hover -> point highlight from
+   #273) without anything sliding underneath anything (issue #302). Shorter
+   screens keep normal flow -- the plots scroll away and the 64vh box above
+   applies -- so the flex column is never over-constrained into overlapping
+   the leaderboard below. Width gate matches the card-layout breakpoint. */
+@media(min-width:821px) and (min-height:800px){{
+.explorer{{display:flex;flex-direction:column;max-height:100vh}}
+.explorer>*{{flex:0 0 auto}}
+.explorer .boardscroll{{flex:1 1 auto;min-height:240px;max-height:none}}}}
 @media(max-width:1000px){{table.board{{table-layout:auto;min-width:820px}}}}
 /* Narrow screens: rather than drop columns (and hide g, a headline metric)
    into a horizontal scroll, each row becomes a card so every field stays
@@ -3152,7 +3163,7 @@ def build():
              '&middot; <b>w</b> max check weight</span>'
              '</div>')
     P.append(board_table(entries, records))
-    P.append('</div>')  # close explorer (bounds the sticky plots)
+    P.append('</div>')  # close explorer (the viewport-fitted plots+table column)
     P.append(contributors_panel(entries))  # leaderboard sits below the table
     P.append('</div>')  # close the main content wrap; footer is full-width
     P.append(


### PR DESCRIPTION
Fixes #302.

The scatters were made `position:sticky` in #273 so the point↔row hover highlight stayed visible while the table scrolled. But the pinned plots have an opaque background, so whenever plots + legend + the 64vh board box outgrew the viewport (two plot rows at medium widths, short screens), the code table and leaderboard slid underneath them and were hidden — the behavior Mathys reported.

**The fix**

- Drop the sticky rule entirely.
- On screens tall enough to fit everything (≥821px wide, ≥800px tall), `.explorer` becomes a flex column capped at `100vh`: plots and legend keep their natural height and the board's scroll box absorbs the remainder (240px floor). Plots and table are always on screen together — the #273 hover-sync still works — and nothing can be occluded.
- Shorter screens keep normal document flow (the plots scroll away; the existing 64vh board box applies) rather than over-constraining the flex column into overlapping the leaderboard below it. The width gate matches the existing 820px card-layout breakpoint.

**Not addressed here**: the mobile issue raised in the #302 comments (the card list from #312 buries the leaderboard below 150+ cards) is a separate regression and should get its own issue/PR.

Site generator only (`site/build.py`); `docs/` is rebuilt by CI on merge. Verified locally: rebuilt the site and checked the emitted CSS and the explorer's child structure (`.plots`, `.plotx`, `.chartlegend`, `.legend`, `.boardscroll` are all direct flex children).

🤖 Generated with [Claude Code](https://claude.com/claude-code)