### PR TITLE
Fix pre-convention attribution: [[294,8,19]] and [[320,6,28]]

### DIFF
--- a/codes/294-8-19.json
+++ b/codes/294-8-19.json
@@ -3006,9 +3006,9 @@
  },
  "provenance": {
   "authors": [
-   "Antigravity",
    "@FarLab"
   ],
+  "model": "Gemini 3.1 Pro",
   "construction": "Generalized Bicycle code on Metacyclic group (n=49, k=3, r=18).",
   "references": [
    "Autoresearch"


### PR DESCRIPTION
`codes/294-8-19.json` listed `authors: ["Antigravity", "@FarLab"]` with no `model` field — a pre-convention entry. Antigravity is the agent/IDE, not an author; the model behind it was Gemini 3.1 Pro (per @FarLab).

- `authors`: now `["@FarLab"]` (humans only)
- `model`: now `"Gemini 3.1 Pro"` (version-specific, per the schema's guidance)

Same convention as every entry from PRs #121/#122 onward. One-line diff; no change to the code itself (verifier re-run locally: ok). The by-model view of the record chart will now attribute this entry correctly.

Attribution: Claude Fable 5 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)