### PR TITLE
Add optional fast backend for research screening

### DIFF
--- a/research/AUTORESEARCH.md
+++ b/research/AUTORESEARCH.md
@@ -163,7 +163,9 @@ update_leaderboard("board.json", records)   # merge + persist, so a sweep can re
 description of how the code was built — so you can point it at **your own generator** for any
 family. `sample_bb` is a ready-made one; a 2BGA or coset sampler over `group_algebra` / `coset`
 has the same shape. `backend="fast"` requires `make fast`; `threads=` controls its CPU workers.
-All screening values remain upper bounds, and finalists must still pass the validation gate.
+The `trials` value is backend-specific: NumPy iterations and fast RIS samples are
+not comparable screening budgets. All screening values remain upper bounds, and
+finalists must still pass the validation gate.
 
 ## 4. Package a submission
 

--- a/research/AUTORESEARCH.md
+++ b/research/AUTORESEARCH.md
@@ -6,11 +6,9 @@ tool. It is both the **operating manual for the research loop** and the **refere
 `research/` starter kit**: constructing a code, estimating its distance, and packaging a
 verifiable submission.
 
-Everything in `research/` is **pure numpy** (no deps beyond what the verifier needs) and sits
-directly on the verifier's own GF(2) core, so what you build here is exactly what the board
-records. Your job: given a research direction, construct and search qLDPC codes and surface
-**verified, genuinely-new candidates** for human review. You may write and run any code you
-like — but you do **not** get to decide whether a code is good. A trusted gate does.
+The default path in `research/` is pure NumPy. An optional bit-packed C++ RIS backend can be
+built with `make fast` for larger screens and confirmation runs; Python still validates its
+witnesses.
 
 Layout:
 
@@ -153,6 +151,10 @@ frontier.
 from search import screen, pareto_frontier, sample_bb, update_leaderboard
 records = screen(sample_bb(400, seed=7), min_k=4, min_d=4, trials=250)
 records[:5]                       # best by k*d^2/n (the board's headline metric)
