### PR TITLE
Close #453 and #481 with geo-score eligibility and verification receipts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -102,11 +102,18 @@ jobs:
       - name: distance refutation gate (trusted verifier for code changes)
         if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
         working-directory: trusted
-        run: uv run --frozen --with ldpc python verify/gate_changed.py --code-root ../submitted origin/${{ github.base_ref || 'main' }}
+        run: uv run --frozen --with ldpc python verify/gate_changed.py --code-root ../submitted origin/${{ github.base_ref || 'main' }} --receipt-dir ../receipts --pr-number "${{ github.event.pull_request.number }}" --pr-author "${{ github.event.pull_request.user.login }}" --base-sha "${{ github.event.pull_request.base.sha }}" --head-sha "${{ github.event.pull_request.head.sha }}"
       - name: distance refutation gate (changed submissions only)
         if: github.event_name != 'pull_request'
         working-directory: submitted
         run: uv run --frozen --with ldpc python verify/gate_changed.py origin/${{ github.base_ref || 'main' }}
+      - name: upload verification receipts
+        if: always() && github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-receipts-${{ github.event.pull_request.number }}
+          path: receipts/
+          if-no-files-found: warn
       - name: authorship check (PR author must be a listed @handle author)
         if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
         working-directory: trusted

--- a/TRACKS.md
+++ b/TRACKS.md
@@ -113,11 +113,13 @@ surface code to 1, but they answer different questions.
   free nor forbidden -- they must earn their density.
 
   Conventions and guards:
-  - g is computed only from a verifier-accepted layout (an honest layout
-    within a class cap). A code without one has no f. That is a certification
-    status, not a property: such a code may still be geometrically local
-    (e.g. on a torus, or simply unlayouted) -- it is not thereby an
-    "expander code".
+  - g is computed from any honest layout accepted by the verifier; the caps
+    decide the cell, not the score. A layout outside a locality cap therefore
+    remains in `unrestricted` while still receiving its continuously computed
+    (usually smaller) g. A code without a layout has no g. That is a
+    certification status, not a property: such a code may still be
+    geometrically local (e.g. on a torus, or simply unlayouted) -- it is not
+    thereby an "expander code".
   - g inherits the distance tier: computed from an upper-bound d it is an
     upper bound, and the site marks it so.
   - The headline card requires d >= 3: g is scale-free, so d = 2 tilings

--- a/site/build.py
+++ b/site/build.py
@@ -1247,9 +1247,10 @@ def cert_consistent(cert, doc):
 # and rho the layer count (the capacity charge rho^2 is the unique exponent
 # that makes re-packaging a layout into layers score-neutral). The constant 4
 # = (sqrt(2))^4 normalizes the planar surface code (r = sqrt(2), rho = 1) to
-# exactly 1. Defined only for codes whose layout the verifier accepted
-# (locality class != unrestricted); a code without a layout has no f -- that
-# is a certification status, not a claim that the code is an expander.
+# exactly 1. Defined for any honest layout accepted by the verifier; the
+# locality caps decide the leaderboard cell, not score eligibility. A code
+# without a layout has no f -- that is a certification status, not a claim
+# that the code is an expander.
 # D = 2 only: the schema accepts planar coordinates; other D are reserved.
 GEO_MIN_D = 3   # headline eligibility: d = 2 tilings (a [[4,2,2]] block on
                 # one plaquette scores g = 2) beat the surface code trivially,
@@ -1272,7 +1273,7 @@ def geo_score(doc, n, k, d, locality_class):
     """(f, r, rho) for a verifier-accepted layout, else (None, None, None).
     r is recomputed exactly from the stored coordinates (the report's value
     is rounded for display)."""
-    if locality_class == "unrestricted" or "locality" not in doc:
+    if "locality" not in doc:
         return None, None, None
     loc = doc["locality"]
     coords = [tuple(c) for c in loc["coordinates"]]

