### PR TITLE
TRACKS: add a reference bar for the ZSZ-LP family (arXiv:2607.27644)

### DIFF
--- a/TRACKS.md
+++ b/TRACKS.md
@@ -175,22 +175,24 @@ surface code to 1, but they answer different questions.
 - High-rate, weight-9, second construction: the ZSZ-LP codes of
   arXiv:2607.27644, balanced products of rate-1/2 classical LDPC codes sharing a
   non-abelian Z_l1 semidirect_q Z_l2 symmetry, also at 20% rate and check weight
-  9. Twelve of the paper's fourteen instances fit under the n <= 700 cap and are
-  seeded as baselines, from [[60,12,6]] up to [[700,140,22]]. The paper's
-  distances are SAT-exact through [[320,64,14]] and upper bounds above it,
-  which the board's per-side confidence fields mirror. The remaining two
-  exceed the cap and stay bars only: [[775,155,<=22]] (kd^2/n ~ 96.8) and
-  [[840,168,<=24]] (~115.2). Its Table 3 lists the group parameters
-  (l1, l2, q) and the trinomials a, b, c, d for every instance, so the seeded
-  entries are reconstructions rather than parameter claims.
+  9. Twelve of the paper's fourteen instances fit under the n <= 700 cap, from
+  [[60,12,6]] up to [[700,140,22]]. Unlike the mitten entries above these are
+  not baselines: the paper's author submitted them directly (#357 to #368), so
+  they carry origin `submission`. The paper's distances are SAT-exact through
+  [[320,64,14]] and upper bounds above it, which the board's per-side
+  confidence fields mirror. The remaining two exceed the cap and stay bars
+  only: [[775,155,<=22]] (kd^2/n ~ 96.8) and [[840,168,<=24]] (~115.2). Its
+  Table 3 lists the group parameters (l1, l2, q) and the trinomials a, b, c, d
+  for every instance, and each submission repeats its own generators in its
+  construction string, so every entry is checkable against the paper rather
+  than a bare parameter claim.
   This family and the mitten codes above reach the same design point by
   different routes: both sit at rate 1/5 with weight-9 checks, and since
   kd^2/n = rate * d^2, their over-cap bars coincide numerically at any shared
   distance (96.8 at d = 22, 115.2 at d = 24). [[150,30,10]] is not merely
   comparable but the same code in both papers.
-  Codes built with this construction but not taken from the paper are board
-  submissions in their own right rather than baselines, such as [[270,54,10]]
-  over ZSZ(18,3,13).
+  [[270,54,10]] over ZSZ(18,3,13) uses this construction without being a paper
+  instance, so it is an independent submission rather than a reproduction.
 
 ## Baselines and provenance
 

--- a/TRACKS.md
+++ b/TRACKS.md
@@ -157,18 +157,40 @@ surface code to 1, but they answer different questions.
   rather than seeded (their distance witnesses are not published and the verifier
   does not certify distance at these sizes). The challenge is to land a code in
   this regime with a checkable distance witness.
