### PR TITLE
verify: standalone GPU RIS deep-search tool (ris_gpu)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: build verify example test test-fast fast
+.PHONY: build verify example test test-fast fast ris
 
 build:
 	uv run python site/build.py
+
+# Optional GPU RIS deep-search binary (verify/ris_gpu.cu); needs nvcc + an
+# NVIDIA GPU. Driven by verify/ris_gpu.py, which CPU-verifies its output.
+ris:
+	mkdir -p build
+	nvcc -O3 -arch=$(or $(RIS_ARCH),native) -o build/ris_gpu verify/ris_gpu.cu
 
 # Optional C++ RIS accelerator (verify/gf2_fast.cpp); pure Python is the fallback.
 fast:

--- a/verify/ris_gpu.cu
+++ b/verify/ris_gpu.cu
@@ -1,0 +1,573 @@
+/*
+ * ris_gpu -- standalone GPU random-information-set distance search for CSS
+ * codes. OPTIONAL deep-search accelerator, like gf2_fast.cpp: the pure-Python
+ * verifier stays the reference, and every operator this tool reports is
+ * re-verified on the CPU by verify/ris_gpu.py before anyone believes it.
+ *
+ * The two device kernels are ported verbatim from sqetch by Muzhou Ma
+ * (https://github.com/Muzhou-Ma/sqetch, MIT License, Copyright (c) 2026
+ * Muzhou Ma). The host side replaces sqetch's torch JIT wrappers with plain
+ * CUDA runtime calls so the binary has no Python or torch dependency.
+ *
+ * Build:   make ris          (nvcc -O3 -arch=native -o build/ris_gpu ...)
+ * Input:   packed matrix file written by verify/ris_gpu.py ("RISGPU01"
+ *          header; W_null = basis of ker(H_check), W_logical = opposite-type
+ *          logical basis; rows bit-packed LSB-first into uint64 words).
+ * Output:  key=value lines on stdout; recover mode adds "support=..." with
+ *          the qubit indices of the best logical operator found.
+ *
+ * Each trial draws a random column permutation and a k_sub-row random sketch
+ * of W_null, row-reduces the sketch in permuted column order, and keeps the
+ * lightest row that anticommutes with a logical -- i.e. a random-ISD trial.
+ * Weights found are upper bounds on d; nothing here is a proof.
+ */
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+#include <vector>
+
+#define BLOCK_SIZE 128
+
+#define CUDA_CHECK(call)                                                    \
+    do {                                                                    \
+        cudaError_t err_ = (call);                                          \
+        if (err_ != cudaSuccess) {                                          \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__,          \
+                    __LINE__, cudaGetErrorString(err_));                    \
+            exit(2);                                                        \
+        }                                                                   \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Device code, ported verbatim from sqetch (MIT, Muzhou Ma)          */
+/* ------------------------------------------------------------------ */
+
+__device__ __forceinline__ uint64_t xorshift64(uint64_t* state) {
+    uint64_t x = *state;
+    x ^= x << 13; x ^= x >> 7; x ^= x << 17;
+    *state = x;
+    return x;
+}
+
+__device__ __forceinline__ int row_weight(const uint64_t* row, int nw) {
+    int w = 0;
+    for (int i = 0; i < nw; i++) w += __popcll(row[i]);
+    return w;
+}
+
+__device__ __forceinline__ int gf2_dot(const uint64_t* a, const uint64_t* b, int nw) {
+    uint64_t acc = 0;
+    for (int i = 0; i < nw; i++) acc ^= (a[i] & b[i]);
+    acc ^= acc >> 32; acc ^= acc >> 16; acc ^= acc >> 8;
+    acc ^= acc >> 4;  acc ^= acc >> 2;  acc ^= acc >> 1;
+    return (int)(acc & 1);
+}
+
+__global__ void __launch_bounds__(BLOCK_SIZE)
+sqetch_ksub_kernel(
+    const uint64_t* __restrict__ W_null,
+    const uint64_t* __restrict__ W_logical,
+    int k,
+    int kx,
+    int nw,
+    int n,
+    int k_sub,
+    int* global_best,
+    unsigned long long base_seed,
+    int d_target,
+    int* found_flag
+) {
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+
+    extern __shared__ char raw_shmem[];
+
+    uint16_t* perm = (uint16_t*)raw_shmem;
+    int perm_bytes = (n * 2 + 7) & ~7;
+
+    uint64_t* W_sub = (uint64_t*)(raw_shmem + perm_bytes);
+    int wsub_bytes = k_sub * nw * 8;
+
+    uint64_t* pivot_row_shmem = (uint64_t*)(raw_shmem + perm_bytes + wsub_bytes);
+    int pivot_bytes = nw * 8;
+
+    int* control = (int*)(raw_shmem + perm_bytes + wsub_bytes + pivot_bytes);
+    int* thread_best = control + 2;
+
+    uint64_t block_seed = base_seed ^ ((uint64_t)bid * 6364136223846793005ULL + 1442695040888963407ULL);
+
+    if (tid == 0) {
+        uint64_t rng = block_seed;
+        xorshift64(&rng);
+        for (int i = 0; i < n; i++) perm[i] = (uint16_t)i;
+        for (int i = n - 1; i > 0; i--) {
+            int j = (int)(xorshift64(&rng) % (uint64_t)(i + 1));
+            uint16_t tmp = perm[i]; perm[i] = perm[j]; perm[j] = tmp;
+        }
+        control[1] = 0;
+    }
+
+    uint64_t thread_rng = block_seed ^ ((uint64_t)tid * 2685821657736338717ULL + 1);
+    xorshift64(&thread_rng);
+
+    for (int s = tid; s < k_sub; s += BLOCK_SIZE) {
+        int src_row = (int)(xorshift64(&thread_rng) % (uint64_t)k);
+        const uint64_t* src = W_null + (size_t)src_row * nw;
+        uint64_t* dst = W_sub + (size_t)s * nw;
+        for (int w = 0; w < nw; w++) dst[w] = __ldg(src + w);
+    }
+    __syncthreads();
+
+    for (int c_virt = 0; c_virt < n; c_virt++) {
+        int pr = control[1];
+        if (pr >= k_sub) { __syncthreads(); __syncthreads(); continue; }
+
+        int c_phys = (int)perm[c_virt];
+        int word = c_phys >> 6;
+        int bit_pos = c_phys & 63;
+        uint64_t mask = (uint64_t)1 << bit_pos;
+
+        if (tid == 0) {
+            int found = -1;
+            for (int r = pr; r < k_sub; r++) {
+                if (W_sub[(size_t)r * nw + word] & mask) { found = r; break; }
+            }
+            control[0] = found;
+            if (found != -1) {
+                if (found != pr) {
+                    for (int w = 0; w < nw; w++) {
+                        uint64_t tmp = W_sub[(size_t)pr * nw + w];
+                        W_sub[(size_t)pr * nw + w] = W_sub[(size_t)found * nw + w];
+                        W_sub[(size_t)found * nw + w] = tmp;
+                    }
+                }
+                for (int w = 0; w < nw; w++)
+                    pivot_row_shmem[w] = W_sub[(size_t)pr * nw + w];
+                control[1] = pr + 1;
+            }
+        }
+        __syncthreads();
+
+        if (control[0] == -1) { __syncthreads(); continue; }
+
+        int pr2 = pr;
+        for (int r = tid; r < k_sub; r += BLOCK_SIZE) {
+            if (r != pr2 && (W_sub[(size_t)r * nw + word] & mask)) {
+                for (int w = 0; w < nw; w++)
+                    W_sub[(size_t)r * nw + w] ^= pivot_row_shmem[w];
+            }
+        }
+        __syncthreads();
+    }
+
+    thread_best[tid] = n + 1;
+
+    for (int r = tid; r < k_sub; r += BLOCK_SIZE) {
+        uint64_t* row = W_sub + (size_t)r * nw;
+        int all_zero = 1;
+        for (int w = 0; w < nw; w++) if (row[w]) { all_zero = 0; break; }
+        if (all_zero) continue;
+
+        int wt = row_weight(row, nw);
+        if (wt >= thread_best[tid]) continue;
+
+        int is_logical = 0;
+        for (int rx = 0; rx < kx && !is_logical; rx++)
+            if (gf2_dot(W_logical + (size_t)rx * nw, row, nw)) is_logical = 1;
+
+        if (is_logical && wt < thread_best[tid])
+            thread_best[tid] = wt;
+    }
+    __syncthreads();
+
+    for (int stride = BLOCK_SIZE / 2; stride > 0; stride >>= 1) {
+        if (tid < stride)
+            if (thread_best[tid + stride] < thread_best[tid])
+                thread_best[tid] = thread_best[tid + stride];
+        __syncthreads();
+    }
+
+    if (tid == 0 && thread_best[0] <= n) {
+        atomicMin(global_best, thread_best[0]);
+        if (d_target >= 0 && thread_best[0] < d_target && found_flag)
+            atomicExch(found_flag, 1);
+    }
+}
+
+
+__global__ void __launch_bounds__(BLOCK_SIZE)
+sqetch_ksub_recover_kernel(
+    const uint64_t* __restrict__ W_null,
+    const uint64_t* __restrict__ W_logical,
+    int k, int kx, int nw, int n, int k_sub,
+    int* global_best,
+    unsigned long long base_seed,
+    int d_target,
+    int* found_flag,
+    uint64_t* out_vec,
+    int32_t* out_perm,
+    int* done_flag
+) {
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+
+    extern __shared__ char raw_shmem[];
+
+    uint16_t* perm = (uint16_t*)raw_shmem;
+    int perm_bytes = (n * 2 + 7) & ~7;
+
+    uint64_t* W_sub = (uint64_t*)(raw_shmem + perm_bytes);
+    int wsub_bytes = k_sub * nw * 8;
+
+    uint64_t* pivot_row_shmem = (uint64_t*)(raw_shmem + perm_bytes + wsub_bytes);
+    int pivot_bytes = nw * 8;
+
+    int* control = (int*)(raw_shmem + perm_bytes + wsub_bytes + pivot_bytes);
+    int* thread_best = control + 2;
+    int* thread_best_row = thread_best + BLOCK_SIZE;
+
+    uint64_t block_seed = base_seed ^ ((uint64_t)bid * 6364136223846793005ULL + 1442695040888963407ULL);
+
+    if (tid == 0) {
+        uint64_t rng = block_seed;
+        xorshift64(&rng);
+        for (int i = 0; i < n; i++) perm[i] = (uint16_t)i;
+        for (int i = n - 1; i > 0; i--) {
+            int j = (int)(xorshift64(&rng) % (uint64_t)(i + 1));
+            uint16_t tmp = perm[i]; perm[i] = perm[j]; perm[j] = tmp;
+        }
+        control[1] = 0;
+    }
+
+    uint64_t thread_rng = block_seed ^ ((uint64_t)tid * 2685821657736338717ULL + 1);
+    xorshift64(&thread_rng);
+
+    for (int s = tid; s < k_sub; s += BLOCK_SIZE) {
+        int src_row = (int)(xorshift64(&thread_rng) % (uint64_t)k);
+        const uint64_t* src = W_null + (size_t)src_row * nw;
+        uint64_t* dst = W_sub + (size_t)s * nw;
+        for (int w = 0; w < nw; w++) dst[w] = __ldg(src + w);
+    }
+    __syncthreads();
+
+    for (int c_virt = 0; c_virt < n; c_virt++) {
+        int pr = control[1];
+        if (pr >= k_sub) { __syncthreads(); __syncthreads(); continue; }
+
+        int c_phys = (int)perm[c_virt];
+        int word = c_phys >> 6;
+        int bit_pos = c_phys & 63;
+        uint64_t mask = (uint64_t)1 << bit_pos;
+
+        if (tid == 0) {
+            int found = -1;
+            for (int r = pr; r < k_sub; r++) {
+                if (W_sub[(size_t)r * nw + word] & mask) { found = r; break; }
+            }
+            control[0] = found;
+            if (found != -1) {
+                if (found != pr) {
+                    for (int w = 0; w < nw; w++) {
+                        uint64_t tmp = W_sub[(size_t)pr * nw + w];
+                        W_sub[(size_t)pr * nw + w] = W_sub[(size_t)found * nw + w];
+                        W_sub[(size_t)found * nw + w] = tmp;
+                    }
+                }
+                for (int w = 0; w < nw; w++)
+                    pivot_row_shmem[w] = W_sub[(size_t)pr * nw + w];
+                control[1] = pr + 1;
+            }
+        }
+        __syncthreads();
+
+        if (control[0] == -1) { __syncthreads(); continue; }
+
+        int pr2 = pr;
+        for (int r = tid; r < k_sub; r += BLOCK_SIZE) {
+            if (r != pr2 && (W_sub[(size_t)r * nw + word] & mask)) {
+                for (int w = 0; w < nw; w++)
+                    W_sub[(size_t)r * nw + w] ^= pivot_row_shmem[w];
+            }
+        }
+        __syncthreads();
+    }
+
+    thread_best[tid] = n + 1;
+    thread_best_row[tid] = -1;
+    for (int r = tid; r < k_sub; r += BLOCK_SIZE) {
+        uint64_t* row = W_sub + (size_t)r * nw;
+        int all_zero = 1;
+        for (int w = 0; w < nw; w++) if (row[w]) { all_zero = 0; break; }
+        if (all_zero) continue;
+
+        int wt = row_weight(row, nw);
+        if (wt >= thread_best[tid]) continue;
+
+        int is_logical = 0;
+        for (int rx = 0; rx < kx && !is_logical; rx++)
+            if (gf2_dot(W_logical + (size_t)rx * nw, row, nw)) is_logical = 1;
+
+        if (is_logical && wt < thread_best[tid]) {
+            thread_best[tid] = wt;
+            thread_best_row[tid] = r;
+        }
+    }
+    __syncthreads();
+
+    for (int stride = BLOCK_SIZE / 2; stride > 0; stride >>= 1) {
+        if (tid < stride && thread_best[tid + stride] < thread_best[tid]) {
+            thread_best[tid] = thread_best[tid + stride];
+            thread_best_row[tid] = thread_best_row[tid + stride];
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0 && thread_best[0] <= n) {
+        int wt = thread_best[0];
+        atomicMin(global_best, wt);
+        if (d_target >= 0 && wt < d_target) {
+            if (found_flag) atomicExch(found_flag, 1);
+            if (out_vec && out_perm && done_flag &&
+                atomicExch(done_flag, 1) == 0) {
+                control[0] = thread_best_row[0];
+            } else {
+                control[0] = -1;
+            }
+        } else {
+            control[0] = -1;
+        }
+    }
+    __syncthreads();
+
+    int winner_row = control[0];
+    if (winner_row >= 0) {
+        const uint64_t* wrow = W_sub + (size_t)winner_row * nw;
+        for (int w = tid; w < nw; w += BLOCK_SIZE)
+            out_vec[w] = wrow[w];
+        for (int i = tid; i < n; i += BLOCK_SIZE)
+            out_perm[i] = (int32_t)perm[i];
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Host                                                               */
+/* ------------------------------------------------------------------ */
+
+struct Input {
+    int n = 0;
+    int k_null = 0;
+    int k_logical = 0;
+    int nw = 0;
+    std::vector<uint64_t> w_null;
+    std::vector<uint64_t> w_logical;
+};
+
+static Input read_input(const char* path) {
+    FILE* f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path); exit(2); }
+    char magic[8];
+    if (fread(magic, 1, 8, f) != 8 || memcmp(magic, "RISGPU01", 8) != 0) {
+        fprintf(stderr, "%s: bad magic (want RISGPU01)\n", path);
+        exit(2);
+    }
+    Input in;
+    int32_t hdr[4];
+    if (fread(hdr, 4, 4, f) != 4) { fprintf(stderr, "%s: truncated header\n", path); exit(2); }
+    in.n = hdr[0]; in.k_null = hdr[1]; in.k_logical = hdr[2]; in.nw = hdr[3];
+    if (in.n <= 0 || in.n > 65535 || in.k_null <= 0 || in.k_logical <= 0 ||
+        in.nw != (in.n + 63) / 64) {
+        fprintf(stderr, "%s: implausible header n=%d k_null=%d k_logical=%d nw=%d\n",
+                path, in.n, in.k_null, in.k_logical, in.nw);
+        exit(2);
+    }
+    in.w_null.resize((size_t)in.k_null * in.nw);
+    in.w_logical.resize((size_t)in.k_logical * in.nw);
+    if (fread(in.w_null.data(), 8, in.w_null.size(), f) != in.w_null.size() ||
+        fread(in.w_logical.data(), 8, in.w_logical.size(), f) != in.w_logical.size()) {
+        fprintf(stderr, "%s: truncated matrix data\n", path);
+        exit(2);
+    }
+    fclose(f);
+    return in;
+}
+
+static int shmem_bytes_for(int n, int nw, int k_sub, bool recover) {
+    int perm_bytes = (n * 2 + 7) & ~7;
+    int wsub_bytes = k_sub * nw * 8;
+    int pivot_bytes = nw * 8;
+    int ctrl_bytes = 8;
+    int best_bytes = BLOCK_SIZE * 4;
+    int brow_bytes = recover ? BLOCK_SIZE * 4 : 0;
+    return perm_bytes + wsub_bytes + pivot_bytes + ctrl_bytes + best_bytes + brow_bytes;
+}
+
+static void usage(const char* argv0) {
+    fprintf(stderr,
+        "usage: %s <input.risgpu> [--mode recover|estimate] [--trials N]\n"
+        "          [--batch N] [--seed S] [--k-sub K] [--target D]\n"
+        "  recover (default): ladder toward the lightest logical operator it\n"
+        "  can find within the budget; prints its support. estimate: weight\n"
+        "  only, slightly faster. --target D stops early once a weight < D\n"
+        "  is committed.\n", argv0);
+    exit(2);
+}
+
+int main(int argc, char** argv) {
+    const char* path = nullptr;
+    long long trials = 50000000;
+    int batch = 50000;
+    unsigned long long seed = 1;
+    int k_sub = 64;
+    int d_target = -1;
+    bool recover = true;
+
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--mode") && i + 1 < argc) {
+            i++;
+            if (!strcmp(argv[i], "recover")) recover = true;
+            else if (!strcmp(argv[i], "estimate")) recover = false;
+            else usage(argv[0]);
+        } else if (!strcmp(argv[i], "--trials") && i + 1 < argc) {
+            trials = atoll(argv[++i]);
+        } else if (!strcmp(argv[i], "--batch") && i + 1 < argc) {
+            batch = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--seed") && i + 1 < argc) {
+            seed = strtoull(argv[++i], nullptr, 10);
+        } else if (!strcmp(argv[i], "--k-sub") && i + 1 < argc) {
+            k_sub = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--target") && i + 1 < argc) {
+            d_target = atoi(argv[++i]);
+        } else if (argv[i][0] == '-') {
+            usage(argv[0]);
+        } else if (!path) {
+            path = argv[i];
+        } else {
+            usage(argv[0]);
+        }
+    }
+    if (!path || trials <= 0 || batch <= 0 || k_sub <= 0) usage(argv[0]);
+
+    Input in = read_input(path);
+    int n = in.n, nw = in.nw;
+    int k_sub_eff = k_sub < in.k_null ? k_sub : in.k_null;
+
+    int shmem = shmem_bytes_for(n, nw, k_sub_eff, recover);
+    int max_shmem = 0;
+    CUDA_CHECK(cudaDeviceGetAttribute(&max_shmem,
+        cudaDevAttrMaxSharedMemoryPerBlockOptin, 0));
+    if (shmem > max_shmem) {
+        int overhead = shmem_bytes_for(n, nw, 0, recover);
+        int k_cap = (max_shmem - overhead) / (nw * 8);
+        fprintf(stderr, "k_sub=%d needs %d bytes shared memory, device max %d; "
+                "max k_sub for n=%d is %d\n", k_sub_eff, shmem, max_shmem, n, k_cap);
+        exit(2);
+    }
+    int shmem_request = (shmem + 4095) & ~4095;
+    if (recover) {
+        CUDA_CHECK(cudaFuncSetAttribute(sqetch_ksub_recover_kernel,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_request));
+        CUDA_CHECK(cudaFuncSetCacheConfig(sqetch_ksub_recover_kernel,
+            cudaFuncCachePreferShared));
+    } else {
+        CUDA_CHECK(cudaFuncSetAttribute(sqetch_ksub_kernel,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_request));
+        CUDA_CHECK(cudaFuncSetCacheConfig(sqetch_ksub_kernel,
+            cudaFuncCachePreferShared));
+    }
+
+    uint64_t *d_null, *d_logical, *d_vec;
+    int *d_best, *d_flag, *d_done;
+    int32_t *d_perm;
+    CUDA_CHECK(cudaMalloc(&d_null, in.w_null.size() * 8));
+    CUDA_CHECK(cudaMalloc(&d_logical, in.w_logical.size() * 8));
+    CUDA_CHECK(cudaMalloc(&d_best, 4));
+    CUDA_CHECK(cudaMalloc(&d_flag, 4));
+    CUDA_CHECK(cudaMalloc(&d_done, 4));
+    CUDA_CHECK(cudaMalloc(&d_vec, (size_t)nw * 8));
+    CUDA_CHECK(cudaMalloc(&d_perm, (size_t)n * 4));
+    CUDA_CHECK(cudaMemcpy(d_null, in.w_null.data(), in.w_null.size() * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_logical, in.w_logical.data(), in.w_logical.size() * 8,
+                          cudaMemcpyHostToDevice));
+
+    int best_overall = n + 1;
+    std::vector<uint64_t> best_vec;
+    long long trials_done = 0;
+    unsigned long long batch_seed = seed;
+    /* recover ladder: any strictly lighter operator than the best committed
+       so far claims the output slot; estimate: plain d_target early stop. */
+    int current_target = recover ? n + 1 : d_target;
+
+    while (trials_done < trials) {
+        int B = (int)((trials - trials_done < batch) ? (trials - trials_done) : batch);
+        int init_best = n + 1, zero = 0;
+        CUDA_CHECK(cudaMemcpy(d_best, &init_best, 4, cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(d_flag, &zero, 4, cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(d_done, &zero, 4, cudaMemcpyHostToDevice));
+
+        if (recover) {
+            sqetch_ksub_recover_kernel<<<B, BLOCK_SIZE, shmem>>>(
+                d_null, d_logical, in.k_null, in.k_logical, nw, n, k_sub_eff,
+                d_best, batch_seed, current_target, d_flag, d_vec, d_perm, d_done);
+        } else {
+            sqetch_ksub_kernel<<<B, BLOCK_SIZE, shmem>>>(
+                d_null, d_logical, in.k_null, in.k_logical, nw, n, k_sub_eff,
+                d_best, batch_seed, current_target, d_flag);
+        }
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        trials_done += B;
+        batch_seed += (unsigned long long)B * 100003ULL;
+
+        int batch_best = 0, done = 0;
+        CUDA_CHECK(cudaMemcpy(&batch_best, d_best, 4, cudaMemcpyDeviceToHost));
+        if (batch_best < best_overall && !recover) best_overall = batch_best;
+
+        if (recover) {
+            CUDA_CHECK(cudaMemcpy(&done, d_done, 4, cudaMemcpyDeviceToHost));
+            if (done) {
+                std::vector<uint64_t> vec(nw);
+                CUDA_CHECK(cudaMemcpy(vec.data(), d_vec, (size_t)nw * 8,
+                                      cudaMemcpyDeviceToHost));
+                int w = 0;
+                for (int i = 0; i < nw; i++) w += __builtin_popcountll(vec[i]);
+                if (w < best_overall) {
+                    best_overall = w;
+                    best_vec = vec;
+                    current_target = w;
+                    fprintf(stderr, "trials %lld: committed weight %d\n",
+                            trials_done, w);
+                    if (d_target >= 0 && w < d_target) break;
+                }
+            }
+        } else {
+            int flag = 0;
+            CUDA_CHECK(cudaMemcpy(&flag, d_flag, 4, cudaMemcpyDeviceToHost));
+            if (flag) break;
+        }
+    }
+
+    printf("mode=%s\n", recover ? "recover" : "estimate");
+    printf("n=%d\nk_null=%d\nk_logical=%d\nk_sub=%d\n", n, in.k_null,
+           in.k_logical, k_sub_eff);
+    printf("seed=%llu\ntrials=%lld\n", seed, trials_done);
+    printf("best_weight=%d\n", best_overall <= n ? best_overall : -1);
+    if (recover && !best_vec.empty()) {
+        printf("support=");
+        int first = 1;
+        for (int j = 0; j < n; j++) {
+            if ((best_vec[j >> 6] >> (j & 63)) & 1) {
+                printf(first ? "%d" : ",%d", j);
+                first = 0;
+            }
+        }
+        printf("\n");
+    }
+    return 0;
+}

--- a/verify/ris_gpu.py
+++ b/verify/ris_gpu.py
@@ -1,0 +1,181 @@
+"""
+GPU deep RIS refutation/witness search for board codes -- wrapper around the
+standalone verify/ris_gpu.cu binary (build with `make ris`).
+
+For each side of a CSS code this derives the opposite-type logical basis
+exactly as qldpc_verify.py does (via gf2.py, the audited reference), hands
+the packed matrices to the GPU binary, and then re-verifies any recovered
+operator here on the CPU: in ker(H_check), anticommutes with a logical,
+weight recounted. Only CPU-verified operators are reported. All weights are
+upper bounds on distance; nothing here is a proof.
+
+    make ris
+    python verify/ris_gpu.py codes/674-128-87.json --trials 1000000000
+
+Writes <code>.witness.json alongside each input. The GPU binary needs an
+NVIDIA GPU + CUDA; this wrapper itself is numpy + stdlib only.
+"""
+
+import argparse
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gf2  # noqa: E402
+
+MAGIC = b"RISGPU01"
+
+
+def find_binary(explicit=None):
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    candidates = [explicit, os.environ.get("RIS_GPU_BIN"),
+                  os.path.join(root, "build", "ris_gpu")]
+    for c in candidates:
+        if c and os.path.isfile(c) and os.access(c, os.X_OK):
+            return c
+    raise FileNotFoundError(
+        "ris_gpu binary not found; build it with `make ris` or set RIS_GPU_BIN")
+
+
+def checks_matrix(support_list, n):
+    H = np.zeros((len(support_list), n), dtype=np.int8)
+    for r, sup in enumerate(support_list):
+        for q in sup:
+            H[r, q] ^= 1
+    return H
+
+
+def pack_rows(M):
+    """Bit-pack GF(2) rows LSB-first: column j -> word j//64, bit j%64.
+    Must match the layout ris_gpu.cu reads."""
+    M = (np.asarray(M, dtype=np.uint8) % 2)
+    m, n = M.shape
+    nw = (n + 63) // 64
+    padded = np.zeros((m, nw * 64), dtype=np.uint8)
+    padded[:, :n] = M
+    powers = np.uint64(1) << np.arange(64, dtype=np.uint64)
+    return (padded.reshape(m, nw, 64).astype(np.uint64) * powers).sum(axis=2,
+                                                                      dtype=np.uint64)
+
+
+def write_input(path, W_null, W_logical, n):
+    packed_null = pack_rows(W_null)
+    packed_logical = pack_rows(W_logical)
+    nw = packed_null.shape[1]
+    with open(path, "wb") as f:
+        f.write(MAGIC)
+        f.write(struct.pack("<4i", n, packed_null.shape[0],
+                            packed_logical.shape[0], nw))
+        f.write(packed_null.astype("<u8").tobytes())
+        f.write(packed_logical.astype("<u8").tobytes())
+
+
+def parse_output(text):
+    out = {}
+    for line in text.splitlines():
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        out[key] = val
+    if "support" in out:
+        out["support"] = [int(x) for x in out["support"].split(",") if x]
+    for key in ("best_weight", "trials", "n"):
+        if key in out:
+            out[key] = int(out[key])
+    return out
+
+
+def cpu_verify(support, n, H_check, L_opp):
+    """The trust boundary: accept an operator only on CPU-checked evidence."""
+    v = np.zeros(n, dtype=np.int8)
+    v[support] = 1
+    if not v.any():
+        return False
+    if not gf2.commutes(v, H_check):
+        return False
+    return bool(((gf2._as_gf2(L_opp) @ v) % 2).any())
+
+
+def run_side(side, H_check, L_opp, claimed, args, binary):
+    with tempfile.NamedTemporaryFile(suffix=".risgpu", delete=False) as tmp:
+        write_input(tmp.name, gf2.kernel_basis(H_check), L_opp,
+                    H_check.shape[1])
+        cmd = [binary, tmp.name, "--mode", args.mode,
+               "--trials", str(args.trials), "--seed", str(args.seed),
+               "--k-sub", str(args.k_sub)]
+        if args.target is not None:
+            cmd += ["--target", str(args.target)]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True,
+                                  check=True)
+        finally:
+            os.unlink(tmp.name)
+    res = parse_output(proc.stdout)
+    entry = {"claimed": claimed, "gpu_best_weight": res.get("best_weight"),
+             "trials": res.get("trials"), "witness_weight": None,
+             "operator_support": None, "cpu_verified": False}
+    support = res.get("support")
+    if support:
+        if cpu_verify(support, H_check.shape[1], H_check, L_opp):
+            entry["witness_weight"] = len(support)
+            entry["operator_support"] = support
+            entry["cpu_verified"] = True
+        else:
+            print(f"  [{side}] GPU operator FAILED CPU verification -- "
+                  "discarded", file=sys.stderr)
+    print(f"  [{side}] claimed {claimed}, GPU best {res.get('best_weight')}, "
+          f"cpu-verified witness "
+          f"{entry['witness_weight'] if entry['cpu_verified'] else 'none'}")
+    return entry
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("code_json", nargs="+", help="board code JSON file(s)")
+    ap.add_argument("--trials", type=int, default=50_000_000)
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--k-sub", type=int, default=64)
+    ap.add_argument("--mode", choices=("recover", "estimate"),
+                    default="recover")
+    ap.add_argument("--target", type=int, default=None,
+                    help="early-stop once a weight < target is committed")
+    ap.add_argument("--sides", default="X,Z")
+    ap.add_argument("--binary", default=None,
+                    help="path to the ris_gpu binary (default: build/ris_gpu)")
+    args = ap.parse_args()
+    binary = find_binary(args.binary)
+    sides = [s.strip().upper() for s in args.sides.split(",") if s.strip()]
+
+    for path in args.code_json:
+        with open(path) as f:
+            doc = json.load(f)
+        n = doc["n"]
+        HX = checks_matrix(doc["checks"]["X"], n)
+        HZ = checks_matrix(doc["checks"]["Z"], n)
+        dist = doc["distance"]
+        print(f"{path}: [[{n},{doc['k']},{dist['d']}]] mode={args.mode} "
+              f"trials={args.trials}")
+        out = {"code": path, "tool": "ris_gpu", "mode": args.mode,
+               "trials": args.trials, "seed": args.seed}
+        # An X-type logical lives in ker(H_Z) and must anticommute with a
+        # Z-type logical; mirror for Z.
+        if "X" in sides:
+            out["X"] = run_side("X", HZ, gf2.logical_basis(HX, HZ),
+                                dist["X"]["value"], args, binary)
+        if "Z" in sides:
+            out["Z"] = run_side("Z", HX, gf2.logical_basis(HZ, HX),
+                                dist["Z"]["value"], args, binary)
+        res_path = path.rsplit(".json", 1)[0] + ".witness.json"
+        with open(res_path, "w") as f:
+            json.dump(out, f, indent=1)
+        print(f"  -> {res_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/verify/ris_gpu.py
+++ b/verify/ris_gpu.py
@@ -92,14 +92,21 @@ def parse_output(text):
 
 
 def cpu_verify(support, n, H_check, L_opp):
-    """The trust boundary: accept an operator only on CPU-checked evidence."""
+    """The trust boundary: accept an operator only on CPU-checked evidence.
+
+    Returns the recounted weight of the verified operator, or None. Malformed
+    support lists (out-of-range or duplicate indices) are rejected like any
+    failed verification rather than crashing the sweep."""
+    if not support or len(set(support)) != len(support) or \
+            not all(isinstance(q, int) and 0 <= q < n for q in support):
+        return None
     v = np.zeros(n, dtype=np.int8)
     v[support] = 1
-    if not v.any():
-        return False
     if not gf2.commutes(v, H_check):
-        return False
-    return bool(((gf2._as_gf2(L_opp) @ v) % 2).any())
+        return None
+    if not bool(((gf2._as_gf2(L_opp) @ v) % 2).any()):
+        return None
+    return int(v.sum())
 
 
 def run_side(side, H_check, L_opp, claimed, args, binary):
@@ -113,7 +120,7 @@ def run_side(side, H_check, L_opp, claimed, args, binary):
             cmd += ["--target", str(args.target)]
         try:
             proc = subprocess.run(cmd, capture_output=True, text=True,
-                                  check=True)
+                                  check=True, timeout=args.proc_timeout)
         finally:
             os.unlink(tmp.name)
     res = parse_output(proc.stdout)
