### PR TITLE
TRACKS: cite mitten codes as reference bars (#377)

### DIFF
--- a/TRACKS.md
+++ b/TRACKS.md
@@ -157,6 +157,16 @@ surface code to 1, but they answer different questions.
   rather than seeded (their distance witnesses are not published and the verifier
   does not certify distance at these sizes). The challenge is to land a code in
   this regime with a checkable distance witness.
+- High-rate, weight-9 (any connectivity): the mitten codes of Bhardwaj et al
+  (arXiv:2607.28795), non-abelian lifted-product codes at 20% rate, reach
+  [[300,60,14]] (kd^2/n ~ 39.2) and [[540,108,18]] (kd^2/n ~ 64.8) at n <= 700,
+  and [[975,195,<=24]] beyond the cap. Cited as bars for now rather than seeded:
+  the construction is fully specified (a 1x2 base matrix over F_2[G] for a
+  non-abelian group G, per their Definition 4), and the per-code group and
+  generators are published in the paper's tables and open-source toolkit, so a
+  faithful reconstruction with a checkable witness is possible and is tracked as
+  follow-up (#377). The paper evaluates these at the circuit level (logical error
+  rate under noise), not by kd^2/n.
 
 ## Baselines and provenance
 


### PR DESCRIPTION
Addresses issue #377 (add arXiv:2607.28795 results) by citing the mitten codes in the reference-bars section of TRACKS.md, alongside the Kasai and tile-code bars.

The mitten codes ([[300,60,14]] kd^2/n 39.2, [[540,108,18]] kd^2/n 64.8 at n<=700; [[975,195,<=24]] beyond the cap) are strong high-rate weight-9 codes that would advance the board. Unlike Kasai/tile, their construction is fully published (Definition 4: a 1x2 base matrix over F_2[G] for a non-abelian G, with per-code groups in Table I and generators in the appendix + open-source toolkit), so a faithful reconstruction with a checkable distance witness is possible. Cited as bars now; seeding the actual codes is the follow-up (see #377).

Reference added separately in #378.