--- a/verify/build_receipt.py
+++ b/verify/build_receipt.py
@@ -1,0 +1,105 @@
+"""Build non-authoritative verification receipts for submission CI.
+
+Receipts summarize facts already computed by the trusted verifier and the distance
+refutation gate. They are CI artifacts, not board data: generating one never changes
+whether a submission passes, and self-reported provenance is labelled as such.
+"""
+import hashlib
+import json
+import os
+import subprocess
+
+
+def _git(root, *args):
+    try:
+        return subprocess.check_output(["git", *args], cwd=root, text=True).strip()
+    except Exception:
+        return None
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def make_receipt(doc, path, verdict, *, gate, repo_root, pr_number=None,
+                 pr_author=None, base_sha=None, head_sha=None):
+    """Return a JSON-serializable receipt for one already-gated submission."""
+    prov = doc.get("provenance") or {}
+    candidate = verdict.get("candidate", {})
+    gates = verdict.get("gates", {})
+    novelty = gates.get("novelty", {})
+    refute = gates.get("refute", {})
+    receipt = {
+        "receipt_version": "1",
+        "submission": {
+            "path": os.path.relpath(path, repo_root),
+            "sha256": _sha256(path),
+            "pull_request": pr_number,
+            "pr_author": pr_author,
+            "base_sha": base_sha or _git(repo_root, "rev-parse", "HEAD"),
+            "head_sha": head_sha,
+        },
+        "trusted_validation": {
+            "verifier_commit": base_sha or _git(repo_root, "rev-parse", "HEAD"),
+            "validator_source_sha256": verdict.get("validator", {}).get(
+                "source_sha256"),
+            "validator_seed": verdict.get("validator", {}).get("seed"),
+            "structural_result": "passed" if gates.get("verify", {}).get("ok")
+                                 else "failed",
+            "distance_gate": gate,
+        },
+        "computed": {
+            "n": candidate.get("n"),
+            "k": candidate.get("k"),
+            "d": candidate.get("d"),
+            "family": candidate.get("family"),
+            "weight_class": candidate.get("weight_class"),
+            "locality_class": candidate.get("locality_class"),
+            "fingerprint": candidate.get("fingerprint"),
+            "signature": candidate.get("signature"),
+        },
+        "deduplication": gates.get("dedup", {}),
+        "frontier": {
+            "board_advancing": novelty.get("board_advancing"),
+            "cell": novelty.get("cell"),
+            "dominated_by": novelty.get("dominated_by", []),
+        },
+        "provenance": {
+            "authors": {
+                "value": prov.get("authors", []),
+                "status": "self_reported",
+            },
+            "contributors": {
+                "value": prov.get("contributors", []),
+                "status": "self_reported",
+            },
+            "model": {
+                "value": prov.get("model"),
+                "status": "self_reported",
+            },
+            "novelty": {
+                "value": prov.get("novelty"),
+                "status": "self_reported",
+            },
+        },
+        "routing": {
+            "status": "eligible_under_current_checks"
+            if verdict.get("passed") and not gate.get("refuted")
+            else "maintainer_review",
+            "reasons": list(verdict.get("labels", [])),
+        },
+    }
+    return receipt
+
+
+def write_receipt(receipt, output_dir, slug):
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, slug + ".json")
+    with open(path, "w") as f:
+        json.dump(receipt, f, indent=2)
+        f.write("\n")
+    return path

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -36,6 +36,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gf2
 import heuristic_distance as H
 from qldpc_verify import file_size_error
+from validate_candidate import validate_candidate
+from build_receipt import make_receipt, write_receipt
 
 try:
     import gf2_fast as GF          # optional C++ accelerator (make fast); the
@@ -209,6 +211,31 @@ def main(argv):
     rest = [a for a in argv if not a.endswith(".json")]
     seed = None
     code_root = ROOT
+    receipt_dir = None
+    pr_number = None
+    pr_author = None
+    base_sha = None
+    head_sha = None
+    if "--receipt-dir" in rest:
+        i = rest.index("--receipt-dir")
+        receipt_dir = os.path.abspath(rest[i + 1])
+        rest = rest[:i] + rest[i + 2:]
+    if "--pr-number" in rest:
+        i = rest.index("--pr-number")
+        pr_number = int(rest[i + 1])
+        rest = rest[:i] + rest[i + 2:]
+    if "--pr-author" in rest:
+        i = rest.index("--pr-author")
+        pr_author = rest[i + 1]
+        rest = rest[:i] + rest[i + 2:]
+    if "--base-sha" in rest:
+        i = rest.index("--base-sha")
+        base_sha = rest[i + 1]
+        rest = rest[:i] + rest[i + 2:]
+    if "--head-sha" in rest:
+        i = rest.index("--head-sha")
+        head_sha = rest[i + 1]
+        rest = rest[:i] + rest[i + 2:]
     if "--code-root" in rest:
         i = rest.index("--code-root")
         code_root = os.path.abspath(rest[i + 1])
