### PR TITLE
Site: consistent shading between the kd^2/n and g track views

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -609,7 +609,9 @@ padding:3px 0;color:var(--ink)}}
 color:var(--ac);font-weight:700;flex:1 1 auto}}
 .gitem .geff{{font-size:11px;color:var(--mut);font-variant-numeric:tabular-nums}}
 .gitem.ghide{{display:none}}
-.pt-geo .gitem[data-ref]{{opacity:.45}}
+/* Reference surface/toric tilings render with the same shading in both the
+   kd^2/n and g views; in the g view they are distinguished by sorting last
+   (JS) and by their tooltip, not by a colour change, so the two views match. */
 .ptbar{{display:flex;justify-content:flex-end;margin:0 0 8px}}
 .gempty{{background:repeating-linear-gradient(45deg,#fafafa 0 6px,#fff 6px 12px)}}
 .searchbar{{display:flex;align-items:center;gap:12px;margin:14px 0 8px}}


### PR DESCRIPTION
The primary-tracks grid dimmed the reference surface/toric tilings to 45% opacity in the g view only (`.pt-geo .gitem[data-ref]{opacity:.45}`). That made the weight-4 column, and any cell holding a reference, look faded and differently coloured than the same grid in the kd^2/n view, which reads as an inconsistency.

This drops the opacity rule so both views shade every code identically (same green `d =` badge, same code colour). The references are still distinguished in the g view by sorting last (the JS `v-1e9` penalty) and by their tooltip, just no longer by a colour change.

Tradeoff worth a second opinion: this removes the visual "these are the reference ceiling, not raced" cue. If the team wants to keep marking references, a subtler non-colour tag would preserve consistency better than the opacity dim. Rendered both views at desktop width and confirmed they now match.

Site generator only (`site/build.py`); `docs/` rebuilt by CI on merge.