@@ -122,8 +129,9 @@ def run_side(side, H_check, L_opp, claimed, args, binary):
              "operator_support": None, "cpu_verified": False}
     support = res.get("support")
     if support:
-        if cpu_verify(support, H_check.shape[1], H_check, L_opp):
-            entry["witness_weight"] = len(support)
+        weight = cpu_verify(support, H_check.shape[1], H_check, L_opp)
+        if weight is not None:
+            entry["witness_weight"] = weight
             entry["operator_support"] = support
             entry["cpu_verified"] = True
         else:
@@ -148,6 +156,8 @@ def main():
     ap.add_argument("--sides", default="X,Z")
     ap.add_argument("--binary", default=None,
                     help="path to the ris_gpu binary (default: build/ris_gpu)")
+    ap.add_argument("--proc-timeout", type=int, default=7200,
+                    help="kill a wedged GPU binary after this many seconds")
     args = ap.parse_args()
     binary = find_binary(args.binary)
     sides = [s.strip().upper() for s in args.sides.split(",") if s.strip()]

--- a/verify/test_ris_gpu.py
+++ b/verify/test_ris_gpu.py
@@ -108,6 +108,18 @@ def test_cpu_verify_gate():
     # a single qubit is outside ker(HZ) in the Steane code: must be rejected
     assert not ris_gpu.cpu_verify([0], n, HZ, L_opp)
 
