### PR TITLE
Clarify contributor and autoresearch workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,28 @@ This repo is a public, automatically verified leaderboard for quantum LDPC (qLDP
 The `verify/` stack machine-checks submissions; `research/` is a starter kit for constructing
 and searching for new codes.
 
+## Choose the workflow before acting
+
+There are two supported workflows. The user's publication authorization determines which one
+applies:
+
+### Contributor-driven submission
+
+Use this when the user explicitly asks you to submit a code, prepare a PR, create a branch,
+commit, push, or open a PR on their behalf. Follow `CONTRIBUTING.md`. After the candidate passes
+the trusted validation gate, the agent may write the verified submission to `codes/` and use
+`./qldpc submit ... --open-pr` to create the branch, commit, push, and PR.
+
+### Unattended autoresearch
+
+Use this when the task is to explore or search for candidates without human review or explicit
+publication authorization. Follow `research/AUTORESEARCH.md`. Candidates stay in
+`research/candidates/`; do not write to `codes/`, commit, or open a PR. Report staged survivors
+for a human to review and promote.
+
+If both documents are read, this section is the precedence rule: an explicit contributor-driven
+submission request selects the first workflow; otherwise use unattended autoresearch.
+
 ## Doing autoresearch (finding new codes)
 
 Read **[`research/AUTORESEARCH.md`](research/AUTORESEARCH.md)** and follow it. That is the
@@ -12,8 +34,10 @@ tool-agnostic operating manual for the research loop and the reference for the `
 The one rule, up front so it is never missed:
 
 **No code is a "find" until `verify/validate_candidate.py` returns `passed: true` for it.**
-Never write your own distance/quality check; never edit anything under `verify/` (the trusted,
-CI-hash-pinned stack); stage candidates for human review — never commit to `codes/` or open a PR.
+Never write your own distance/quality check or edit anything under `verify/` (the trusted,
+CI-hash-pinned stack). In unattended autoresearch, stage candidates for human review; the
+contributor-driven workflow above is allowed to promote a validated candidate into `codes/`
+and open a PR when the user explicitly authorized that submission.
 
 A second rule, equally non-negotiable:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Useful flags:
 
 Either way — `--open-pr`, or the commands it prints for you to run — the PR
 body is drafted for you from
-[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and the
+[`.github/pull_request_template.md`](.github/pull_request_template.md) and the
 verified submission: parameters, the computed track membership, distance
 confidence, construction, and a pointer to your note. The "what frontier does
 this advance?" section is now **computed too**: `qldpc submit` reuses the
@@ -117,14 +117,14 @@ If you have an LLM or coding agent, it can do the whole loop: pick a target,
 search for a code, verify it, and open the PR. This is the lowest-effort way in.
 Paste the prompt below into your agent.
 
-A note on scope: here your agent acts on *your* behalf, so it may open the PR
-from your account (you are the author of record and CI checks that the PR
-author is listed in the code's `authors`). This is different from the in-repo
-autoresearch manual, [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md),
-whose stage-only rule (never commit to `codes/`, never open a PR) governs
-autonomous research runs where no human has reviewed the candidate yet. If
-your agent reads both documents: this section wins for a contributor-driven
-submission; AUTORESEARCH.md wins for an unattended search. 
+A note on scope: this contributor-driven section applies only when you explicitly
+ask the agent to submit on your behalf. In that case the agent acts from your
+account (you are the author of record and CI checks that the PR author is listed
+in the code's `authors`). Without that explicit publication authorization, use
+the stage-only workflow in [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md):
+do not commit to `codes/` or open a PR. If an agent reads both documents, this
+section wins for an explicit contributor-driven submission; AUTORESEARCH.md wins
+otherwise.
 The method follows IBM's LLM-guided
 evolutionary search for these codes (arXiv:2606.02418): the model mutates the
 program that generates a code, rather than tweaking numbers by hand.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ one winner. Construction family is a separate filter tag. See
 
 ## Start here
 
+Choose the workflow before you begin. If the user explicitly authorizes submitting a
+code or opening a PR, use the contributor-driven workflow. Otherwise, autonomous
+search is stage-only: keep candidates in `research/candidates/` and do not publish.
+See [`AGENTS.md`](AGENTS.md) for the precedence rule.
+
 | You want to... | Read |
 |---|---|
 | Submit a code you already have | [`CONTRIBUTING.md`](CONTRIBUTING.md) — one command: `./qldpc submit` |
-| Have an LLM find and submit a code | [Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) (a ready-to-paste prompt) and [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md) (the full research-loop manual) |
+| Have an LLM find and submit a code on your behalf | [Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) (a ready-to-paste prompt) |
+| Have an agent search without publishing | [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md) (stage-only research workflow) |
 | Understand the boards and the targets to beat | [`TRACKS.md`](TRACKS.md) — especially the "Reference bars" section |
 | Point a coding agent at this repo | [`AGENTS.md`](AGENTS.md) |
 
@@ -106,9 +112,10 @@ uv run python verify/qldpc_verify.py codes/your-code.json
 
 ## Bring your LLM
 
-If you have an LLM or coding agent, it can do the whole loop — pick a target
-from the reference bars, search a construction family, verify locally, and
-open the PR from your account. This is the lowest-effort way to participate:
+If you have explicitly authorized a contributor-driven submission, an LLM or
+coding agent can do the whole loop — pick a target from the reference bars,
+search a construction family, verify locally, and open the PR from your account.
+This is the lowest-effort way to participate:
 paste the ready-made prompt from
 [Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) into your
 agent. The tool-agnostic operating manual for the research loop (constructors,

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -428,7 +428,7 @@ def cmd_submit(args):
     print(f"  gh pr create --title {title!r} --body-file {body_file}")
     print(f"\nthe PR body was drafted for you from the verified submission:"
           f"\n  {body_file}"
-          f"\nit follows .github/PULL_REQUEST_TEMPLATE.md — read it and fill"
+          f"\nit follows .github/pull_request_template.md — read it and fill"
           f"\nin the 'what frontier does this advance?' section before review.")
     print("\nor re-run with --open-pr to do this automatically.")
     return 0
@@ -440,7 +440,7 @@ def open_pr(slug, out, note_out=None, title=None, body_file=None):
     title = title or f"Add [[{n_k_d}]]"
     add = ["git", "add", out] + ([note_out] if note_out else [])
     # --title/--body-file rather than --fill: the body is the filled-in
-    # PULL_REQUEST_TEMPLATE, which the commit message does not carry (#404).
+    # pull request template, which the commit message does not carry (#404).
     create = ["gh", "pr", "create", "--title", title]
     create += ["--body-file", body_file] if body_file else ["--fill"]
     cmds = [
@@ -516,7 +516,7 @@ def main(argv=None):
         prog="qldpc", description="qLDPC challenge submission tool")
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    s = sub.add_parser("submit", help="build, verify, score, and stage a code")
+    s = sub.add_parser("submit", help="build, verify, and prepare a code submission")
     s.add_argument("code", help=".npz with H_X/H_Z (+ optional coords) or a "
                                 ".json draft")
     s.add_argument("--authors", nargs="+", required=True,


### PR DESCRIPTION
## Summary

Clarifies the distinction between contributor-driven submissions and unattended autoresearch so agents can determine when they are authorized to open a PR.

## Changes

- Adds an explicit workflow decision and precedence rule to `AGENTS.md`.
- Scopes the stage-only restriction to unattended research.
- Separates the two workflows in `README.md`.
- Clarifies publication authorization in `CONTRIBUTING.md`.
- Corrects the pull request template path and removes misleading stage-only CLI wording.

## Validation

- `git diff --check`
- `uv run python cli/qldpc.py submit --help`

Only the four workflow/documentation files are included in this PR.