### PR TITLE
Automate the PR body's frontier section in qldpc submit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,13 +38,15 @@ Useful flags:
 - `--dry-run` build and verify without writing.
 
 Either way — `--open-pr`, or the commands it prints for you to run — the PR
-title and body are drafted for you from
+body is drafted for you from
 [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and the
 verified submission: parameters, the computed track membership, distance
-confidence, construction, and a pointer to your note. One section the tool
-cannot fill is left as a `TODO` — **which frontier this advances, and which
-existing entry it beats or extends, on which axis**. Write that in (`gh pr edit
---body-file ...`) before asking for review; it is what a reviewer reads first.
+confidence, construction, and a pointer to your note. The "what frontier does
+this advance?" section is now **computed too**: `qldpc submit` reuses the
+site's own cell + Pareto logic to list the track cells the code lands in,
+whether it sits on each cell's frontier, and which existing board entries it
+dominates (and on which axis). Review it before requesting review — it is a
+board-relative claim, not a statement against the wider literature.
 
 ## Share the search, not just the code
 
@@ -162,10 +164,10 @@ codes. Goal: find a CSS qLDPC code that advances a frontier, and submit it.
 5. Submit: ./qldpc submit yourcode.npz --authors @yourhandle --family <family>
    --model "<exact model version, e.g. Claude Opus 4.8>". It finds the witness,
    runs the verifier (which computes the locality and weight classes), and opens
-   the PR. CI re-verifies. The PR body is drafted from the submission, but the
-   "what frontier does this advance?" section is left as a TODO: replace it
-   with the track and the specific existing entry you beat or extend, and on
-   which axis, before the PR is ready for review.
+   the PR. CI re-verifies. The PR body is drafted from the submission,
+   including a computed "what frontier does this advance?" section (the track
+   cells the code lands in and the existing entries it dominates). Review it
+   before the PR is ready for review.
 
 Report the [[n,k,d]], which track it advances, and that the distance held under
 deep re-verification.

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -8,8 +8,11 @@ a single command, the way ecdsa.fail does: you bring H_X and H_Z, the tool
   2. searches for the lightest logical on each side (RIS) and records it as a
      self-certifying distance witness,
   3. assembles a schema-valid submission,
-  4. runs the full trustless verifier locally (the same gate CI runs), and
-  5. writes codes/<n>-<k>-<d>.json and prints the steps to open the PR
+  4. runs the full trustless verifier locally (the same gate CI runs),
+  5. fills the PR body's "what frontier does this advance?" section by
+     comparing against the current board (reusing the site's Pareto logic),
+     and
+  6. writes codes/<n>-<k>-<d>.json and prints the steps to open the PR
      (or opens it for you with --open-pr).
 
 If verification fails, nothing is written: you see exactly which check failed
@@ -40,10 +43,14 @@ import numpy as np
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _ROOT = os.path.dirname(_HERE)
 sys.path.insert(0, os.path.join(_ROOT, "verify"))
+sys.path.insert(0, os.path.join(_ROOT, "site"))
 
 import gf2                       # noqa: E402
 import heuristic_distance as hd  # noqa: E402
 from qldpc_verify import verify  # noqa: E402
+# Reuse the site's computed-cell + Pareto-frontier helpers so the PR body
+# states exactly what the board will show (no drift between the two).
+from build import cells, pareto, LOCALITY_LABEL, WEIGHT_LABEL  # noqa: E402
 
 
 # ----------------------------------------------------------------------------
@@ -243,8 +250,16 @@ def pr_body(doc, report, args, out, note_out=None):
                    "`provenance.notes`"),
         "",
         "### What frontier does this advance?",
-        "<!-- TODO: name the track and the existing entry this beats or "
-        "extends, and on which axis. -->",
+        "<!-- Computed by `qldpc submit` against the current board; review and "
+        "edit. -->",
+    ]
+    front = frontier_summary(doc, report)
+    if front:
+        lines += front
+    else:
+        lines += ["<!-- TODO: name the track and the existing entry this beats "
+                  "or extends, and on which axis. -->"]
+    lines += [
         f"Score kd^2/n = {round(k * d * d / n, 3)}, max check weight {wmax}, "
         f"locality class {comp.get('locality_class', 'unknown')}.",
         "",
@@ -267,6 +282,75 @@ def write_pr_body(slug, body):
     with os.fdopen(fd, "w") as f:
         f.write(body + "\n")
     return path
+
+
+# ----------------------------------------------------------------------------
+# frontier comparison (reuses the site's own cell + Pareto logic)
+# ----------------------------------------------------------------------------
+def _load_board_entries():
+    """The board's current entries as the site sees them (verified, earned
+    distance). Returns [] if the site builder cannot be imported or the board
+    is empty, so the frontier section degrades gracefully to a TODO."""
+    try:
+        from build import load_entries
+        return load_entries()
+    except Exception as e:
+        print(f"  note: could not load the current board for frontier "
+              f"comparison ({e}); leaving the frontier section as a TODO")
+        return []
+
+
+def _entry_for(doc, report):
+    """A board-shaped entry for the candidate, mirroring site/build.load_entries
+    (n, k, d, w, locality/weight class, eff). The site's pareto()/cells() only
+    read these keys, so this is enough to compare against the board."""
+    comp = report.get("computed", {})
+    n, k = doc["n"], doc["k"]
+    earned = report.get("earned_distance", {}).get("d")
+    d = earned["value"] if isinstance(earned, dict) else (earned or doc["distance"]["d"])
+    return {
+        "slug": f"{n}-{k}-{d}",
+        "n": n, "k": k, "d": d,
+        "eff": round(k * d * d / n, 3),
+        "w": comp.get("max_check_weight"),
+        "locality_class": comp.get("locality_class", "unrestricted"),
+        "weight_class": comp.get("weight_class", "weight-9plus"),
+    }
+
+
+def frontier_summary(doc, report):
+    """A human summary of where the candidate lands on the current board:
+    which track cells it belongs to, whether it sits on each cell's Pareto
+    frontier, and which existing entries it strictly dominates (and on which
+    axis). Returns a list of markdown lines (may be empty if the board is
+    unavailable)."""
+    entries = _load_board_entries()
+    if not entries:
+        return []
+    cand = _entry_for(doc, report)
+    lines = []
+    for cell in cells(cand):
+        L, W = cell
+        idxs = [i for i, e in enumerate(entries) if cell in cells(e)]
+        peers = [entries[i] for i in idxs]
+        # pareto() returns the set of indices on the frontier; the candidate is
+        # appended last, so its index is len(peers).
+        on_front = len(peers) in pareto(peers + [cand])
+        # existing entries the candidate strictly dominates on (n, k, d, w)
+        dominated = [e for e in peers
+                     if e["n"] >= cand["n"] and e["k"] <= cand["k"]
+                     and e["d"] <= cand["d"] and e["w"] >= cand["w"]
+                     and (e["n"] > cand["n"] or e["k"] < cand["k"]
+                          or e["d"] < cand["d"] or e["w"] > cand["w"])]
+        dominated.sort(key=lambda e: (-e["eff"], e["n"]))
+        head = (f"- **{LOCALITY_LABEL[L]} / {WEIGHT_LABEL[W]}**: "
+                f"{'on the Pareto frontier' if on_front else 'not on the frontier'}")
+        if dominated:
+            names = ", ".join(f"[[{e['n']},{e['k']},{e['d']}]]"
+                              for e in dominated)
+            head += f" — dominates {names}"
+        lines.append(head)
+    return lines
 
 
 # ----------------------------------------------------------------------------

--- a/verify/test_frontier_summary.py
+++ b/verify/test_frontier_summary.py
@@ -1,0 +1,80 @@
+"""The `qldpc submit` PR body now auto-fills the "what frontier does this
+advance?" section by reusing the site's computed-cell + Pareto logic. This
+checks the helper that shapes a candidate into a board entry, and that the
+summary runs against the real board without crashing and reports the candidate's
+cells.
+
+The frontier comparison is intentionally board-relative and read-only: it never
+writes, and it degrades to an empty summary (leaving the PR body's TODO) if the
+site builder cannot be imported.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "cli"))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "site"))
+
+import qldpc  # noqa: E402
+import qldpc_verify  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_fail = []
+
+
+def check(label, cond):
+    print(f"  {'OK ' if cond else 'FAIL'} {label}")
+    if not cond:
+        _fail.append(label)
+
+
+def main():
+    # --- _entry_for shapes a candidate like the site's load_entries ---------
+    doc = {
+        "n": 98, "k": 6,
+        "distance": {"d": 12, "X": {"value": 12}, "Z": {"value": 12}},
+    }
+    report = {
+        "computed": {"max_check_weight": 6, "locality_class": "unrestricted",
+                     "weight_class": "weight-6"},
+        "earned_distance": {"d": {"value": 12, "tier": "upper_bound"}},
+    }
+    e = qldpc._entry_for(doc, report)
+    check("entry carries n/k/d", (e["n"], e["k"], e["d"]) == (98, 6, 12))
+    check("entry carries w and classes",
+          (e["w"], e["locality_class"], e["weight_class"])
+          == (6, "unrestricted", "weight-6"))
+    check("eff = kd^2/n rounded", e["eff"] == round(6 * 12 * 12 / 98, 3))
+
+    # --- frontier_summary runs against the real board -----------------------
+    p = os.path.join(ROOT, "codes", "98-6-12.json")
+    if os.path.exists(p):
+        with open(p) as f:
+            bdoc = json.load(f)
+        brep = qldpc_verify.verify(bdoc, refute=False)
+        check("board code verifies", brep["ok"])
+        lines = qldpc.frontier_summary(bdoc, brep)
+        check("summary reports at least one cell", len(lines) >= 1)
+        check("summary lines mention a cell", any(" / " in ln for ln in lines))
+    else:
+        print("  (codes/98-6-12.json absent; skipping board-dependent checks)")
+
+    # --- graceful degradation when the board is unavailable -----------------
+    # _load_board_entries returns [] on import failure; frontier_summary then
+    # returns [] so the PR body keeps its TODO rather than crashing.
+    orig = qldpc._load_board_entries
+    qldpc._load_board_entries = lambda: []
+    try:
+        lines = qldpc.frontier_summary(doc, report)
+        check("empty board -> empty summary", lines == [])
+    finally:
+        qldpc._load_board_entries = orig
+
+    print(f"\n{'PASS' if not _fail else 'FAIL: ' + ', '.join(_fail)}")
+    return 1 if _fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`qldpc submit` now auto-fills the **"What frontier does this advance?"** section of the PR body, which was previously left as a `TODO` for every contributor to fill in by hand. With submissions landing daily, this removes the last manual step from the submission flow.

The CLI reuses the site's own computed-cell + Pareto-frontier logic (`cells`, `pareto` from `site/build.py`), so the PR body states exactly what the board will show — no drift between the claim and the rendered board.

For each track cell the candidate lands in, the body now reports:
- whether the code sits on that cell's Pareto frontier, and
- which existing board entries it strictly dominates (by `n`, `k`, `d`, `w`).

If the board can't be loaded (e.g. run outside the repo), it degrades gracefully back to the `TODO` comment rather than crashing.

## Changes

- **`cli/qldpc.py`** — added `_load_board_entries()`, `_entry_for()`, and `frontier_summary()`; wired the summary into `pr_body`. Updated the module docstring.
- **`verify/test_frontier_summary.py`** (new) — auto-discovered by `run_tests.py`; covers the entry-shaping helper, the real-board summary, and the graceful-degradation path.
- **`CONTRIBUTING.md`** — updated the "One command" section and the LLM prompt to reflect that the frontier section is now computed.

## Validation

- Full test suite passes: `10/10` test files (`uv run --frozen python run_tests.py --skip-slow`), including the new test.
- Manually exercised `frontier_summary` and the full `pr_body` against real board codes (e.g. `[[98,6,12]]` now renders "on the Pareto frontier — dominates [[180,6,10]], [[264,6,12]], ...").

## Notes

- The frontier claim is board-relative (same caveat as the site's star marker) — a strong starting point for review, not a statement against the wider literature; the PR body keeps an explicit "review and edit" comment.
- This PR touches only the three files above. It was built from an isolated worktree so it does not disturb any in-flight code submission.