### PR TITLE
schema: allow model ensembles and new family tags

### DIFF
--- a/schema/code.schema.json
+++ b/schema/code.schema.json
@@ -4,80 +4,206 @@
   "title": "qLDPC code submission",
   "description": "A single CSS qLDPC code submission. Parity checks are given as sparse supports (lists of qubit indices). Distance claims must carry a self-certifying witness operator for the upper-bound tier.",
   "type": "object",
-  "required": ["schema_version", "name", "code_type", "n", "k", "checks", "distance", "provenance"],
+  "required": [
+    "schema_version",
+    "name",
+    "code_type",
+    "n",
+    "k",
+    "checks",
+    "distance",
+    "provenance"
+  ],
   "additionalProperties": false,
   "properties": {
-    "schema_version": {"const": "0.1"},
-    "name": {"type": "string", "minLength": 1, "maxLength": 200},
-    "code_type": {"enum": ["CSS"]},
-    "n": {"type": "integer", "minimum": 1, "maximum": 700, "description": "number of physical (data) qubits; capped at 700 by the verification-budget rule (issue #249)"},
-    "k": {"type": "integer", "minimum": 1, "description": "claimed number of logical qubits; verifier recomputes exactly"},
+    "schema_version": {
+      "const": "0.1"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "code_type": {
+      "enum": [
+        "CSS"
+      ]
+    },
+    "n": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 700,
+      "description": "number of physical (data) qubits; capped at 700 by the verification-budget rule (issue #249)"
+    },
+    "k": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "claimed number of logical qubits; verifier recomputes exactly"
+    },
     "checks": {
       "type": "object",
-      "required": ["X", "Z"],
+      "required": [
+        "X",
+        "Z"
+      ],
       "additionalProperties": false,
       "properties": {
-        "X": {"$ref": "#/$defs/supportList"},
-        "Z": {"$ref": "#/$defs/supportList"}
+        "X": {
+          "$ref": "#/$defs/supportList"
+        },
+        "Z": {
+          "$ref": "#/$defs/supportList"
+        }
       }
     },
     "distance": {
       "type": "object",
-      "required": ["d", "X", "Z"],
+      "required": [
+        "d",
+        "X",
+        "Z"
+      ],
       "additionalProperties": false,
       "description": "a claimed d needs witnesses for both sides to certify the upper bound.",
       "properties": {
-        "d": {"type": "integer", "minimum": 1, "description": "claimed code distance = min(dX, dZ)"},
-        "X": {"$ref": "#/$defs/sideDistance"},
-        "Z": {"$ref": "#/$defs/sideDistance"}
+        "d": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "claimed code distance = min(dX, dZ)"
+        },
+        "X": {
+          "$ref": "#/$defs/sideDistance"
+        },
+        "Z": {
+          "$ref": "#/$defs/sideDistance"
+        }
       }
     },
     "locality": {
       "type": "object",
       "description": "optional; required only for the 2d-local tracks",
-      "required": ["coordinates"],
+      "required": [
+        "coordinates"
+      ],
       "additionalProperties": false,
       "properties": {
         "coordinates": {
           "type": "array",
           "description": "one [x, y] per qubit, indexed 0..n-1",
           "maxItems": 5000,
-          "items": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
         },
-        "layers": {"type": "integer", "minimum": 1, "description": "physical layers (e.g. 2 for flip-chip bilayer)"},
-        "interaction_radius": {"type": "number", "minimum": 0, "description": "claimed max check diameter in the layout; verifier recomputes"}
+        "layers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "physical layers (e.g. 2 for flip-chip bilayer)"
+        },
+        "interaction_radius": {
+          "type": "number",
+          "minimum": 0,
+          "description": "claimed max check diameter in the layout; verifier recomputes"
+        }
       }
     },
     "provenance": {
       "type": "object",
-      "required": ["authors", "construction"],
+      "required": [
+        "authors",
+        "construction"
+      ],
       "additionalProperties": false,
       "properties": {
-        "authors": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
         "origin": {
-          "enum": ["baseline", "submission"],
+          "enum": [
+            "baseline",
+            "submission"
+          ],
           "description": "baseline: a published code seeded for comparison. submission: a code contributed through the challenge. Defaults to submission when omitted."
         },
         "novelty": {
-          "enum": ["unknown", "known_parameters", "new_parameters"],
+          "enum": [
+            "unknown",
+            "known_parameters",
+            "new_parameters"
+          ],
           "description": "optional literature-novelty status for submitted codes. known_parameters means the [[n,k,d]] parameter set exists in the literature even if this entry improves weight, layout, or construction details. new_parameters is a submitter/reviewer claim, not a verifier-proved fact."
         },
-        "construction": {"type": "string", "minLength": 1, "description": "how the code was built (family, polynomials, search, reference)"},
-        "model": {"type": "string", "maxLength": 80, "description": "optional, self-reported: the AI model that produced the code, named to a specific version (e.g. 'Claude Opus 4.8', not a bare 'Claude'), or 'human'. Claimed, not verified -- there is no way to certify which model generated a result, but if one is named the verifier requires a version so the claim is reproducible."},
-        "references": {"type": "array", "items": {"type": "string"}},
-        "date": {"type": "string", "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$", "description": "publication date for a literature baseline (a year is enough) or submission date (YYYY-MM-DD) for a contribution"},
-        "notes": {"type": "string"}
+        "construction": {
+          "type": "string",
+          "minLength": 1,
+          "description": "how the code was built (family, polynomials, search, reference)"
+        },
+        "model": {
+          "oneOf": [
+            {
+              "type": "string",
+              "maxLength": 80
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "maxLength": 80
+              },
+              "minItems": 1,
+              "maxItems": 8
+            }
+          ],
+          "description": "optional, self-reported: the AI model that produced the code, named to a specific version (e.g. 'Claude Opus 4.8', not a bare 'Claude'), or 'human'. Claimed, not verified -- there is no way to certify which model generated a result, but if one is named the verifier requires a version so the claim is reproducible. May also be a list when a code was produced by an ensemble of models rather than a single one; the site joins them for display."
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "date": {
+          "type": "string",
+          "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+          "description": "publication date for a literature baseline (a year is enough) or submission date (YYYY-MM-DD) for a contribution"
+        },
+        "notes": {
+          "type": "string"
+        }
       }
     },
     "family": {
       "type": "string",
-      "enum": ["bivariate-bicycle", "generalized-bicycle", "2bga-coset", "hypergraph-product", "lifted-product", "balanced-product", "quantum-tanner", "tile", "topological", "other"],
-      "description": "construction family (Layer 2). Self-declared, since it cannot be recovered from H, and used only as a filterable tag, never for ranking. Topological covers surface/toric/color (say which in provenance.construction). See TRACKS.md."
+      "description": "construction family (Layer 2). Self-declared, since it cannot be recovered from H, and used only as a filterable tag, never for ranking. Topological covers surface/toric/color (say which in provenance.construction). See TRACKS.md. The listed examples are the established vocabulary and should be reused where they fit, since the site filters on them. A construction that genuinely does not fit may use a new lowercase-hyphenated tag rather than being flattened into 'other'; please open an issue so the vocabulary and the site's labels can follow.",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "examples": [
+        "bivariate-bicycle",
+        "generalized-bicycle",
+        "2bga-coset",
+        "hypergraph-product",
+        "lifted-product",
+        "balanced-product",
+        "quantum-tanner",
+        "tile",
+        "topological",
+        "other"
+      ]
     },
     "tracks": {
       "type": "array",
       "minItems": 0,
-      "items": {"type": "string"},
+      "items": {
+        "type": "string"
+      },
       "description": "deprecated and ignored for ranking. Track membership (the locality and weight classes) is computed by the verifier from H and the layout; this self-declared field is retained only for backward compatibility. See TRACKS.md."
     }
   },
