### PR TITLE
refs: add Hong ZSZ-LP codes (arXiv:2607.27644)

### DIFF
--- a/refs.bib
+++ b/refs.bib
@@ -391,3 +391,15 @@
   primaryClass  = {quant-ph},
   note          = {arXiv:2607.25865}
 }
+
+@misc{hong2026zszlp,
+  title         = {Quantum {LDPC} codes with design rate 1/5 and good
+                   performance below 1000 physical qubits},
+  author        = {Hong, Yifan},
+  year          = {2026},
+  eprint        = {2607.27644},
+  archivePrefix = {arXiv},
+  primaryClass  = {quant-ph},
+  note          = {arXiv:2607.27644; ZSZ-LP balanced-product codes over
+                   metacyclic groups}
+}


### PR DESCRIPTION
Adds the reference for Hong, "Quantum LDPC codes with design rate 1/5 and good performance below 1000 physical qubits" (arXiv:2607.27644).

Directly relevant to the board: a rate-1/5, check-weight-9 balanced-product (ZSZ-LP) family over non-abelian metacyclic Z_l x| Z_m groups, the same construction as Mathys's #343 submission. Its Table 1 lists explicit [[n,k,d]] instances at n <= 700 with kd^2/n up to ~65 (e.g. [[320,64,14]] at 39.2, [[390,78,<=16]] at 51.2, [[550,110,<=18]] at 64.8), several of which would advance the board if seeded.