@@ -219,6 +246,18 @@ def main(argv):
         rest = rest[:i] + rest[i + 2:]
     files = [a for a in argv if a.endswith(".json")]
     base = next((a for a in rest), "origin/main")
+    if base_sha is None:
+        try:
+            base_sha = subprocess.check_output(
+                ["git", "rev-parse", base], cwd=code_root, text=True).strip()
+        except Exception:
+            pass
+    if head_sha is None:
+        try:
+            head_sha = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=code_root, text=True).strip()
+        except Exception:
+            pass
     if not files:
         files = changed_codes(base, code_root)
     if files is None:
@@ -287,6 +326,34 @@ def main(argv):
         fast_tag = (f" + fast x {ftrials}" if ftrials else "")
         tag = (f"deep, {len(seeds)} RIS seeds x {trials} trials (<={budget:.0f}s each)"
                f"{fast_tag}" if deep else f"standard, {trials} trials (<={budget:.0f}s)")
+        gate = {
+            "refuted": bool(hits),
+            "seed": seed,
+            "seeds": seeds,
+            "trials": trials,
+            "budget_seconds": budget,
+            "deep": deep,
+            "fast_trials": ftrials,
+            "methods": list(results),
+        }
+        if receipt_dir:
+            # The distance search above is authoritative for this run. Reuse the
+            # trusted structural/dedup/frontier checks without running refutation a
+            # second time just to produce an artifact.
+            verdict = validate_candidate(doc, seed=seed, refute=False)
+            verdict["gates"]["refute"] = {
+                "refuted": bool(hits),
+                "seed": seed,
+                "detail": "distance gate recorded by gate_changed.py",
+            }
+            verdict["passed"] = bool(
+                verdict.get("passed") and not hits)
+            slug = os.path.splitext(os.path.basename(f))[0]
+            receipt = make_receipt(
+                doc, p, verdict, gate=gate, repo_root=code_root,
+                pr_number=pr_number, pr_author=pr_author,
+                base_sha=base_sha, head_sha=head_sha)
+            write_receipt(receipt, receipt_dir, slug)
         if hits:
             refuted += 1
             for m, (dh, wit) in hits.items():

--- a/verify/test_receipt.py
+++ b/verify/test_receipt.py
@@ -1,0 +1,42 @@
+"""Regression tests for additive verification receipts."""
+import json
+import os
+import tempfile
+
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from build_receipt import make_receipt, write_receipt
+from validate_candidate import validate_candidate
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIXTURE = os.path.join(ROOT, "verify", "fixtures", "72-6-6.json")
+
+
+def main():
+    with open(FIXTURE) as f:
+        doc = json.load(f)
+    verdict = validate_candidate(doc, seed=123, refute=False)
+    with tempfile.TemporaryDirectory() as td:
+        source = os.path.join(td, "code.json")
+        with open(source, "w") as f:
+            json.dump(doc, f)
+        receipt = make_receipt(
+            doc, source, verdict,
+            gate={"refuted": False, "seed": 123, "methods": ["RIS"]},
+            repo_root=td, pr_number=7, pr_author="alice",
+            base_sha="base", head_sha="head")
+        path = write_receipt(receipt, os.path.join(td, "receipts"), "code")
+        loaded = json.load(open(path))
+        assert loaded["receipt_version"] == "1"
+        assert loaded["submission"]["pull_request"] == 7
+        assert loaded["submission"]["sha256"]
+        assert loaded["trusted_validation"]["validator_source_sha256"]
+        assert loaded["trusted_validation"]["distance_gate"]["seed"] == 123
+        assert loaded["provenance"]["model"]["status"] == "self_reported"
+        assert "board_advancing" in loaded["frontier"]
+    print("receipt tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/verify/validate_candidate.py
+++ b/verify/validate_candidate.py
@@ -95,8 +95,13 @@ def _board_entries():
     return _board_entries_cached(_board_stamp())
 
 
-def validate_candidate(doc, *, seed=None):
-    """Run the full trusted gate on a candidate submission ``doc``.
+def validate_candidate(doc, *, seed=None, refute=True):
+    """Run the trusted gate on a candidate submission ``doc``.
+
+    ``refute`` defaults to True and preserves the full candidate-gate behavior.
+    Trusted callers that already ran the independent distance gate may set it to
+    False to obtain the structural, deduplication, and frontier verdict without
+    repeating the expensive random search.
 
     Returns a structured verdict (JSON-serializable). ``passed`` is the honest bottom
     line; ``gates`` is the evidence for each check; ``labels`` are the human-facing
@@ -116,9 +121,10 @@ def validate_candidate(doc, *, seed=None):
     }
     g = verdict["gates"]
 
