### PR TITLE
verify: rank novelty on check weight, matching the site's own frontier

### DIFF
--- a/verify/validate_candidate.py
+++ b/verify/validate_candidate.py
@@ -81,6 +81,7 @@ def _board_entries_cached(_stamp):
                 "fingerprint": rep.get("fingerprint"),
                 "sig": rep.get("signature", {}).get("hash"),
                 "weight_class": comp.get("weight_class"),
+                "w": comp.get("max_check_weight"),
                 "locality_class": comp.get("locality_class"),
             })
         except Exception:
@@ -155,15 +156,28 @@ def validate_candidate(doc, *, seed=None):
         verdict["labels"].append(f"possibly equivalent (same WL signature) to {wl_equiv}")
 
     # 4. NOVELTY (label only) -- non-dominated within the candidate's own track cell?
+    #
+    # The comparison is over all four axes (n lower, k higher, d higher, w
+    # lower), matching TRACKS.md and site/build.py:pareto. Weight enters twice
+    # and the two roles are distinct: the weight CLASS selects which cell a
+    # code competes in, and the raw max check weight is a ranking axis inside
+    # it. Comparing on class alone treated a w = 32 code as dominating a w = 7
+    # one whenever n, k and d allowed, which the site's own frontier does not,
+    # so a code could be labelled "does not advance its board cell" while
+    # starring on the rendered board.
     n, k, d = doc["n"], doc["k"], claimed_d
+    w = comp.get("max_check_weight")
     dominators = []
     for b in board:
         # a board code shares the candidate's cell iff it is stricter-or-equal on both axes
         if (_WEIGHT_ORDER.get(b["weight_class"], 9) <= _WEIGHT_ORDER.get(wc, 9)
                 and _LOCAL_ORDER.get(b["locality_class"], 9) <= _LOCAL_ORDER.get(lc, 9)):
-            if (b["n"] <= n and b["k"] >= k and b["d"] >= d
-                    and (b["n"] < n or b["k"] > k or b["d"] > d)):
-                dominators.append(f"[[{b['n']},{b['k']},{b['d']}]] {b['name']}")
+            bw = b.get("w")
+            if bw is None:                     # pre-fix cache entry; skip the w axis
+                bw = w
+            if (b["n"] <= n and b["k"] >= k and b["d"] >= d and bw <= w
+                    and (b["n"] < n or b["k"] > k or b["d"] > d or bw < w)):
+                dominators.append(f"[[{b['n']},{b['k']},{b['d']}]] w={bw} {b['name']}")
     board_advancing = not dominators and not exact_dup
     g["novelty"] = {"cell": [wc, lc], "board_advancing": board_advancing,
                     "dominated_by": dominators, "literature_novelty": "unverified"}

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Pinned SHA-256 of the trusted autoresearch validation stack. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
-    "validate_candidate.py": "ea4430bacb9c5e68b5bac66f56d9a82e83f0ba8823b1357288b26972ce8842b8",
+    "validate_candidate.py": "698822632b200ec2d23d8d3b0c6d0b722bbf79579be45084ec4ae3275f196035",
     "qldpc_verify.py": "00490f5f4de0ad503b363dc1766c9438b1ae67d238fd35906e197c5ff856dcd1",
     "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",


### PR DESCRIPTION
`validate_candidate.py`'s novelty gate compared candidates on `(n, k, d)` only. Weight entered solely through the cell filter, never as a ranking axis. But `TRACKS.md` and `site/build.py:pareto` both rank on four axes with weight included, so the validator and the rendered board could disagree about the same code.

The two roles of weight were conflated. The weight **class** selects which cell a code competes in; the **raw** max check weight is a ranking axis inside that cell. Comparing on class alone let a `w = 32` code dominate a `w = 7` one whenever n, k and d allowed.

Before this change:

| candidate | reported dominator |
|---|---|
| `[[310,6,26]]` w=9 | `[[310,14,26]]` **w=10** |
| `[[660,8,30]]` w=7 | `[[420,10,30]]` **w=8** |
| `[[576,8,32]]` w=10 | `[[390,82,38]]` **w=32** |

Every listed dominator carries strictly *higher* check weight than the code it was said to dominate. None of them dominates under the rule the site actually renders, so these codes were labelled `does not advance its board cell` while starring on the board. All three now report `board_advancing`.

Genuine domination is unaffected, which is the regression I checked first: `[[632,8,32]]` w=10 is still dominated by `[[592,8,32]]` w=8, which beats it on n and w while tying k and d. Dominator strings now carry the weight so the comparison is legible rather than mysterious.

Cached board entries predating this change lack the `w` field; those fall back to skipping the weight axis rather than crashing on a stale cache.

`verify/test_validate_candidate.py` passes. The manifest is re-pinned, since the integrity gate flagged the change exactly as it should.

This surfaced from three of my own codes sitting unsubmitted because the labels disagreed with the board. Worth fixing before more submitters hit it, since the label is what a reviewer reads first.
