### PR TITLE
certify: 10 codes proven exact by SAT (batch 3)

### DIFF
--- a/certs/120-24-8.json
+++ b/certs/120-24-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[120,24,8]] non-abelian lifted-product (mitten) code",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/150-30-10.json
+++ b/certs/150-30-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[150,30,10]]",
+ "d": 10,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/170-34-8.json
+++ b/certs/170-34-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[170,34,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/180-36-8.json
+++ b/certs/180-36-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[180,36,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/195-39-8.json
+++ b/certs/195-39-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[195,39,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-46-8.json
+++ b/certs/288-46-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,46,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-48-6.json
+++ b/certs/288-48-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,48,6]]",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-50-8.json
+++ b/certs/288-50-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,50,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/360-24-10.json
+++ b/certs/360-24-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[360,24,10]]",
+ "d": 10,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/696-76-3.json
+++ b/certs/696-76-3.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[696,76,3]]",
+ "d": 3,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 3,
+   "exact": true,
+   "note": "no logical < 3 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
## Summary

Certify exact distances for 10 codes that were previously at witness-backed upper bounds (`d<=`), using the CryptoMiniSat SAT certifier (native XOR + sequential-counter cardinality, same approach as PR #435).

Each certificate asserts `d_exact: true` with both X and Z sides proven exact — no logical operator of weight < d exists on either side.

## Codes certified

| Code | d | Wall time |
|------|---|-----------|
| `696-76-3` | 3 | 2.8s |
| `288-48-6` | 6 | 30.6s |
| `120-24-8` | 8 | 352s |
| `170-34-8` | 8 | 3931s |
| `180-36-8` | 8 | 3930s |
| `195-39-8` | 8 | 6181s |
| `288-46-8` | 8 | 3122s |
| `288-50-8` | 8 | 2401s |
| `150-30-10` | 10 | 13789s |
| `360-24-10` | 10 | 1230s |

## What frontier does this advance?

These certs upgrade the leaderboard from `d<=` (upper bound) to `d=` (exact) for 10 codes across the d=3, 6, 8, and 10 tiers, tightening the exact-distance frontier that the board tracks.