### PR TITLE
notes: record the mitten rediscovery of [[150,30,10]]

### DIFF
--- a/notes/150-30-10.md
+++ b/notes/150-30-10.md
@@ -34,3 +34,29 @@ Model/harness: GPT 5.6 Sol via OpenAI Codex. The reproduction used the paper's P
 ## Reproduction
 
 Use ZSZ parameters (ell1, ell2, q)=(15, 2, 11) and group relation yx=x^11y. Set a=1+x^11+x^12y, b=1+y+x^6y, c=1+x^3+x^11, d=1+x^6+x^14y. Form H_left=(L[a] L[b]) and H_right=(R[c] R[d]), then use the five-block balanced-product matrices in arXiv:2607.27644v1. The submitted JSON contains the resulting sparse checks and logical witnesses.
+
+## Independently rediscovered as a mitten code
+
+The mitten codes of [arXiv:2607.28795](https://arxiv.org/abs/2607.28795)
+(Bhardwaj et al., Table I) include a [[150,30,10]] weight-9 instance built as a
+lifted product over C5 x S3. The challenge verifier's Weisfeiler-Leman dedup
+gate flags it as equivalent to this entry, so the two papers, published within
+days of each other in July 2026, arrived at the same code up to relabeling.
+
+The reason is that the two groups are the same. Writing Z15 = Z3 x Z5 by CRT,
+the action x -> 11x of this entry's ZSZ(15,2,11) splits across the factors:
+11 = -1 (mod 3) inverts the 3-part, and 11 = 1 (mod 5) fixes the 5-part (with
+11^2 = 1 mod 15, so the order-2 action is valid). Hence
+
+    Z15 x|_11 Z2  =  (Z3 x|_-1 Z2) x Z5  =  S3 x C5,
+
+which is the mitten group. Independently: both tables have order 30, are
+non-abelian, and share the element-order profile (1:1, 2:3, 3:2, 5:4, 10:12,
+15:8); the three involutions alone identify C5 x S3 among the four groups of
+order 30 (D30 has 15, C3 x D10 has 5, C30 is abelian).
+
+So the balanced/lifted product over ZSZ(15,2,11) and the mitten lifted product
+over C5 x S3 are the same construction in different notation. This entry keeps
+priority; the mitten seeding of arXiv:2607.28795 therefore contributes five
+codes to the board rather than six (issue #377).
+


### PR DESCRIPTION
From #377. The mitten codes of arXiv:2607.28795 (Table I) include a [[150,30,10]] weight-9 instance over C5 x S3, which @FarLab found the WL dedup gate flags as equivalent to @yifanhong's existing `codes/150-30-10.json` (ZSZ-LP from arXiv:2607.27644). The mitten seed PR was withdrawn as a duplicate.

Rather than lose that in a closed PR, this records the convergence in the existing note, with the reason the two constructions coincide:

By CRT, Z15 = Z3 x Z5, and the ZSZ(15,2,11) action x -> 11x splits across the factors (11 = -1 mod 3 inverts the 3-part, 11 = 1 mod 5 fixes the 5-part, 11^2 = 1 mod 15), so `Z15 x|_11 Z2 = (Z3 x|_-1 Z2) x Z5 = S3 x C5`, the mitten group. I verified this independently by building both Cayley tables: same order, both non-abelian, identical element-order profiles, and the three involutions alone identify C5 x S3 among the four groups of order 30.

Two independent July-2026 papers landing on the same code is worth a permanent cross-reference. The entry keeps priority with @yifanhong; this is editorial, no code data changes. Note is 5.5 KiB, under the 10 KiB cap, and renders on the code page.

@yifanhong, flagging since this appends to your note.