### PR TITLE
CI: reject prose that cites files a reviewer cannot open

### DIFF
--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -1,0 +1,45 @@
+name: prose
+
+# Runs on every PR, including docs-only ones (verify.yml deliberately skips those,
+# but a note is exactly what needs checking here). Stdlib-only and seconds long.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+
+jobs:
+  prose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out submitted tree
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: submitted
+      # The checker runs from the base branch, like every other check here: a PR
+      # must not be able to weaken the check that judges it.
+      - name: check out trusted tree (base branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+          path: trusted
+      # The PR body is untrusted input: it reaches the checker as a FILE via the
+      # environment, never interpolated into a shell command.
+      - name: capture PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr_body.md"
+      - name: prose check (cited paths must resolve; no scaffolding left in)
+        working-directory: trusted
+        run: |
+          if [ -f verify/check_prose.py ]; then
+            python3 verify/check_prose.py \
+              --root ../submitted \
+              --base origin/${{ github.base_ref }} \
+              --body-file "$RUNNER_TEMP/pr_body.md"
+          else
+            echo "base branch has no verify/check_prose.py yet; skipping"
+          fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -99,6 +99,13 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.codes_changed != 'true'
         working-directory: submitted
         run: uv run --frozen python verify/verify_all.py
+      # Cheap metadata checks run BEFORE the ~15-minute refutation gate: a PR that
+      # fails one of them should not first burn a full gate run (PR #278 spent the
+      # whole gate on 18 valid layouts and then died on one authorship mismatch).
+      - name: authorship check (PR author must be a listed @handle author)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
+        working-directory: trusted
+        run: uv run --frozen python verify/check_authorship.py --root ../submitted --author "${{ github.event.pull_request.user.login }}" --base origin/${{ github.base_ref }}
       - name: distance refutation gate (trusted verifier for code changes)
         if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
         working-directory: trusted
@@ -114,7 +121,3 @@ jobs:
           name: verification-receipts-${{ github.event.pull_request.number }}
           path: receipts/
           if-no-files-found: warn
-      - name: authorship check (PR author must be a listed @handle author)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.codes_changed == 'true'
-        working-directory: trusted
-        run: uv run --frozen python verify/check_authorship.py --root ../submitted --author "${{ github.event.pull_request.user.login }}" --base origin/${{ github.base_ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,34 @@ Never run an ad-hoc `python -c` that calls a witness/distance search and only pr
 The `research/candidates/` directory is gitignored working output, so writes there are safe and never pollute the board. If a search finds a valid logical but the save fails, that is a hard
 error — stop and report it, do not just print.
 
+## Writing the submission (the PR body and the note)
+
+The board's durable value is the evidence trail, and an evidence trail that cites a file
+nobody else has is not one. `verify/check_prose.py` enforces this on every changed
+`notes/`/`fieldnotes/` file and on the PR body:
+
+**Every path you name must resolve in the PR's own tree.** If the artifact lives somewhere
+else, name the source and pin it — "taken from github.com/a7b/yarn @ 82fb695,
+`processor_codes/mitten/[[300,60,14]]/Hx.npy`" — or do not cite it. Never write "available
+on request", and never point at a private checkout (`~/…`, `/Users/…`) or a machine name.
+
+**`research/candidates/` is gitignored working output; it can never be the audit trail.**
+It is the right place to *stage* a candidate (see above) and the wrong place to *cite*. If
+a search script matters to the result, either commit it or describe the method in the note
+so someone can rewrite it.
+
+Two more, same reason:
+
+- What you claim in the body must match the file in the diff. A distance is `upper_bound`
+  until a certificate says otherwise — do not call a witnessed bound "certified", and do
+  not put a distance in the filename that the JSON does not support.
+- Delete the drafting scaffolding before asking for review: the `qldpc submit` footer, HTML
+  comments, unticked checklist boxes, session URLs. If a checklist box is not true, make it
+  true or say why.
+
+A note named `<n>-<k>-<d>.md` must state its own `[[n,k,d]]` first. Follow
+`notes/TEMPLATE.md`; its sections are what a later searcher reads.
+
 ## Working on the repo itself
 
 - `verify/` is the trust anchor and is hash-pinned in CI (`verify/check_validator_integrity.py`).

--- a/notes/TEMPLATE.md
+++ b/notes/TEMPLATE.md
@@ -1,5 +1,12 @@
 # [[n,k,d]] — one-line description of the construction
 
+<!-- Keep the [[n,k,d]] above matching the filename. Every path cited below must
+exist in this PR's tree, or name and pin its external source (e.g.
+"github.com/org/repo @ abc1234, `path/there.py`"). research/candidates/ is
+gitignored working output and cannot be cited as evidence: commit the script or
+describe the method. Checked by verify/check_prose.py. Delete this comment. -->
+
+
 ## Direction & hypothesis
 
 Which track cell and family you aimed at, and why. What made you expect an

--- a/verify/check_prose.py
+++ b/verify/check_prose.py
@@ -1,0 +1,243 @@
+"""Check that a PR body and its research notes only point at things a reader can open.
+
+The board's durable value is the evidence trail, and an evidence trail that cites
+a file nobody else has is not one. Three habits recur in agent-written submissions
+and this check refuses all three:
+
+  * a repo-relative path that does not exist in the PR's own tree (local tooling
+    named as if it were committed here);
+  * `research/candidates/` and other gitignored working output offered as the
+    audit trail -- it is deliberately never committed, so the citation cannot be
+    resolved by anyone, ever;
+  * an absolute local path (/Users/..., /tmp/...).
+
+The escape hatch is the convention the good notes already use: name the source
+and pin it, e.g. "taken from github.com/a7b/yarn @ 82fb695,
+`processor_codes/mitten/[[300,60,14]]/Hx.npy`". A file that names an external
+source is trusted to be citing that source, not this repo.
+
+Also refuses leftover tool scaffolding (an unedited `qldpc submit` draft footer,
+HTML comments, unticked checklist boxes), session URLs, and -- for a note named
+`<n>-<k>-<d>.md` -- a missing or mismatched [[n,k,d]] header.
+
+Only files CHANGED by the PR are checked. Notes already on the board are left
+alone; this guards what arrives from here on.
+
+Usage:
+  python verify/check_prose.py [--root PATH] [--base origin/main]
+                               [--body-file PATH] [--files a.md b.md]
+
+The PR body is passed as a FILE, never as a command-line string: it is untrusted
+input and must not reach a shell.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Directories the repo deliberately does not commit. Citing one as evidence is
+# unfalsifiable by construction -- AGENTS.md defines research/candidates/ as
+# gitignored working output.
+GITIGNORED = (
+    "research/candidates/",
+    "research/out/",
+    "research/runs/",
+    "build/",
+    ".venv/",
+    "__pycache__",
+)
+
+# Top-level directories that make a token repo-relative rather than incidental
+# prose. Anything starting with one of these must resolve in the tree.
+TOPDIRS = (
+    "codes/", "notes/", "verify/", "research/", "site/", "schema/", "certs/",
+    "docs/", "cli/", "decode/", "qldpc/", "talks/", "fieldnotes/", "tests/",
+    ".github/",
+)
+
+FILE_EXT = (
+    ".py", ".json", ".md", ".npz", ".npy", ".txt", ".csv", ".tex", ".yml",
+    ".yaml", ".ipynb", ".sh", ".lean", ".log", ".pkl",
+)
+
+ABSOLUTE_LOCAL = re.compile(
+    r"(?:^|[\s(`\"'])((?:/Users/|/home/|/tmp/|/private/tmp/|/var/folders/|~/|C:\\)[\w./\\~-]+)")
+
+# A file may cite an external artifact if it says where that artifact lives.
+EXTERNAL_MARKERS = re.compile(
+    r"https?://|github\.com|gitlab\.com|zenodo|doi\.org|arxiv\.org/abs|"
+    r"upstream repo|authors'? (?:own )?(?:published )?(?:repo|artifact)",
+    re.I)
+
+SESSION_URL = re.compile(r"claude\.ai/code/session[_/]|chatgpt\.com/c/", re.I)
+
+SCAFFOLDING = (
+    ("unedited `qldpc submit` draft footer",
+     re.compile(r"edit before requesting review", re.I)),
+    ("HTML comment left in the text", re.compile(r"<!--")),
+    ("unticked checklist box", re.compile(r"^\s*[-*]\s*\[ \]", re.M)),
+    ("TODO/FIXME placeholder", re.compile(r"\b(TODO|FIXME|TBD)\b")),
+)
+
+# Backticked span, or a bare slash-separated token.
+TOKEN = re.compile(r"`([^`\n]+)`|(?<![\w/`])((?:\.{0,2}/)?[\w.\-]+(?:/[\w.\-]+)+)")
+
+# arXiv-style identifiers look like paths (quant-ph/9601029) but are not.
+ARXIV_ID = re.compile(r"^(quant-ph|math|cs|cond-mat|physics)/")
+
+NKD = re.compile(r"\[\[\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\]\]")
+SLUG = re.compile(r"^(\d+)-(\d+)-(\d+)$")
+
+# The note template is scaffolding by definition: it carries the placeholder
+# header and the instruction comment that every real note must not.
+EXEMPT = {"notes/TEMPLATE.md"}
+
+
+def is_repo_pathish(tok):
+    """True when a token claims to be a path inside THIS repo."""
+    if not tok or " " in tok or tok.startswith(("http", "www.", "@", "#")):
+        return False
+    if ARXIV_ID.match(tok):
+        return False
+    if "<" in tok or ">" in tok or "*" in tok:      # placeholder or glob
+        return False
+    bare = tok.lstrip("./")
+    if bare.startswith(TOPDIRS):
+        return True
+    return "/" in bare and bare.endswith(FILE_EXT)
+
+
+def resolves(tok, root):
+    """A token resolves if the path, or the module file behind a
+    `module.function` / `file.py::symbol` reference, exists in the tree."""
+    bare = tok.lstrip("./").rstrip("/")
+    candidates = [bare]
+    if "::" in bare:                                 # file.py::symbol
+        candidates.append(bare.split("::", 1)[0])
+    if not bare.endswith(FILE_EXT):                  # research/kit/mod.function
+        head = bare.rsplit(".", 1)[0]
+        candidates += [head, head + ".py", bare + ".py"]
+    if any(os.path.exists(os.path.join(root, c)) for c in candidates):
+        return True
+    # An extensionless reference to a source file that is not .py: `verify/gf2_fast`
+    # is the C++ accelerator, shipped as gf2_fast.cpp and a built .so.
+    for c in candidates:
+        d, base = os.path.split(os.path.join(root, c))
+        if base and os.path.isdir(d):
+            if any(f.startswith(base + ".") for f in os.listdir(d)):
+                return True
+    return False
+
+
+def check_text(text, label, root, problems, is_note_slug=None):
+    external_ok = bool(EXTERNAL_MARKERS.search(text))
+    # One line per distinct problem: a path repeated through a note should be
+    # reported once, and never under two headings at the same time.
+    def add(why, detail):
+        if (label, why, detail) not in problems:
+            problems.append((label, why, detail))
+
+    absolute = set()
+    for m in ABSOLUTE_LOCAL.finditer(text):
+        absolute.add(m.group(1))
+        add("absolute local path", m.group(1))
+
+    if SESSION_URL.search(text):
+        add("session URL", "links a private session")
+
+    for why, pat in SCAFFOLDING:
+        if pat.search(text):
+            add("leftover scaffolding", why)
+
+    seen = set()
+    for m in TOKEN.finditer(text):
+        tok = (m.group(1) or m.group(2) or "").strip().rstrip(".,;:)`").lstrip("(")
+        if not is_repo_pathish(tok) or tok in seen or tok in absolute:
+            continue
+        seen.add(tok)
+        bare = tok.lstrip("./")
+        if any(g in bare for g in GITIGNORED):
+            add("gitignored working output cited as evidence", tok)
+        elif not resolves(tok, root) and not external_ok:
+            add("path does not exist in this tree", tok)
+
+    if is_note_slug:
+        n, k, d = is_note_slug
+        found = NKD.findall(text)
+        if not found:
+            add("note states no [[n,k,d]]", f"expected [[{n},{k},{d}]]")
+        elif found[0] != (n, k, d):
+            add("note's first [[n,k,d]] disagrees with its filename",
+                f"[[{','.join(found[0])}]] vs [[{n},{k},{d}]]")
+
+
+def changed_prose(base, root):
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "--diff-filter=AMR", f"{base}...HEAD"],
+            cwd=root, text=True)
+    except Exception as e:
+        print(f"could not diff vs {base}: {e}; failing closed")
+        return None
+    return [f for f in out.splitlines()
+            if f.endswith(".md") and (f.startswith("notes/")
+                                      or f.startswith("fieldnotes/"))]
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=ROOT)
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--body-file",
+                    help="file holding the PR body (never pass the body inline)")
+    ap.add_argument("--files", nargs="*",
+                    help="explicit files to check instead of the diff")
+    args = ap.parse_args(argv)
+    root = os.path.abspath(args.root)
+
+    files = args.files
+    if files is None:
+        files = changed_prose(args.base, root)
+        if files is None:
+            return 1
+
+    problems = []
+    for rel in files:
+        if rel in EXEMPT:
+            continue
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        slug = None
+        m = SLUG.match(os.path.basename(rel)[:-3])
+        if m and rel.startswith("notes/"):
+            slug = m.groups()
+        check_text(text, rel, root, problems, is_note_slug=slug)
+
+    if args.body_file and os.path.exists(args.body_file):
+        with open(args.body_file, encoding="utf-8") as f:
+            check_text(f.read(), "PR body", root, problems)
+
+    if not problems:
+        print(f"prose check ok ({len(files)} file(s) checked)")
+        return 0
+
+    print("Prose check failed: the text points at things a reviewer cannot open.\n")
+    for label, why, detail in problems:
+        print(f"  {label}: {why}\n    {detail}")
+    print("\nFix by pointing at something that exists in this PR, or by naming the")
+    print("external source and pinning it (e.g. 'github.com/org/repo @ abc1234,")
+    print("`path/in/that/repo.py`'). research/candidates/ is gitignored working")
+    print("output and can never be cited as evidence. See AGENTS.md, 'Writing the")
+    print("submission'.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/verify/test_check_prose.py
+++ b/verify/test_check_prose.py
@@ -1,0 +1,125 @@
+"""Tests for verify/check_prose.py.
+
+Fixtures are synthetic (written to a temp tree) so the suite does not depend on
+which notes happen to be on the board; the last case pins the one behaviour that
+must hold against the real repo -- a note citing an attributed external artifact
+passes, and a note citing gitignored working output does not.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_HERE)
+sys.path.insert(0, _HERE)
+import check_prose
+
+FAILURES = []
+
+
+def check(name, ok, detail=""):
+    print(("PASS" if ok else "FAIL"), name, detail)
+    if not ok:
+        FAILURES.append(name)
+
+
+def problems_for(text, root, slug=None):
+    out = []
+    check_prose.check_text(text, "t.md", root, out, is_note_slug=slug)
+    return [why for _, why, _ in out]
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        os.makedirs(os.path.join(tmp, "research", "kit"))
+        open(os.path.join(tmp, "research", "kit", "group_algebra.py"), "w").close()
+
+        check("path that exists resolves",
+              problems_for("built with `research/kit/group_algebra.py`", tmp) == [])
+
+        check("module.function form resolves",
+              problems_for("call `research/kit/group_algebra.build_2bga`", tmp) == [])
+
+        check("file::symbol form resolves",
+              problems_for("see `research/kit/group_algebra.py::build_2bga`", tmp) == [])
+
+        check("missing path is caught",
+              problems_for("MILP via `evaluation/distance_milp.py`", tmp)
+              == ["path does not exist in this tree"])
+
+        check("missing path is allowed when an external source is named",
+              problems_for(
+                  "MILP via `evaluation/distance_milp.py` from "
+                  "https://github.com/qiskit-community/qcode-discovery", tmp) == [])
+
+        check("pinned external artifact passes",
+              problems_for(
+                  "taken from github.com/a7b/yarn @ 82fb695, "
+                  "`processor_codes/mitten/Hx.npy`", tmp) == [])
+
+        check("gitignored dir is caught even with an external source named",
+              problems_for(
+                  "evidence in `research/candidates/run1/` see https://example.com",
+                  tmp) == ["gitignored working output cited as evidence"])
+
+        check("absolute local path is caught",
+              "absolute local path"
+              in problems_for("ran /Users/me/scratch/search.py", tmp))
+
+        check("session URL is caught",
+              "session URL" in problems_for(
+                  "https://claude.ai/code/session_01ABC", tmp))
+
+        check("scaffolding is caught",
+              "leftover scaffolding" in problems_for(
+                  "Drafted by `qldpc submit`; edit before requesting review.", tmp))
+
+        check("unticked checkbox is caught",
+              "leftover scaffolding" in problems_for("- [ ] verified", tmp))
+
+        check("arXiv id is not treated as a path",
+              problems_for("see quant-ph/9601029 for the original", tmp) == [])
+
+        check("placeholder path is not treated as a path",
+              problems_for("writes `codes/<n>-<k>-<d>.json`", tmp) == [])
+
+        check("note slug mismatch is caught",
+              "note's first [[n,k,d]] disagrees with its filename"
+              in problems_for("# [[270,54,12]] code", tmp, slug=("270", "54", "10")))
+
+        check("note with no params is caught",
+              "note states no [[n,k,d]]"
+              in problems_for("A note with no parameters.", tmp,
+                              slug=("482", "146", "42")))
+
+        check("matching note slug passes",
+              problems_for("# [[270,54,10]] code", tmp, slug=("270", "54", "10"))
+              == [])
+
+    # Against the real tree: the two behaviours the check exists to distinguish.
+    real = os.path.join(ROOT, "notes", "300-60-14.md")
+    if os.path.exists(real):
+        r = subprocess.run([sys.executable, os.path.join(_HERE, "check_prose.py"),
+                            "--files", "notes/300-60-14.md"],
+                           cwd=ROOT, capture_output=True, text=True)
+        check("real note with a pinned external artifact passes",
+              r.returncode == 0, r.stdout.strip().splitlines()[-1:] or "")
+
+    real = os.path.join(ROOT, "notes", "700-75-3.md")
+    if os.path.exists(real):
+        r = subprocess.run([sys.executable, os.path.join(_HERE, "check_prose.py"),
+                            "--files", "notes/700-75-3.md"],
+                           cwd=ROOT, capture_output=True, text=True)
+        check("real note citing research/candidates/ fails", r.returncode == 1)
+
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} failure(s): {', '.join(FAILURES)}")
+        return 1
+    print("all prose checks pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `verify/check_prose.py`, run on every PR against the changed `notes/` and `fieldnotes/` files and the PR body.

## Why

An evidence trail that cites a file nobody else has is not one. Auditing the 276 code-submission PRs merged so far, and the notes currently on the board:

| | unresolvable reference |
|---|---|
| notes | 30 / 96 |
| PR bodies | 10 / 276 |
| fieldnotes | 0 / 11 |

Four habits produce it: local tooling named as if it were committed here (`research/kit/cornucopia.py`, `research/geometry_audit.py`, `research/kit/surrogate_fast.py`); literal scratch paths (`/tmp/dense_7.npz` in four of the dense-code notes) and private checkouts (`~/qldpc-challenge`, machine names); a fieldnote that was never committed, cited from both a note and a PR; and `research/candidates/` — which `AGENTS.md` defines as gitignored working output — offered as the audit trail in nine notes.

Notes are the worse case, and that is a side effect of something that went right. Note coverage went 0% → 85% and the ladder detail correctly moved out of PR bodies into notes; the unverifiable references moved with it, into the artifact a later searcher actually relies on. `notes/700-75-3.md` is already cited by a later submission (#462) for its boundary-parity failure mode, so a dangling pointer there costs someone a re-derivation.

## The rule, and its escape hatch

Every path named must resolve in the PR's own tree — **unless** the file names and pins an external source. That is the convention the good notes already use:

> taken verbatim from the authors' own published artifact: github.com/a7b/yarn @ 82fb695, `processor_codes/mitten/[[300,60,14]]/Hx.npy`
> — `notes/300-60-14.md`

A file that names its source is trusted to be citing that source rather than this repo, so the mitten notes and the qcode-discovery MILP notes pass unchanged. `research/candidates/` has no escape hatch: it is deliberately never committed, so the citation cannot be resolved by anyone.

Also refused: leftover drafting scaffolding (the `qldpc submit` footer, HTML comments, unticked checklist boxes — 37 PRs merged carrying one), session URLs, and a note whose `[[n,k,d]]` is missing or disagrees with its filename (`notes/270-54-10.md` leads with `[[270,54,12]]`; `notes/482-146-42.md` and `notes/578-18-20.md` state none).

**Only changed files are checked.** The 30 notes currently on the board are left as they are — this guards what arrives from here on.

## Calibration

Run over all 96 notes and 11 fieldnotes: 30 flagged, 77 clean, no false positives after two fixes — `verify/gf2_fast` resolves through its `.cpp`/`.so`, and `module.function` / `file.py::symbol` forms resolve through the module file. Each distinct problem is reported once. `notes/TEMPLATE.md` is exempt: a template is scaffolding by definition.

## Supporting changes

- **`AGENTS.md` gains a "Writing the submission" section.** This repo's record is that prose guidance does not hold and CI does: one-code-per-PR and the n≤700 cap have had zero violations since they became checks, while provenance fix-up commits went 3 → 1 → 23 across the same window despite five `CONTRIBUTING.md` edits. The section is written as the checker's rationale rather than as a second place to state the rule. `notes/TEMPLATE.md` gets the same rule where it will be copied.
- **`verify.yml` runs the authorship check before the refutation gate.** The cheap metadata checks ran last, which is how #278 spent a full ~15-minute gate on 18 valid layouts and then failed on a single authorship mismatch — those layouts were never resubmitted, and `codes/263-16-12.json` still sits at radius 5.0 today. The receipts step added since is untouched and still runs after the gate.

## Notes for review

- The prose job runs from the base branch, like every other check here, so a PR cannot weaken the check that judges it.
- The PR body reaches the checker as a **file via the environment**, never as a shell argument — it is untrusted input.
- The job runs on all PRs including docs-only ones, which `verify.yml` deliberately skips; it is stdlib-only and takes seconds.
- `check_prose.py` is **not** part of the hash-pinned trusted stack — it does not decide whether a code is valid, so no `check_validator_integrity.py --update` is needed.
- The step no-ops until this merges, since the base branch has no `check_prose.py` yet.

Full suite green locally: 8/8 test files, including the new `verify/test_check_prose.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