-- High-rate, weight-9 (any connectivity): the mitten codes of Bhardwaj et al
-  (arXiv:2607.28795), non-abelian lifted-product codes at 20% rate. Six of the
-  paper's eight processor codes fit under the n <= 700 cap and are seeded as
-  baselines (#377): [[150,30,10]], [[200,40,12]], [[300,60,14]],
-  [[500,100,16]], [[540,108,18]] and [[630,126,<=20]], reaching kd^2/n ~ 20 to
-  80. The remaining two exceed the cap and stay bars only: [[780,156,<=22]]
-  (kd^2/n ~ 96.8) and [[975,195,<=24]] (~115.2). The construction is fully
+- High-rate, weight-9 (any connectivity): the mitten codes of arXiv:2607.28795,
+  non-abelian lifted-product codes at 20% rate. Six of the paper's eight
+  processor codes fit under the n <= 700 cap (#377): [[150,30,10]],
+  [[200,40,12]], [[300,60,14]], [[500,100,16]], [[540,108,18]] and
+  [[630,126,<=20]], reaching kd^2/n ~ 20 to 80. Five of those six are seeded
+  from this paper; [[150,30,10]] was already on the board from the ZSZ-LP
+  seeding below and keeps that provenance, for the reason worked out in
+  notes/150-30-10.md. The remaining two exceed the cap and stay bars only:
+  [[780,156,<=22]] (kd^2/n ~ 96.8) and [[975,195,<=24]] (~115.2). The
+  construction is fully
   specified (a 1x2 base matrix over F_2[G] for a non-abelian G, their
   Definition 4) and the authors publish their check matrices, so the seeded
   entries are reconstructions checked against the authors' own matrices rather
   than parameter claims. Note the paper evaluates these at the circuit level
   (logical error rate under noise), not by kd^2/n.
+- High-rate, weight-9, second construction: the ZSZ-LP codes of
+  arXiv:2607.27644, balanced products of rate-1/2 classical LDPC codes sharing a
+  non-abelian Z_l1 semidirect_q Z_l2 symmetry, also at 20% rate and check weight
+  9. Twelve of the paper's fourteen instances fit under the n <= 700 cap and are
+  seeded as baselines, from [[60,12,6]] up to [[700,140,22]]. The paper's
+  distances are SAT-exact through [[320,64,14]] and upper bounds above it,
+  which the board's per-side confidence fields mirror. The remaining two
+  exceed the cap and stay bars only: [[775,155,<=22]] (kd^2/n ~ 96.8) and
+  [[840,168,<=24]] (~115.2). Its Table 3 lists the group parameters
+  (l1, l2, q) and the trinomials a, b, c, d for every instance, so the seeded
+  entries are reconstructions rather than parameter claims.
+  This family and the mitten codes above reach the same design point by
+  different routes: both sit at rate 1/5 with weight-9 checks, and since
+  kd^2/n = rate * d^2, their over-cap bars coincide numerically at any shared
+  distance (96.8 at d = 22, 115.2 at d = 24). [[150,30,10]] is not merely
+  comparable but the same code in both papers.
+  Codes built with this construction but not taken from the paper are board
+  submissions in their own right rather than baselines, such as [[270,54,10]]
+  over ZSZ(18,3,13).
 
 ## Baselines and provenance
 


### PR DESCRIPTION
The codes from this paper are already on the board: twelve of its fourteen rate-1/5 instances, submitted by the paper's author in #357 through #368. This PR adds no codes. What is missing is the documentation, and current `main`'s TRACKS.md has no mention of ZSZ, Hong, or 2607.27644 at all.

The gap that made visible: the two instances that do not fit under the `n <= 700` cap are recorded nowhere.

| over-cap instance | kd^2/n |
|---|---|
| `[[775,155,<=22]]` | 96.8 |
| `[[840,168,<=24]]` | 115.2 |

That is the same treatment the mitten bar already gives its own two over-cap codes.

### Why the two weight-9 bars carry identical numbers

Both families sit at rate 1/5 with weight-9 checks, and `kd^2/n = rate * d^2`, so at equal distance their bars coincide exactly: 96.8 at `d = 22`, 115.2 at `d = 24`. Without saying so, the new entry looks like a duplicate of the mitten one. The new text states the arithmetic.

### Submission, not baseline

The ZSZ-LP entries carry `origin: submission` with author `@yifanhong`, while the mitten entries carry `origin: baseline` with the paper's full author list, because those were reconstructed here from the paper. The entry says which is which. My first draft called both "seeded as baselines" and erased that distinction; the second commit fixes it.

### Correction to the mitten bar

It read that six codes were seeded from arXiv:2607.28795. Six fit under the cap, but `[[150,30,10]]` was already on the board from the ZSZ-LP submissions and keeps that provenance, so five came from that paper. `notes/150-30-10.md` already concluded exactly this, deriving the group isomorphism by CRT, and the bar contradicted the note.

### Provenance boundary

`[[270,54,10]]` over ZSZ(18,3,13) uses the construction but is not a paper instance, so the entry marks it as an independent submission rather than a reproduction. It was the one board code citing the paper that does not appear in the paper.

### Where the instance list came from

Table 1 of the arXiv HTML, not the abstract. The paper writes parameters as `\llbracket n,k,d \rrbracket`, so a plain text scrape finds nothing; extracting from the MathML `alttext` gives all twenty instances mentioned and lets them be diffed against the board directly. The paper's distances are SAT-exact through `[[320,64,14]]` and upper bounds above it, matching the per-side confidence fields already on the board.

No `docs/` changes: the site workflow rebuilds the generated pages on push to main.