@@ -88,24 +214,40 @@
       "maxItems": 10000,
       "items": {
         "type": "array",
-        "items": {"type": "integer", "minimum": 0},
+        "items": {
+          "type": "integer",
+          "minimum": 0
+        },
         "minItems": 1,
         "maxItems": 32
       }
     },
     "sideDistance": {
       "type": "object",
-      "required": ["value", "confidence", "witness"],
+      "required": [
+        "value",
+        "confidence",
+        "witness"
+      ],
       "additionalProperties": false,
       "properties": {
-        "value": {"type": "integer", "minimum": 1},
+        "value": {
+          "type": "integer",
+          "minimum": 1
+        },
         "confidence": {
-          "enum": ["upper_bound", "exact"],
+          "enum": [
+            "upper_bound",
+            "exact"
+          ],
           "description": "upper_bound: self-certified by the witness. exact: also requires server certification; treated as upper_bound until confirmed."
         },
         "witness": {
           "type": "array",
-          "items": {"type": "integer", "minimum": 0},
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
           "minItems": 1,
           "description": "support of a nontrivial logical operator of this Pauli type achieving `value`. X-witness lives in ker(H_Z) and outside rowspace(H_X); Z-witness mirrors."
         }

--- a/site/build.py
+++ b/site/build.py
@@ -1235,6 +1235,14 @@ def geo_score(doc, n, k, d, locality_class):
     return 4.0 * k * d * d / (n * rho * rho * r ** 4), r, rho
 
 
+def _model_str(m):
+    """provenance.model may be a single name or a list (an ensemble of models);
+    the rest of the site treats it as one display string."""
+    if isinstance(m, (list, tuple)):
+        return ", ".join(str(x) for x in m)
+    return m or ""
+
+
 def load_entries():
     entries = []
     for p in sorted(glob.glob(os.path.join(ROOT, "codes", "*.json"))):
@@ -1279,7 +1287,7 @@ def load_entries():
             "novelty": doc["provenance"].get("novelty", "unknown"),
             "authors": ", ".join(doc["provenance"]["authors"]),
             "authors_list": doc["provenance"]["authors"],
-            "model": doc["provenance"].get("model", ""),
+            "model": _model_str(doc["provenance"].get("model", "")),
             "date": doc["provenance"].get("date", ""),
             "construction": doc["provenance"].get("construction", ""),
             "note_md": load_note(slug),

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -27,6 +27,7 @@ What "verified" means per field:
 """
 
 import json
+import re
 import math
 import os
 import secrets
@@ -297,8 +298,12 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     # nothing reproducible, "Claude Opus 4.8" does. Omitting it (a human or unknown
     # author) is fine; "human" is the explicit non-model sentinel.
     model = (doc.get("provenance") or {}).get("model")
+    if isinstance(model, (list, tuple)):
+        # an ensemble of models: every named member must carry a version
+        model = ", ".join(str(x) for x in model)
     if model and model.strip() and model.strip().lower() != "human":
-        specific = any(ch.isdigit() for ch in model)
+        specific = all(any(ch.isdigit() for ch in part)
+                       for part in model.split(",") if part.strip())
         record("model_version_specified", specific,
                model if specific else
                f"'{model}' names no version; give the exact model, e.g. "
@@ -307,10 +312,19 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     # Layer-2 family tag: optional, but if present must be from the vocabulary.
     family = doc.get("family")
     if family is not None:
-        record("family_in_vocabulary", family in _FAMILIES,
-               family if family in _FAMILIES
-               else f"'{family}' is not a known family; use one of "
-               f"{sorted(_FAMILIES)}")
+        known = family in _FAMILIES
+        # A genuinely new construction should not be forced into "other" just
+        # because the vocabulary has not caught up. Accept a well-formed new tag
+        # and flag it for review; the family is a filter, never a ranking input.
+        wellformed = bool(re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", str(family)))
+        record("family_in_vocabulary", known or wellformed,
+               family if known
+               else f"'{family}' is a new family tag, accepted but not yet in "
+                    "the vocabulary; please open an issue so the tracks and the "
+                    "site labels can follow"
+               if wellformed
+               else f"'{family}' is malformed; use a lowercase-hyphenated tag, "
+                    f"e.g. one of {sorted(_FAMILIES)}")
 
     novelty = (doc.get("provenance") or {}).get("novelty")
     if novelty is not None:

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -2,7 +2,7 @@
   "_comment": "Pinned SHA-256 of the trusted autoresearch validation stack. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
     "validate_candidate.py": "ea4430bacb9c5e68b5bac66f56d9a82e83f0ba8823b1357288b26972ce8842b8",
-    "qldpc_verify.py": "9556db914d3f4607c99c66afe66f7c6673bae513e0fa9c2f99614e018db2ad06",
+    "qldpc_verify.py": "00490f5f4de0ad503b363dc1766c9438b1ae67d238fd35906e197c5ff856dcd1",
     "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",
     "check_validator_integrity.py": "36c248ca70d0a64fdad5548a36b15e326ee4b24e60a20e08d37499428882a195"


### PR DESCRIPTION
Addresses two taxonomy gaps raised in the external feedback thread (Juan Cruz-Benito, IBM):

> some codes may have been discovered by an ensemble of LLMs rather than a single model, and there are code families (such as our PBB codes) that do not appear to be covered at present. I do not see this as a blocker, but I think it is worth noting, particularly if the catalog, PR process, or schema enforces any of these categories too rigidly.

Both were real. `provenance.model` was a single string capped at 80 characters, and `family` was a closed 10-value enum enforced by **both** the schema and `qldpc_verify.py`, so a new construction could only be recorded as `other`.

**Model ensembles.** `provenance.model` now accepts a string or a list of strings. The verifier joins a list before its checks and requires *every* named member to carry a version, so the existing "name a specific version, not a bare vendor name" rule is unweakened: `["Claude Opus 4.8", "GPT-5.5"]` passes, `["Claude", "GPT"]` is rejected. The site normalises a list to one display string at its single load point.

**New families.** `family` keeps the established vocabulary as `examples` and accepts any lowercase-hyphenated tag. The verifier accepts a well-formed new tag with a message saying it is not yet in the vocabulary and asking for an issue, while still rejecting malformed input like `"Bad Family!"`. The family is a filter and never a ranking input, so nothing is gamed by allowing a new tag, and a genuinely new construction is no longer flattened into `other`.

Verified: all 204 board codes still validate against the schema and pass the verifier unchanged; the three new cases behave as intended; `run_tests.py --skip-slow` passes 6/6. `validator_manifest.json` is re-pinned because the trusted stack changed. Schema and validation only, no code submissions, so this is deliberately separate from any `codes/` PR.