### PR TITLE
Fix [[320,6,28]] attribution: model belongs in provenance.model, not authors

### DIFF
--- a/codes/320-6-28.json
+++ b/codes/320-6-28.json
@@ -3283,9 +3283,9 @@
  },
  "provenance": {
   "authors": [
-   "Claude-autoresearch",
    "@FarLab"
   ],
+  "model": "Claude Opus 4.8",
   "construction": "2BGA on metacyclic group (n=16, k=10, r=7), a=[56, 72, 46, 104], b=[54, 60, 152, 11]",
   "references": [
    "autoresearch sweep 2026-07-02"


### PR DESCRIPTION
Follow-up to #389, which merged before the second commit landed on its branch — the [[320,6,28]] fix never reached main. Same pre-convention issue as [[294,8,19]]:

- `authors`: `["Claude-autoresearch", "@FarLab"]` → `["@FarLab"]` (humans only)
- `model`: now `"Claude Opus 4.8"` (the 2026-07-02 autoresearch sweep, confirmed by @FarLab)

One-line diff, no change to the code itself; verifier re-run locally: ok. This was the last pre-convention entry — a scan of all non-baseline codes found no others.

Attribution: Claude Fable 5 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)