+    # a verified operator's weight is recounted, never len(support)
+    assert ris_gpu.cpu_verify(found, n, HZ, L_opp) == len(found)
+
+    # malformed GPU output must be rejected, not crash or miscount:
+    # duplicate indices (would silently collapse in the indicator vector)
+    assert ris_gpu.cpu_verify(found + [found[0]], n, HZ, L_opp) is None
+    # out-of-range index (would raise IndexError unguarded)
+    assert ris_gpu.cpu_verify([0, n + 3], n, HZ, L_opp) is None
+    assert ris_gpu.cpu_verify([-1], n, HZ, L_opp) is None
+    # empty support
+    assert ris_gpu.cpu_verify([], n, HZ, L_opp) is None
+
 
 def gpu_available(binary):
     if not (os.path.isfile(binary) and os.access(binary, os.X_OK)):

--- a/verify/test_ris_gpu.py
+++ b/verify/test_ris_gpu.py
@@ -1,0 +1,148 @@
+"""Tests for the ris_gpu wrapper (verify/ris_gpu.py).
+
+Everything CPU-side runs everywhere: packing layout, input-file format,
+output parsing, and the CPU witness verification that gates what the GPU
+reports. The end-to-end GPU check runs only when build/ris_gpu exists and a
+CUDA device answers; otherwise it is skipped (this is CI, which has no GPU).
+"""
+
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gf2
+import ris_gpu
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_pack_rows_layout():
+    # column j must land in word j//64, bit j%64 (LSB-first)
+    M = np.zeros((2, 130), dtype=np.uint8)
+    M[0, 0] = 1
+    M[0, 63] = 1
+    M[0, 64] = 1
+    M[1, 129] = 1
+    P = ris_gpu.pack_rows(M)
+    assert P.shape == (2, 3), P.shape
+    assert P[0, 0] == (1 | (1 << 63)), hex(P[0, 0])
+    assert P[0, 1] == 1
+    assert P[0, 2] == 0
+    assert P[1, 2] == 2, hex(P[1, 2])
+
+    # round-trip through an independent unpack
+    rng = np.random.default_rng(7)
+    M = rng.integers(0, 2, size=(5, 100)).astype(np.uint8)
+    P = ris_gpu.pack_rows(M)
+    back = np.zeros_like(M)
+    for r in range(M.shape[0]):
+        for j in range(M.shape[1]):
+            back[r, j] = (int(P[r, j // 64]) >> (j % 64)) & 1
+    assert np.array_equal(M, back)
+
+
+def test_input_file_format():
+    W_null = np.eye(3, 70, dtype=np.uint8)
+    W_log = np.ones((2, 70), dtype=np.uint8)
+    with tempfile.NamedTemporaryFile(suffix=".risgpu", delete=False) as tmp:
+        path = tmp.name
+    try:
+        ris_gpu.write_input(path, W_null, W_log, 70)
+        with open(path, "rb") as f:
+            blob = f.read()
+        assert blob[:8] == b"RISGPU01"
+        n, k_null, k_logical, nw = struct.unpack_from("<4i", blob, 8)
+        assert (n, k_null, k_logical, nw) == (70, 3, 2, 2)
+        assert len(blob) == 8 + 16 + (3 + 2) * nw * 8
+        words = np.frombuffer(blob, dtype="<u8", offset=24)
+        assert words[0] == 1          # W_null row 0 = e_0
+        assert words[2 * 2] == 4      # row 2 = e_2
+    finally:
+        os.unlink(path)
+
+
+def test_parse_output():
+    res = ris_gpu.parse_output(
+        "mode=recover\nn=7\ntrials=100000\nbest_weight=3\nsupport=0,1,2\n")
+    assert res["best_weight"] == 3
+    assert res["trials"] == 100000
+    assert res["support"] == [0, 1, 2]
+    res = ris_gpu.parse_output("mode=estimate\nbest_weight=-1\n")
+    assert res["best_weight"] == -1
+    assert "support" not in res
+
+
+def load_steane():
+    with open(os.path.join(ROOT, "codes", "7-1-3.json")) as f:
+        doc = json.load(f)
+    n = doc["n"]
+    HX = ris_gpu.checks_matrix(doc["checks"]["X"], n)
+    HZ = ris_gpu.checks_matrix(doc["checks"]["Z"], n)
+    return n, HX, HZ
+
+
+def test_cpu_verify_gate():
+    n, HX, HZ = load_steane()
+    L_opp = gf2.logical_basis(HX, HZ)  # Z-type logicals, for the X side
+
+    # a stabilizer row commutes with everything: must be rejected
+    stab = sorted(int(q) for q in np.flatnonzero(HX[0]))
+    assert not ris_gpu.cpu_verify(stab, n, HZ, L_opp)
+
+    # a genuine X logical (weight 3 in the Steane code): kernel_basis(HZ)
+    # rows that anticommute with a Z logical
+    found = None
+    for row in gf2.kernel_basis(HZ):
+        sup = sorted(int(q) for q in np.flatnonzero(row))
+        if ris_gpu.cpu_verify(sup, n, HZ, L_opp):
+            found = sup
+            break
+    assert found is not None, "no logical found in ker(HZ) basis"
+
+    # a single qubit is outside ker(HZ) in the Steane code: must be rejected
+    assert not ris_gpu.cpu_verify([0], n, HZ, L_opp)
+
+
+def gpu_available(binary):
+    if not (os.path.isfile(binary) and os.access(binary, os.X_OK)):
+        return False
+    r = subprocess.run(["nvidia-smi", "-L"], capture_output=True)
+    return r.returncode == 0 and b"GPU" in r.stdout
+
+
+def test_end_to_end_gpu():
+    binary = os.path.join(ROOT, "build", "ris_gpu")
+    if not gpu_available(binary):
+        print("SKIP: no ris_gpu binary or no GPU")
+        return
+    n, HX, HZ = load_steane()
+    L_opp = gf2.logical_basis(HX, HZ)
+    with tempfile.NamedTemporaryFile(suffix=".risgpu", delete=False) as tmp:
+        path = tmp.name
+    try:
+        ris_gpu.write_input(path, gf2.kernel_basis(HZ), L_opp, n)
+        proc = subprocess.run(
+            [binary, path, "--mode", "recover", "--trials", "200000",
+             "--seed", "5", "--k-sub", "8"],
+            capture_output=True, text=True, check=True)
+        res = ris_gpu.parse_output(proc.stdout)
+        assert res["best_weight"] == 3, res  # Steane distance is exactly 3
+        assert ris_gpu.cpu_verify(res["support"], n, HZ, L_opp)
+        assert len(res["support"]) == 3
+    finally:
+        os.unlink(path)
+
+
+if __name__ == "__main__":
+    test_pack_rows_layout()
+    test_input_file_format()
+    test_parse_output()
+    test_cpu_verify_gate()
+    test_end_to_end_gpu()
+    print("ok")


### PR DESCRIPTION
## What

A standalone GPU random-ISD distance-search tool, with no dependency on another Python package beyond numpy (which the repo already requires):

- **`verify/ris_gpu.cu`** — CUDA binary, built by `make ris` into `build/ris_gpu`. The two device kernels are ported verbatim from [sqetch](https://github.com/Muzhou-Ma/sqetch) by Muzhou Ma (MIT, attribution in the file header); the torch/ninja JIT host stack is replaced with plain CUDA runtime calls. Two modes: `recover` (default — ladders toward the lightest logical operator it can find and prints its support) and `estimate` (weight only).
- **`verify/ris_gpu.py`** — wrapper on numpy + stdlib: reads board code JSON, derives logical bases via the audited `verify/gf2.py`, feeds packed matrices to the binary, and **re-verifies every GPU-reported operator on the CPU** (in `ker(H_check)`, anticommutes with an opposite-type logical, weight recounted) before writing a `.witness.json`. The GPU is never trusted directly.
- **`verify/test_ris_gpu.py`** — picked up automatically by `run_tests.py`: packing layout, input-file format, output parsing, and the CPU verification gate run everywhere; the GPU end-to-end check (Steane code, expects exactly d=3) auto-skips when there is no device, so CI is unaffected.

## Why

Deep RIS refutation of high-n board claims was bottlenecked on CPU budgets (2M-trial convergence checks, minutes to hours). The sqetch stack runs ~3.2M trials/s on an L40S but its torch `load_inline` JIT needed four environment fixes on a fresh cloud box before it ran once. This tool keeps the kernel and drops the fragile stack: one `nvcc` invocation at build time, zero runtime dependencies.

Like `gf2_fast.cpp`, this is an optional accelerator — the pure-Python verifier remains the reference and nothing in the trusted validation path changes. All reported weights are upper bounds; witnesses, not runs, are the evidence.

## Validation

On an L40S (nvcc 13.0, `-arch=native`):
- **[[112,6,7]]** (exact DRAT-certified d=7): witnessed dX=7, dZ=8 — matches the certificate exactly.
- **[[674,128,87]]** at a 50M-trial budget per side, versus sqetch at the same budget: X witness 86 (sqetch: 87), Z witness 90 (sqetch seeds ranged 84–87) — seed-level parity, all witnesses CPU-verified.
- Full local test suite: 10/10 files pass; the new GPU test passes on-device and skips cleanly off-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)