+
+# ``auto`` uses gf2_fast when available and otherwise falls back to NumPy.
+records = screen(sample_bb(10_000, seed=7), min_k=4, min_d=4, trials=2_000,
+                 backend="auto", threads=8)
 pareto_frontier(records)          # the non-dominated codes over (n, k, d)
 update_leaderboard("board.json", records)   # merge + persist, so a sweep can resume
 ```
@@ -160,8 +162,8 @@ update_leaderboard("board.json", records)   # merge + persist, so a sweep can re
 `screen` consumes any iterable of `(spec, HX, HZ)` triples, where `spec` is a JSON-serializable
 description of how the code was built — so you can point it at **your own generator** for any
 family. `sample_bb` is a ready-made one; a 2BGA or coset sampler over `group_algebra` / `coset`
-has the same shape. Because the screening distance is the surrogate *upper bound*, `screen`
-ranks **candidates** — validate the winners before claiming anything (next).
+has the same shape. `backend="fast"` requires `make fast`; `threads=` controls its CPU workers.
+All screening values remain upper bounds, and finalists must still pass the validation gate.
 
 ## 4. Package a submission
 

--- a/research/kit/search.py
+++ b/research/kit/search.py
@@ -8,11 +8,12 @@ standard three stages:
     2. screen     skip k < min_k; estimate d with the surrogate; score by k*d^2/n
     3. rank       sort by efficiency and/or extract the Pareto frontier
 
-All pure numpy. The screening distance is ``surrogate.distance_rand`` -- an
-UPPER bound -- so ``screen`` gives you ranked *candidates*, not certified codes.
-Confirm the finalists' distance (``research/kit/distance.py``: exact MILP or decoder
-corroboration) before claiming anything, then package the winner with
-``submit.make_submission``.
+The default path is pure numpy. ``surrogate.distance_rand`` also supports an
+optional bit-packed C++ RIS backend (``backend="fast"`` or ``"auto"`` after
+``make fast``). The screening distance is always an UPPER bound, so ``screen``
+gives you ranked *candidates*, not certified codes. Confirm the finalists'
+distance (``research/kit/distance.py``: exact MILP or decoder corroboration)
+before claiming anything, then package the winner with ``submit.make_submission``.
 
 ``screen`` consumes any iterable of ``(label, HX, HZ)`` triples, so you can point
 it at your own generator. Ready-made samplers ship for the BB family
@@ -51,7 +52,8 @@ def fingerprint(HX, HZ):
 
 
 def screen(candidates, *, min_k=1, min_d=1, trials=400, seed=0,
-           metric=efficiency, keep=None, verbose=False):
+           metric=efficiency, keep=None, verbose=False, backend="numpy",
+           threads=1):
     """Screen an iterable of ``(spec, HX, HZ)`` candidates.
 
     ``spec`` is any JSON-serializable description of how the code was built (a
@@ -60,7 +62,8 @@ def screen(candidates, *, min_k=1, min_d=1, trials=400, seed=0,
     estimate ``d`` with ``distance_rand`` (upper bound; require ``d >= min_d``),
     and score with ``metric(n, k, d)``. Returns records
     ``{spec, n, k, d, efficiency, fingerprint}`` sorted by score (best first),
-    deduplicated by fingerprint, truncated to ``keep`` if given.
+    deduplicated by fingerprint, truncated to ``keep`` if given. ``backend`` and
+    ``threads`` control the optional accelerated distance screen.
     """
     seen = {}
     for spec, HX, HZ in candidates:
@@ -73,7 +76,9 @@ def screen(candidates, *, min_k=1, min_d=1, trials=400, seed=0,
         if fp in seen:
             continue
         n = int(HX.shape[1])
-        d = distance_rand(HX, HZ, trials=trials, seed=seed + int(fp, 16))
+        d = distance_rand(
+            HX, HZ, trials=trials, seed=seed + int(fp, 16),
+            backend=backend, threads=threads)
         if d == float("inf") or d < min_d:
             continue
         w = int(max((HX.shape[0] and max((int(r.sum()) for r in HX), default=0)),

--- a/research/kit/surrogate.py
+++ b/research/kit/surrogate.py
@@ -30,7 +30,7 @@ import numpy as np
 from css import kernel_basis, logical_basis, commutes, in_rowspace
 
 try:
-    import gf2_fast as _fast       # optional; build with ``make fast``
+    import gf2_fast as _fast
 except ImportError:
     _fast = None
 
@@ -52,7 +52,8 @@ def _validate_fast_witness(HX, HZ, weight, side, support):
 
 
 def _distance_rand_fast(HX, HZ, trials, seed, threads):
-    assert _fast is not None
+    if _fast is None:
+        raise RuntimeError("gf2_fast backend is unavailable")
     weight, side, support = _fast.distance_rand_witness(
         np.asarray(HX, dtype=np.int8), np.asarray(HZ, dtype=np.int8),
         trials=int(trials), seed=int(seed), pair_depth=10, threads=int(threads))

--- a/research/kit/surrogate.py
+++ b/research/kit/surrogate.py
@@ -21,11 +21,44 @@ submission built this way is ``"upper_bound"``; an ``"exact"`` claim is a
 separate, server-certified tier (see ``verify/certify.py``). The witness this
 search returns is exactly what the verifier checks to certify the upper bound.
 
-Pure numpy; no exact-solver or decoder dependency (those are a later phase).
+The default path is pure numpy. An optional ``gf2_fast`` backend accelerates the
+randomized screening search after ``make fast``; no exact-solver or decoder
+dependency is needed here.
 """
 import numpy as np
 
-from css import kernel_basis, logical_basis
+from css import kernel_basis, logical_basis, commutes, in_rowspace
+
+try:
+    import gf2_fast as _fast       # optional; build with ``make fast``
+except ImportError:
+    _fast = None
+
+
+def _validate_fast_witness(HX, HZ, weight, side, support):
+    """Validate an accelerator proposal with the Python GF(2) stack."""
+    if side not in ("X", "Z"):
+        return weight == HX.shape[1] + 1 and not support
+    support = [int(q) for q in support]
+    n = HX.shape[1]
+    if len(support) != len(set(support)) or any(q < 0 or q >= n for q in support):
+        return False
+    if int(weight) != len(support):
+        return False
+    v = np.zeros(n, dtype=np.int8)
+    v[support] = 1
+    own, opposite = (HX, HZ) if side == "X" else (HZ, HX)
+    return commutes(v, opposite) and not in_rowspace(v, own)
+
+
+def _distance_rand_fast(HX, HZ, trials, seed, threads):
+    assert _fast is not None
+    weight, side, support = _fast.distance_rand_witness(
+        np.asarray(HX, dtype=np.int8), np.asarray(HZ, dtype=np.int8),
+        trials=int(trials), seed=int(seed), pair_depth=10, threads=int(threads))
+    if not _validate_fast_witness(HX, HZ, weight, side, support):
+        raise RuntimeError("gf2_fast returned an invalid logical witness")
+    return int(weight)
 
 
 # =====================================================================
@@ -155,9 +188,21 @@ def lightest_logical(Hself, Hopp, trials=8000, seed=0):
     return _search_lightest(Hself, Hopp, trials, seed)
 
 
-def distance_rand(HX, HZ, trials=2000, seed=0):
-    """Upper bound on the code distance d = min(d_X, d_Z), as an int. Cheap
-    screening number; for the witnesses, call ``lightest_logical`` per side."""
+def distance_rand(HX, HZ, trials=2000, seed=0, *, backend="numpy", threads=1):
+    """Return a randomized upper bound on ``d = min(d_X, d_Z)``.
+
+    ``backend`` is ``"numpy"`` (portable), ``"fast"`` (requires ``make fast``),
+    or ``"auto"`` (fast when available, otherwise NumPy). Fast proposals are
+    validated by Python; this remains an upper-bound search, not a proof.
+    """
+    if backend not in ("numpy", "fast", "auto"):
+        raise ValueError("backend must be 'numpy', 'fast', or 'auto'")
+    if threads < 1:
+        raise ValueError("threads must be at least 1")
+    if backend in ("fast", "auto") and _fast is not None:
+        return _distance_rand_fast(HX, HZ, trials, seed, threads)
+    if backend == "fast":
+        raise ImportError("gf2_fast is unavailable; run `make fast` to build it")
     wx, _ = _search_lightest(HX, HZ, trials, seed)
     wz, _ = _search_lightest(HZ, HX, trials, seed)
     return min(wx, wz)

--- a/research/kit/surrogate.py
+++ b/research/kit/surrogate.py
@@ -51,6 +51,11 @@ def _validate_fast_witness(HX, HZ, weight, side, support):
     return commutes(v, opposite) and not in_rowspace(v, own)
 
 
+def _weight_or_inf(weight, n):
+    """Normalize gf2_fast's no-logical sentinel to NumPy's infinity result."""
+    return float("inf") if int(weight) > n else int(weight)
+
+
 def _distance_rand_fast(HX, HZ, trials, seed, threads):
     if _fast is None:
         raise RuntimeError("gf2_fast backend is unavailable")
@@ -59,10 +64,7 @@ def _distance_rand_fast(HX, HZ, trials, seed, threads):
         trials=int(trials), seed=int(seed), pair_depth=10, threads=int(threads))
     if not _validate_fast_witness(HX, HZ, weight, side, support):
         raise RuntimeError("gf2_fast returned an invalid logical witness")
-    # Match the NumPy backend's no-witness result so screen() filters it out.
-    if weight > HX.shape[1]:
-        return float("inf")
-    return int(weight)
+    return _weight_or_inf(weight, HX.shape[1])
 
 
 # =====================================================================

--- a/research/kit/surrogate.py
+++ b/research/kit/surrogate.py
@@ -58,6 +58,9 @@ def _distance_rand_fast(HX, HZ, trials, seed, threads):
         trials=int(trials), seed=int(seed), pair_depth=10, threads=int(threads))
     if not _validate_fast_witness(HX, HZ, weight, side, support):
         raise RuntimeError("gf2_fast returned an invalid logical witness")
+    # Match the NumPy backend's no-witness result so screen() filters it out.
+    if weight > HX.shape[1]:
+        return float("inf")
     return int(weight)
 
 
@@ -194,6 +197,8 @@ def distance_rand(HX, HZ, trials=2000, seed=0, *, backend="numpy", threads=1):
     ``backend`` is ``"numpy"`` (portable), ``"fast"`` (requires ``make fast``),
     or ``"auto"`` (fast when available, otherwise NumPy). Fast proposals are
     validated by Python; this remains an upper-bound search, not a proof.
+    ``trials`` counts different search operations in the two backends, so the
+    same value is not a comparable screening budget across backends.
     """
     if backend not in ("numpy", "fast", "auto"):
         raise ValueError("backend must be 'numpy', 'fast', or 'auto'")

--- a/research/test_fast_backend.py
+++ b/research/test_fast_backend.py
@@ -11,55 +11,54 @@ import surrogate
 from surrogate import distance_rand
 from search import screen, sample_bb
 
-try:
-    import gf2_fast
-except ImportError:
-    gf2_fast = None
+_fail = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'}  {name}")
+    if not cond:
+        _fail.append(name)
+
+
+def raises(exc, fn, *args, **kwargs):
+    """Return whether calling ``fn`` raises ``exc``."""
+    try:
+        fn(*args, **kwargs)
+    except exc:
+        return True
+    return False
 
 
 def main():
+    print("research/ optional fast-backend test:")
     p = KNOWN["[[72,12,6]]"]
     HX, HZ = build_bb(p["l"], p["m"], p["A"], p["B"])
+    n = HX.shape[1]
 
-    assert distance_rand(HX, HZ, trials=100, seed=0, backend="numpy") == 6
-    assert distance_rand(HX, HZ, trials=100, seed=0, backend="auto") == 6
+    check("NumPy backend finds distance 6",
+          distance_rand(HX, HZ, trials=100, seed=0, backend="numpy") == 6)
+    check("auto backend finds distance 6",
+          distance_rand(HX, HZ, trials=100, seed=0, backend="auto") == 6)
+    check("invalid backend is rejected",
+          raises(ValueError, distance_rand, HX, HZ, trials=1, backend="invalid"))
+    check("sentinel maps to infinity",
+          surrogate._weight_or_inf(n + 1, n) == float("inf"))
 
-    try:
-        distance_rand(HX, HZ, trials=1, backend="invalid")
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("invalid backend was accepted")
-
-    class NoLogicalBackend:
-        @staticmethod
-        def distance_rand_witness(*args, **kwargs):
-            return HX.shape[1] + 1, "", []
-
-    original_backend = surrogate._fast
-    surrogate._fast = NoLogicalBackend()
-    try:
-        assert distance_rand(HX, HZ, trials=1, backend="fast") == float("inf")
-    finally:
-        surrogate._fast = original_backend
-
-    if gf2_fast is not None:
-        assert distance_rand(
-            HX, HZ, trials=100, seed=0, backend="fast", threads=2) == 6
+    if surrogate._fast is not None:
+        check("fast backend finds distance 6",
+              distance_rand(HX, HZ, trials=100, seed=0,
+                            backend="fast", threads=2) == 6)
         records = screen(
             sample_bb(4, seed=1), min_k=2, min_d=2, trials=20,
             backend="fast", threads=2)
-        assert records
+        check("fast screening produced candidates", bool(records))
     else:
-        try:
-            distance_rand(HX, HZ, trials=1, backend="fast")
-        except ImportError:
-            pass
-        else:
-            raise AssertionError("explicit fast backend did not report missing extension")
+        check("missing fast backend is reported",
+              raises(ImportError, distance_rand, HX, HZ,
+                     trials=1, backend="fast"))
 
-    print("PASS: optional fast backend and NumPy fallback")
-    return 0
+    print("PASS" if not _fail else "FAIL: " + ", ".join(_fail))
+    return 0 if not _fail else 1
 
 
 if __name__ == "__main__":

--- a/research/test_fast_backend.py
+++ b/research/test_fast_backend.py
@@ -1,0 +1,53 @@
+"""Regression tests for the optional accelerated research backend."""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "kit"))
+sys.path.insert(0, os.path.join(_HERE, "..", "verify"))
+
+from bb import build_bb, KNOWN
+from surrogate import distance_rand
+from search import screen, sample_bb
+
+try:
+    import gf2_fast
+except ImportError:
+    gf2_fast = None
+
+
+def main():
+    p = KNOWN["[[72,12,6]]"]
+    HX, HZ = build_bb(p["l"], p["m"], p["A"], p["B"])
+
+    assert distance_rand(HX, HZ, trials=100, seed=0, backend="numpy") == 6
+    assert distance_rand(HX, HZ, trials=100, seed=0, backend="auto") == 6
+
+    try:
+        distance_rand(HX, HZ, trials=1, backend="invalid")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid backend was accepted")
+
+    if gf2_fast is not None:
+        assert distance_rand(
+            HX, HZ, trials=100, seed=0, backend="fast", threads=2) == 6
+        records = screen(
+            sample_bb(4, seed=1), min_k=2, min_d=2, trials=20,
+            backend="fast", threads=2)
+        assert records
+    else:
+        try:
+            distance_rand(HX, HZ, trials=1, backend="fast")
+        except ImportError:
+            pass
+        else:
+            raise AssertionError("explicit fast backend did not report missing extension")
+
+    print("PASS: optional fast backend and NumPy fallback")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/test_fast_backend.py
+++ b/research/test_fast_backend.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.join(_HERE, "kit"))
 sys.path.insert(0, os.path.join(_HERE, "..", "verify"))
 
 from bb import build_bb, KNOWN
+import surrogate
 from surrogate import distance_rand
 from search import screen, sample_bb
 
@@ -29,6 +30,18 @@ def main():
         pass
     else:
         raise AssertionError("invalid backend was accepted")
+
+    class NoLogicalBackend:
+        @staticmethod
+        def distance_rand_witness(*args, **kwargs):
+            return HX.shape[1] + 1, "", []
+
+    original_backend = surrogate._fast
+    surrogate._fast = NoLogicalBackend()
+    try:
+        assert distance_rand(HX, HZ, trials=1, backend="fast") == float("inf")
+    finally:
+        surrogate._fast = original_backend
 
     if gf2_fast is not None:
         assert distance_rand(


### PR DESCRIPTION
## Summary

- add an optional `gf2_fast` backend to research distance screening
- keep NumPy as the default and support `backend="auto"` fallback
- expose CPU thread control through `distance_rand` and `search.screen`
- validate accelerator-proposed witnesses with the Python GF(2) stack
- add regression coverage and concise usage documentation

## Validation

- `uv run --frozen python research/test_fast_backend.py`
- `uv run --frozen python research/test_smoke.py`
- `uv run --frozen python verify/test_check_prose.py`
- `uv run --frozen python run_tests.py --skip-slow` — 10/10 test files passed

This PR contains only the optional research backend changes.