### PR TITLE
site: compact model ensembles so they stop overrunning the date column (#407)

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -681,11 +681,18 @@ color:var(--ink);min-width:2.4em;text-align:right}}
 .star{{color:var(--ac);width:18px}}
 .auth{{color:var(--mut);font-size:13px}}
 .board td.date{{color:var(--mut);font-size:13px;white-space:nowrap}}
-.board td.model{{color:var(--mut);font-size:13px;white-space:nowrap}}
+/* nowrap keeps the row one line; the table is table-layout:fixed, so without
+   the clip a name wider than the column paints over the date cell (#407).
+   models_compact() already shortens ensembles -- this bounds the single-name
+   case too, at any font size. */
+.board td.model{{color:var(--mut);font-size:13px;white-space:nowrap;
+overflow:hidden;text-overflow:ellipsis}}
 .nomodel{{color:#94a3b8;display:inline-flex;vertical-align:middle}}
 .modelmark,.modelicon{{display:inline-flex;align-items:center;gap:5px;
 vertical-align:middle}}
-.board td.model .modelname{{font-size:13px;color:var(--ink)}}
+.board td.model .modelname{{font-size:13px;color:var(--ink);
+overflow:hidden;text-overflow:ellipsis;min-width:0}}
+.board td.model .modelmark{{max-width:100%}}
 /* Let the wide board scroll instead of crushing columns, and progressively
    drop the secondary metadata columns (model, then date) on smaller screens.
    Under the breakpoints the table sizes to content so freed space redistributes
@@ -1577,6 +1584,29 @@ def authors_compact(lst):
         return authors_html(lst)
     surname = html.escape(lst[0].split(",")[0].strip())
     return f'{surname} <span class=etal>et al.</span>'
+
+
+def model_parts(model):
+    """The individual models behind a display string. An ensemble reaches the
+    site either as a JSON list (joined with ', ' by _model_str) or, for the
+    older free-text entries, as one string with ' + ' between the names."""
+    parts = [p.strip() for p in re.split(r"\s*\+\s*|\s*,\s*", model or "")]
+    return [p for p in parts if p]
+
+
+def models_compact(model):
+    """Compact model display for the board, the same bargain authors_compact
+    strikes: one line per row. A single model renders in full; an ensemble
+    shows the first name and a '+N' badge. The full list is on the detail page
+    and in the cell's hover title. Without this an ensemble overruns the fixed
+    column width and paints over the date column (issue #407)."""
+    parts = model_parts(model)
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return html.escape(parts[0])
+    return (f'{html.escape(parts[0])} '
+            f'<span class=etal>+{len(parts) - 1}</span>')
 
 
 def layout_svg(doc):
@@ -3215,7 +3245,8 @@ def board_table(entries, records):
             '<td class=model data-label="model">'
             + (f'<span class=modelmark title="{html.escape(e["model"])}">'
                f'{CLAUDE_MARK if e["model"].startswith("Claude") else ""}'
-               f'<span class=modelname>{html.escape(e["model"])}</span></span>'
+               f'<span class=modelname>{models_compact(e["model"])}</span>'
+               f'</span>'
                if e["model"]
                else f'<span class=nomodel title="classical construction, no AI '
                     f'model">{HUMAN_MARK}</span>')


### PR DESCRIPTION
Fixes #407.

### Why it happened

`table.board` is `table-layout:fixed` with the model column at 14%, and `.board td.model` is `white-space:nowrap`. A model string wider than that column therefore could neither wrap nor widen the column — it simply painted over the date cell, which is what the screenshot in the issue shows. A single model name fits, so this only surfaced once ensembles arrived: `Claude Opus 4.6 + GPT-5.3-Codex + Gemini 3.1 Pro Preview` is 56 characters against a column sized for roughly 20.

### The fix

The authors column already solves exactly this problem — `authors_compact()`, whose docstring states the rule as "so every row is one line": it collapses a long author list to `Surname et al.` and keeps the full list in the cell's hover title and on the detail page. `models_compact()` follows that precedent: a single model renders in full, an ensemble renders as its first name plus a `+N` badge.

Nothing is lost. The full ensemble stays in the cell's `title`, on the code's detail page, and — importantly — in the row's `data-model` attribute, so searching the board for `gemini` still matches a row whose visible cell reads `Claude Opus 4.6 +2`.

Ensembles reach the site two ways: as a JSON list, joined with `, ` by `_model_str()` since #409, and as a single free-text string with ` + ` between names, which is what the seven codes currently on the board use. `model_parts()` splits on both.

I also added `overflow:hidden;text-overflow:ellipsis` to the cell. Compaction already handles the ensemble case; the clip is the structural guarantee, bounding a single long name at any font size so nothing can paint over a neighbouring column again.

### Verification

Built the site locally and checked the rendered output:

| visible in cell | hover title |
|---|---|
| `Claude Opus 4.6 +2` | `Claude Opus 4.6 + GPT-5.2 + Gemini 3 Pro Preview` |
| `Claude Opus 4.6 +2` | `Claude Opus 4.6 + GPT-5.3-Codex + Gemini 3.1 Pro Preview` |

Every single-model row is unchanged (`Claude Fable 5`, `Tencent Hy3`, `Xiaomi MiMo-V2.5`, …), the detail page for `288-32-8` still shows the full ensemble, and `data-model` still carries the full lowercased string for search. Helper checked against empty input, a plain name, a JSON list, both separators, stray whitespace, and an HTML-injection attempt (escaping holds). `run_tests.py`: 6/6 files pass.

No `docs/` changes are included — the `site` workflow rebuilds and commits the generated pages on push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
