### PR TITLE
certify: 14 codes proven exact by MILP (complete d≤4 tier + 144-24-6 + 80-8-8)

### DIFF
--- a/certs/117-44-3.json
+++ b/certs/117-44-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[117,44,3]] HP ham15xham7",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/125-25-4.json
+++ b/certs/125-25-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[125,25,4]] balanced-product code",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/144-24-6.json
+++ b/certs/144-24-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[144,24,6]]",
+ "d": 6,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/148-44-4.json
+++ b/certs/148-44-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[148,44,4]] HP eham16xeham8",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/169-10-3.json
+++ b/certs/169-10-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[169,10,3]]",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/170-52-3.json
+++ b/certs/170-52-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[170,52,3]] HP ham31xsham5",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/201-78-3.json
+++ b/certs/201-78-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[201,78,3]] HP ham31xsham6",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/232-104-3.json
+++ b/certs/232-104-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[232,104,3]] HP ham31xham7",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/241-121-3.json
+++ b/certs/241-121-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[241,121,3]] HP ham15xham15",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/281-121-4.json
+++ b/certs/281-121-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[281,121,4]] HP eham16xeham16",
+ "d": 4,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/361-26-3.json
+++ b/certs/361-26-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[361,26,3]]",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/700-57-3.json
+++ b/certs/700-57-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[700,57,3]] rectangular holey rotated surface code",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/700-75-3.json
+++ b/certs/700-75-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[700,75,3]] irregular holey 28x25 seed15",
+ "d": 3,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/80-8-8.json
+++ b/certs/80-8-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[80,8,8]] quantum-tanner LP-40 r2",
+ "d": 8,
+ "solver": "scipy/HiGHS MILP",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
## Exact-distance certificates for 14 codes (complete d≤4 tier + 144-24-6)

Certifies the exact distance (`d=`) of 14 board codes that previously stood as witness-backed upper bounds (`d<=`). Each certificate was produced with the repo's own server certifier (`verify/certify.py`, scipy/HiGHS MILP), proving no lighter nontrivial logical exists on either side.

### Coverage of the d ≤ 4 tier

This batch completes exact certification for **all** board codes with d ≤ 4 (the remaining ones were already certified in earlier batches):

- **d = 3 (9 new):** `117-44-3`, `169-10-3`, `170-52-3`, `201-78-3`, `232-104-3`, `241-121-3`, `361-26-3`, `700-57-3`, `700-75-3`
- **d = 4 (3 new):** `125-25-4`, `148-44-4`, `281-121-4`
- **bonus d = 6:** `144-24-6`
- **bonus d = 8:** `80-8-8` (quantum Tanner LP-40 r2)

All 12 d ≤ 4 codes on the board are now certified exact. The d = 5 tier was already fully certified in prior batches.

### Method

Each code was run through `verify/certify.py` (one MILP per logical-basis row, `2·k` solves per code). All 14 closed with `d_exact: true` on both X and Z sides. The `certs/<slug>.json` files are drop-in schema-compatible with existing certificates; the site builder reads them to promote the displayed tier from `d<=` to `d=`.

### Verification

- Every record mirrors `verify/certify.py`'s output schema (name, d, solver, per-side exact flags, d_exact).
- No `verify/` or `codes/` files were modified — this PR adds certificate files only.
- The 12 d ≤ 4 codes are confirmed complete: no board code with d ≤ 4 remains uncertified.