### PR TITLE
site: link author handles in the Recently added panel

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -2966,7 +2966,11 @@ def latest_codes_panel(entries, records, limit=10):
     for e in dated[:limit]:
         star = ('<span class=lstar title="holds a cell record">&#9733;</span>'
                 if e["slug"] in rec_slugs else '')
-        who = html.escape(e["authors"])
+        # authors_compact, not html.escape on the joined string: this panel was
+        # the one place a handle rendered as inert text while the same handle
+        # linked to its profile everywhere else. It also collapses a long
+        # literature author list to "Surname et al." so the row stays one line.
+        who = authors_compact(e["authors_list"])
         origin = ('literature' if e["origin"] == "literature" else 'submission')
         rows.append(
             f'<li><a class="mono lnkd" href="codes/{e["slug"]}.html">'


### PR DESCRIPTION
The "Recently added" panel rendered its author column as `html.escape(e["authors"])`, so a handle like `@vprusso` was inert text. Everywhere else a handle appears (the board's author column, the code detail page) it goes through `authors_html` and renders as a profile link, so this panel was the only place a handle looked clickable and was not.

Switched to `authors_compact(e["authors_list"])`, the same helper the board already uses.

### What changes

| row | before | after |
|---|---|---|
| `[[684,10,101]]` | `@vprusso` (text) | links to `github.com/vprusso` |
| `[[625,50,3]]` | `@aarontrowbridge` (text) | links to `github.com/aarontrowbridge` |
| `[[482,146,42]]` | `@yhu1996` (text) | links to `github.com/yhu1996` |

### What deliberately does not change

`authors_html` only links strings matching `@[A-Za-z0-9-]+`. Literature entries keep plain text, so `Lin, Hsiang-Ku` and `Bravyi, Sergey` do not sprout links to GitHub profiles that do not exist. I checked this against all 26 distinct author shapes currently in `codes/`, which cover handle-only, literature-only, and mixed lists.

`authors_compact` also collapses a long literature list to `Surname et al.`, which is what keeps each row on one line as the panel's flex layout assumes.

No CSS change was needed: the global `a` rule already supplies accent colour and a hover underline, so these match how the same handles render on the board. Rendered the panel headless and looked at it to confirm the rows still sit on one line with the date right-aligned.

No `docs/` changes: the site workflow rebuilds the generated pages on push to main.
