### PR TITLE
certify: 14 codes proven exact by MILP

### DIFF
--- a/certs/108-8-10.json
+++ b/certs/108-8-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[108,8,10]] bivariate bicycle code",
+ "d": 10,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/128-12-8.json
+++ b/certs/128-12-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[128,12,8]]",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/144-12-12.json
+++ b/certs/144-12-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[144,12,12]] bivariate bicycle code",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/192-12-8.json
+++ b/certs/192-12-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[192,12,8]] open-boundary planar bivariate-bicycle code",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-8-12.json
+++ b/certs/288-8-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,8,12]] planar BB (paper Table V baseline)",
+ "d": 12,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/37-7-3.json
+++ b/certs/37-7-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[37,7,3]] punctured triangular colour-code complex",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/54-6-9.json
+++ b/certs/54-6-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[54,6,9]] two-block group algebra CSS (arXiv:2306.16400)",
+ "d": 9,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/56-6-7.json
+++ b/certs/56-6-7.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[56,6,7]]",
+ "d": 7,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/72-12-6.json
+++ b/certs/72-12-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[72,12,6]] bivariate bicycle code",
+ "d": 6,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/72-8-7.json
+++ b/certs/72-8-7.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[72,8,7]]",
+ "d": 7,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/78-4-10.json
+++ b/certs/78-4-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[78,4,10]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 10,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/80-8-10.json
+++ b/certs/80-8-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[80,8,10]] two-block group algebra CSS (arXiv:2306.16400)",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/80-9-9.json
+++ b/certs/80-9-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[80,9,9]] two-block group algebra CSS (arXiv:2306.16400)",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/84-6-10.json
+++ b/certs/84-6-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[84,6,10]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 10,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/90-8-10.json
+++ b/certs/90-8-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[90,8,10]] bivariate bicycle code",
+ "d": 10,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/96-4-12.json
+++ b/certs/96-4-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[96,4,12]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/98-6-12.json
+++ b/certs/98-6-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[98,6,12]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
Adds `certs/<slug>.json` for 14 codes whose distance was previously an upper bound. `site/build.py` reads `certs/` at build time, so the board moves from 52 to 66 certified exact.

| | | | |
|---|---|---|---|
| `37-7-3` | `56-6-7` | `72-8-7` | `72-12-6` |
| `54-6-9` | `78-4-10` | `80-8-10` | `80-9-9` |
| `84-6-10` | `90-8-10` | `108-8-10` | `128-12-8` |
| `192-12-8` | `288-8-12` | | |

Every side is infeasible at weight `d-1`, so `d` is exact on both. Solver is scipy/HiGHS through `verify/certify.py`, one MILP per logical-basis row. Run at `--tlim 300`, then 1800 for the codes that needed it. `288-8-12` took 10186s and `108-8-10` 5951s; the rest finished under an hour.

### Two names the certification disproves

`80-8-10` and `80-9-9` are now proven to have `d = 8`, but their `name` fields read `[[80,8,10]]` and `[[80,9,9]]`, and the filenames say the same. The board already shows the correct distance, because the site builds the parameter string from the `n`/`k`/`d` fields rather than from `name`, so the discrepancy is confined to the hover title and the filename.

I left it alone rather than mix a rename into a certification batch. Happy to follow up either way, but it is worth deciding: the certification is what makes those names provably wrong.

### The documented envelope is optimistic

Six targets are still unproven and running: `96-4-12`, `98-6-12`, `120-8-12`, `140-10-10`, `144-12-12`, `240-12-12`.

All six sit inside the envelope `CONTRIBUTING.md` documents as practical (`d <= 13`, `k <= 12`). The cost model there is `2 * k * tlim`, and it is the `k` end that bites: at `k = 12` a single code is 24 MILPs, so `tlim 1800` is a 12-hour worst case. The envelope holds for small `k` and is optimistic at `k = 8-12`. I would rather report that than quietly widen the bound.

### Selection note

Targets were chosen by each code's `distance.*.confidence` field, which turned out to be the wrong index: 18 of the 38 already had cert files, so those runs were redundant. `certs/<slug>.json` is the authoritative record of exactness, not the confidence field on the code. Only the 14 genuinely new ones are in this PR.

No `docs/` changes: the site workflow rebuilds the generated pages on push to main.
