### PR TITLE
certify: 5 codes proven exact by SAT (batch 4)

### DIFF
--- a/certs/128-13-10.json
+++ b/certs/128-13-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[128,13,10]] 2BGA on C8:Q8 (odd-k)",
+ "d": 10,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/190-38-8.json
+++ b/certs/190-38-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[190,38,8]] non-abelian lifted-product (mitten) code",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/230-46-8.json
+++ b/certs/230-46-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[230,46,8]] non-abelian lifted-product (mitten) code",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-32-8.json
+++ b/certs/288-32-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,32,8]]",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/288-48-8.json
+++ b/certs/288-48-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[288,48,8]] weight-10 mixed-monomial bivariate bicycle code",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists (CryptoMiniSat, XOR + sequential-counter cardinality)"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
## Summary

Certify exact distances for 5 codes previously at witness-backed upper bounds (`d<=`), using the CryptoMiniSat SAT certifier (native XOR + sequential-counter cardinality, same approach as PR #435 and #479).

Each certificate asserts `d_exact: true` with both X and Z sides proven exact — no logical operator of weight < d exists on either side.

## Codes certified

| Code | d | Wall time |
|------|---|-----------|
| `190-38-8` | 8 | 1473s |
| `288-48-8` | 8 | 2949s |
| `230-46-8` | 8 | 44718s |
| `288-32-8` | 8 | 396s |
| `128-13-10` | 10 | 23056s |

Note: `230-46-8` has asymmetric sides (X=8, Z=10), matching the board claim; `d_exact` remains valid.

## What frontier does this advance?

These certs upgrade the leaderboard from `d<=` (upper bound) to `d=` (exact) for 5 codes in the d=8 and d=10 tiers, tightening the exact-distance frontier the board tracks. Notably `128-13-10` (d=10) was previously unclosable by MILP after 10+ hours and was closed by the SAT certifier.