### PR TITLE
refs: add mitten codes (arXiv:2607.28795)

### DIFF
--- a/refs.bib
+++ b/refs.bib
@@ -403,3 +403,16 @@
   note          = {arXiv:2607.27644; ZSZ-LP balanced-product codes over
                    metacyclic groups}
 }
+
+@misc{bhardwaj2026mitten,
+  title         = {High-rate {qLDPC} processors},
+  author        = {Bhardwaj, Aditya and Ma, Muzhou and Meister, Nadine and
+                   King, Robbie and Bluvstein, Dolev and Preskill, John and
+                   Cain, Madelyn and Xu, Qian and Huang, Hsin-Yuan},
+  year          = {2026},
+  eprint        = {2607.28795},
+  archivePrefix = {arXiv},
+  primaryClass  = {quant-ph},
+  note          = {arXiv:2607.28795; mitten codes, non-abelian lifted-product
+                   qLDPC processors}
+}


### PR DESCRIPTION
Adds the reference for Bhardwaj, Ma, Meister, King, Bluvstein, Preskill, Cain, Xu, Huang, "High-rate qLDPC processors" (arXiv:2607.28795), from issue #377.

Mitten codes: non-abelian lifted-product qLDPC codes, 20% rate, check weight 9, reaching distance 18+ below 1000 qubits. Table I lists eight instances including [[300,60,14]] (kd^2/n = 39.2) and [[540,108,18]] (kd^2/n = 64.8) at n <= 700, both of which would advance the board. Construction and code data are open-sourced; seeding the codes themselves is tracked separately in #377.