### PR TITLE
Certify 23 small codes as exact (d<= -> d=)

### DIFF
--- a/certs/102-33-3.json
+++ b/certs/102-33-3.json
@@ -1,0 +1,17 @@
+{
+ "d_exact": true,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d": 3
+}

--- a/certs/12-4-2.json
+++ b/certs/12-4-2.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[12,4,2]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 2,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 2,
+   "exact": true,
+   "note": "no logical < 2 exists"
+  },
+  "Z": {
+   "value": 2,
+   "exact": true,
+   "note": "no logical < 2 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/14-6-2.json
+++ b/certs/14-6-2.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[14,6,2]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 2,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 2,
+   "exact": true,
+   "note": "no logical < 2 exists"
+  },
+  "Z": {
+   "value": 2,
+   "exact": true,
+   "note": "no logical < 2 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/15-7-3.json
+++ b/certs/15-7-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[15,7,3]] quantum Hamming code, single-layer 2D-local layout",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/16-6-4.json
+++ b/certs/16-6-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[16,6,4]] quantum Reed-Muller code, single-layer 2D-local layout",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/18-4-4.json
+++ b/certs/18-4-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[18,4,4]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/19-1-5.json
+++ b/certs/19-1-5.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[19,1,5]] triangular 6.6.6 colour code, single-layer 2D-local layout",
+ "d": 5,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  },
+  "Z": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/30-4-6.json
+++ b/certs/30-4-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[30,4,6]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 6,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/32-8-4.json
+++ b/certs/32-8-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[32,8,4]] two-block group algebra CSS (arXiv:2306.16400)",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/37-1-7.json
+++ b/certs/37-1-7.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[37,1,7]] triangular 6.6.6 colour code, single-layer 2D-local layout",
+ "d": 7,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/42-8-3.json
+++ b/certs/42-8-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,8,3]] generalized bicycle code",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/45-9-3.json
+++ b/certs/45-9-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[45,9,3]]",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/48-4-8.json
+++ b/certs/48-4-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[48,4,8]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/51-12-3.json
+++ b/certs/51-12-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[51,12,3]] HP ham7xsham6",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/56-2-8.json
+++ b/certs/56-2-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[56,2,8]] generalized bicycle code",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/58-16-3.json
+++ b/certs/58-16-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[58,16,3]]",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/60-8-6.json
+++ b/certs/60-8-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[60,8,6]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 6,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/62-10-6.json
+++ b/certs/62-10-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[62,10,6]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 6,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/65-17-3.json
+++ b/certs/65-17-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[65,17,3]]",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/70-6-8.json
+++ b/certs/70-6-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[70,6,8]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/80-16-4.json
+++ b/certs/80-16-4.json
@@ -1,0 +1,17 @@
+{
+ "d_exact": true,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d": 4
+}

--- a/certs/87-22-3.json
+++ b/certs/87-22-3.json
@@ -1,0 +1,17 @@
+{
+ "d_exact": true,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d": 3
+}

--- a/certs/88-8-7.json
+++ b/certs/88-8-7.json
@@ -1,0 +1,17 @@
+{
+ "d_exact": true,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d": 7
+}


### PR DESCRIPTION
Exact-distance certificates for 23 board codes, upgrading them from witness-backed upper bounds to certified exact (the green d= badge). Addresses the spirit of #274 for the codes small enough to close.

Produced by a gentle `verify/certify.py` sweep (scipy/HiGHS MILP), each certificate proves no logical operator lighter than the claimed distance exists on either side. Adds files under `certs/` only (no code changes). Codes whose MILP did not finish in budget (e.g. n=180 from #274, and a handful of n~50-100) are left as honest upper bounds.

Certs are data, not new code submissions, so this is a single batch PR (CI submission-scope check passes).