-    # 1+2. VERIFY + REFUTE -- one trusted call does schema/n/k/CSS/weight/witnesses
-    #      AND the random-seed distance refutation (the "distance_not_refuted" check).
-    rep = qldpc_verify.verify(doc, refute=True, seed=seed)
+    # 1+2. VERIFY + REFUTE -- the normal path does schema/n/k/CSS/weight/witnesses
+    #      and the random-seed distance refutation in one call. Receipt generation
+    #      can reuse the structural portion after gate_changed.py has already run.
+    rep = qldpc_verify.verify(doc, refute=refute, seed=seed)
     checks = rep["checks"]
     nd = next((c for c in checks if c["check"] == "distance_not_refuted"), None)
     refuted = nd is not None and not nd["ok"]
@@ -129,6 +135,8 @@ def validate_candidate(doc, *, seed=None):
     wc, lc = comp.get("weight_class"), comp.get("locality_class")
     verdict["candidate"]["weight_class"] = wc
     verdict["candidate"]["locality_class"] = lc
+    verdict["candidate"]["fingerprint"] = rep.get("fingerprint")
+    verdict["candidate"]["signature"] = rep.get("signature", {}).get("hash")
 
     g["verify"] = {"ok": verify_ok, "failed_checks": structural_fail,
                    "weight_class": wc, "locality_class": lc}

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Pinned SHA-256 of the trusted autoresearch validation stack. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
-    "validate_candidate.py": "698822632b200ec2d23d8d3b0c6d0b722bbf79579be45084ec4ae3275f196035",
+    "validate_candidate.py": "54cc54f6282506baafe1ac8f97c9f479a017a25c66b0426172ca1a4799fa2892",
     "qldpc_verify.py": "00490f5f4de0ad503b363dc1766c9438b1ae67d238fd35906e197c5ff856dcd1",
     "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",


### PR DESCRIPTION
## Summary

Closes #453 and #481.

### #453 — geometric-score eligibility

- Keep the existing locality caps and verifier-derived locality cells unchanged.
- Compute geometric efficiency `g` for any honest layout accepted by the verifier, including layouts that fall into `unrestricted` because they exceed a locality cap.
- Continue returning no `g` for submissions without a layout.
- Document the rule in `TRACKS.md`: the caps decide the cell, not the score.

### #481 — non-board-breaking verification receipts

- Add `verify/build_receipt.py` to produce an additive, machine-readable receipt for a gated submission.
- Record submission hashes, PR metadata, trusted validator information, distance-gate seed/results, computed classes, deduplication, and frontier status.
- Label model, authorship, contributors, and novelty as self-reported rather than pretending CI can verify them.
- Integrate receipt generation into the existing trusted distance-gate run and upload receipts as CI artifacts.
- Preserve existing schema, board data, rankings, admission behavior, and merge gates; receipts are observational artifacts only.
- Add receipt regression coverage.
- Re-pin the validator manifest for the intentional backward-compatible `refute=False` validator mode, which avoids repeating the expensive distance search during receipt generation.

## Validation

- `uv run --frozen python verify/test_receipt.py` passed.
- Focused geometric-score check passed: an over-cap honest layout receives `g`, while no layout receives no score.
- `uv run --frozen python site/build.py` passed in the original workspace.
- `uv run --frozen python verify/check_validator_integrity.py` passed after re-pinning.
- Verifier, refutation-gate, candidate-validation, and receipt tests passed in the full-suite output observed before the long test command was stopped; the complete suite did not reach a final summary in the original workspace.

Only the eight focused implementation files are included in this branch; unrelated workspace changes are excluded.