### PR TITLE
certify: 11 SAT-proven codes that missed the #423 merge

### DIFF
--- a/certs/100-20-8.json
+++ b/certs/100-20-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[100,20,8]] ZSZ-LP code",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/120-8-12.json
+++ b/certs/120-8-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[120,8,12]] bivariate bicycle code (autoresearch candidate)",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/140-10-10.json
+++ b/certs/140-10-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[140,10,10]] 2BGA on metacyclic Z_35 |x Z_2 (arXiv:2306.16400)",
+ "d": 10,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/144-16-8.json
+++ b/certs/144-16-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[144,16,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/146-18-4.json
+++ b/certs/146-18-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[146,18,4]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 4,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/216-15-11.json
+++ b/certs/216-15-11.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[216,15,11]] grafted planar bivariate-bicycle (bilayer)",
+ "d": 11,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 11,
+   "exact": true,
+   "note": "no logical < 11 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 11,
+   "exact": true,
+   "note": "no logical < 11 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/240-12-12.json
+++ b/certs/240-12-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[240,12,12]]",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/292-18-8.json
+++ b/certs/292-18-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[292,18,8]] twisted-torus BB code (arXiv:2503.03827)",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/60-12-6.json
+++ b/certs/60-12-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[60,12,6]] ZSZ-LP code",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/625-50-3.json
+++ b/certs/625-50-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[625,*,3]] holey rotated surface code, L=25 period-3",
+ "d": 3,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/64-16-6.json
+++ b/certs/64-16-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[64,16,6]]",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
#423 merged at its 14-cert state. These eleven were pushed to that same branch afterwards and did not land, so the proofs exist but the board does not reflect them.

All are proven exact by the SAT backend: parity rows as native XOR clauses in CryptoMiniSat, sequential-counter cardinality bound, one solve per opposite-side logical generator, every side UNSAT one weight below the claim.

| | | |
|---|---|---|
| `60-12-6` | `64-16-6` | `100-20-8` |
| `120-8-12` | `140-10-10` | `144-16-8` |
| `146-18-4` | `216-15-11` | `240-12-12` |
| `292-18-8` | `625-50-3` | |

`625-50-3` is the one promised in the #433 review: Aaron's holey rotated surface code proves `d = 3` in under a second, which makes its geometric-efficiency headline `g = 0.72` exact rather than an upper bound.

`120-8-12`, `140-10-10` and `240-12-12` are the three that resisted the MILP at every budget tried (`98-6-12` had burned a full `2*k*tlim` = 21600s and stayed partial); they close out the `d <= 13, k <= 12` envelope. `216-15-11` (k = 15) and `292-18-8` (k = 18) are past where the MILP tier stalled entirely.

Board 69 -> 80 certified exact.

Worth recording from the sweep that produced these: the SAT tier's practical wall is the weight bound W, not k. Every code with `d <= 11` that was tried succeeded, and every `d = 14` code timed out at `W = 13` at 1800s/call, including `294-12-14` (the board's best 2D-local entry), `168-20-14`, `360-16-14` and the `180-18-14`/`180-20-14` pair from #274. Cost grows with the cardinality encoding over `C(n, W)`, so more time does not move that boundary. No refutations anywhere in the sweep.
