### PR TITLE
authorship gate: witness_provenance refutation binding (#611 PR B)

### DIFF
--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -6,6 +6,21 @@ GitHub user opening the PR is listed among the @handle authors of every code
 they add or change. Literature baselines (no @handle authors) are exempt, and a
 maintainer submitting on someone's behalf just adds themselves as a co-author.
 
+Refutation binding (issue #611): a PR author who is NOT an author of a code may
+still tighten its distance claim, provided the change is exactly a refutation
+and nothing else. The alternative binding holds when every difference from the
+base version is confined to the distance block (plus the name string and an
+append to provenance.notes), every witness_provenance the PR adds lists the PR
+author in found_by, and at least one side's value strictly decreases. Together
+these mean the path can only ever be used to tighten a claim, never to alter a
+construction or its authorship -- the witness itself is machine-verified by the
+distance checks, so a bogus claim cannot pass regardless.
+
+Relatedly, on a change to an existing code the author list itself may only be
+edited by someone already on it: without that, adding (or swapping in) your own
+handle would grant edit rights over anyone's entry, which is the hole the
+refutation binding exists to avoid. New submissions are unaffected.
+
 Fails CLOSED only on a definite author/PR-author mismatch. Anything ambiguous
 (no author info, git/parse error) fails OPEN with a warning -- a bug here must
 not block legitimate contributions, since impersonation is lower-stakes than the
@@ -26,15 +41,20 @@ HANDLE = re.compile(r"^@([A-Za-z0-9-]+)$")
 
 
 def changed_codes(base, root=ROOT):
+    """{path: status} for codes changed vs base; status is A, M, or D."""
     try:
         out = subprocess.check_output(
-            ["git", "diff", "--name-only", "--diff-filter=AM",
-             f"{base}...HEAD", "--", "codes"],
+            ["git", "diff", "--name-status", f"{base}...HEAD", "--", "codes"],
             cwd=root, text=True)
     except Exception as e:
         print(f"(could not diff vs {base}: {e}); skipping authorship check")
         return None
-    return [f for f in out.split() if f.endswith(".json")]
+    changes = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[1].endswith(".json"):
+            changes[parts[1]] = parts[0][:1]
+    return changes
 
 
 def handles(doc):
@@ -45,6 +65,83 @@ def handles(doc):
         if m:
             out.append(m.group(1).lower())
     return out
+
+
+def load_base_doc(base, path, root):
+    """The base-revision content of path, or None if unavailable."""
+    try:
+        out = subprocess.check_output(["git", "show", f"{base}:{path}"],
+                                      cwd=root, text=True,
+                                      stderr=subprocess.DEVNULL)
+        return json.loads(out)
+    except Exception:
+        return None
+
+
+def base_counterpart(path, doc, changes):
+    """The base-revision path this file revises: itself when modified, or the
+    deleted codes/<n>-<k>-*.json when a refutation renamed the file."""
+    if changes.get(path) == "M":
+        return path
+    prefix = os.path.join(os.path.dirname(path),
+                          f"{doc.get('n')}-{doc.get('k')}-")
+    matches = [p for p, s in changes.items()
+               if s == "D" and p.startswith(prefix)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def found_by_handles(side):
+    wp = (side or {}).get("witness_provenance") or {}
+    out = []
+    for a in wp.get("found_by") or []:
+        m = HANDLE.match(str(a).strip())
+        if m:
+            out.append(m.group(1).lower())
+    return out
+
+
+def refutation_binding(author, base_doc, new_doc):
+    """Does new_doc differ from base_doc by exactly a refutation credited to
+    author? Returns (ok, reason-if-not)."""
+    keys = set(base_doc) | set(new_doc)
+    for key in keys - {"distance", "name", "schema_version", "provenance"}:
+        if base_doc.get(key) != new_doc.get(key):
+            return False, f"field '{key}' changed (only the distance claim may change)"
+
+    bp, np_ = base_doc.get("provenance") or {}, new_doc.get("provenance") or {}
+    for key in set(bp) | set(np_):
+        if key == "notes":
+            continue
+        if bp.get(key) != np_.get(key):
+            return False, f"provenance.{key} changed (authors and construction are the constructor's)"
+    old_notes, new_notes = bp.get("notes", ""), np_.get("notes", "")
+    if not new_notes.startswith(old_notes):
+        return False, "provenance.notes may only be appended to"
+
+    bd, nd = base_doc.get("distance") or {}, new_doc.get("distance") or {}
+    tightened = 0
+    for side in ("X", "Z"):
+        bs, ns = bd.get(side) or {}, nd.get(side) or {}
+        if bs == ns:
+            continue
+        if author not in found_by_handles(ns):
+            return False, (f"distance.{side} changed but its witness_provenance"
+                           f".found_by does not list @{author}")
+        if bs.get("confidence") != ns.get("confidence"):
+            return False, f"distance.{side}.confidence changed"
+        if ns.get("value", 0) < bs.get("value", 0):
+            tightened += 1
+        elif (ns.get("value") == bs.get("value")
+              and ns.get("witness") == bs.get("witness")):
+            pass  # survival stamp: witness_provenance recorded, claim untouched
+        else:
+            return False, (f"distance.{side}.value did not strictly decrease "
+                           "and its witness changed")
+    if tightened == 0:
+        return False, "no side's distance strictly decreased"
+    if nd.get("d") != min(nd.get(s, {}).get("value", 0) for s in ("X", "Z")):
+        return False, "distance.d is not min(dX, dZ)"
+    return True, ""
 
 
 def main(argv):
@@ -67,10 +164,16 @@ def main(argv):
         print("no --author given; skipping authorship check")  # fail open
         return 0
 
-    files = [a for a in argv if a.endswith(".json")]
+    explicit = [a for a in argv if a.endswith(".json")]
+    changes = changed_codes(base, root)
+    if explicit:
+        files = explicit
+        changes = changes or {}
+    else:
+        if changes is None:
+            return 0
+        files = [p for p, s in changes.items() if s in ("A", "M")]
     if not files:
-        files = changed_codes(base, root)
-    if files is None or not files:
         print("no added/changed code submissions to check")
         return 0
 
@@ -88,17 +191,35 @@ def main(argv):
         if not hs:
             print(f"ok    {f}: no @handle authors (baseline/anonymous), exempt")
             continue
+        base_path = base_counterpart(f, doc, changes)
+        base_doc = load_base_doc(base, base_path, root) if base_path else None
         if author in hs:
-            print(f"ok    {f}: PR author @{author} is listed")
+            # Being listed binds -- but on a change to an existing code, the
+            # author list itself may only be edited by an existing author.
+            # Otherwise swapping authors would grant edit rights (issue #611).
+            base_hs = handles(base_doc) if base_doc is not None else None
+            if (base_hs and hs != base_hs and author not in base_hs):
+                pass  # fall through to the refutation binding
+            else:
+                print(f"ok    {f}: PR author @{author} is listed")
+                continue
+        if base_doc is not None:
+            ok, why = refutation_binding(author, base_doc, doc)
+            if ok:
+                print(f"ok    {f}: @{author} binds via witness_provenance "
+                      f"(refutation of {base_path})")
+                continue
+            violations.append((f, hs, f"refutation binding failed: {why}"))
         else:
-            violations.append((f, hs))
+            violations.append((f, hs, None))
 
     if violations:
         print("\nAuthorship mismatch: the PR author must be one of a code's "
-              "@handle authors.")
-        for f, hs in violations:
+              "@handle authors, or the change must be exactly a refutation "
+              "credited to them in witness_provenance.found_by (issue #611).")
+        for f, hs, extra in violations:
             print(f"  {f}: authors {['@' + h for h in hs]} do not include "
-                  f"@{author}")
+                  f"@{author}" + (f"; {extra}" if extra else ""))
         print("If you are submitting on someone's behalf, add yourself as a "
               "co-author, or have them open the PR.")
         return 1

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -19,7 +19,10 @@ distance checks, so a bogus claim cannot pass regardless.
 Relatedly, on a change to an existing code the author list itself may only be
 edited by someone already on it: without that, adding (or swapping in) your own
 handle would grant edit rights over anyone's entry, which is the hole the
-refutation binding exists to avoid. New submissions are unaffected.
+refutation binding exists to avoid. This includes first-claiming an @handle on
+a no-handle literature baseline (that needs a maintainer); a refuted 'exact'
+claim must demote to upper_bound, and no correction may claim 'exact' at the
+new value without going through certification. New submissions are unaffected.
 
 Fails CLOSED only on a definite author/PR-author mismatch. Anything ambiguous
 (no author info, git/parse error) fails OPEN with a warning -- a bug here must
@@ -119,27 +122,35 @@ def refutation_binding(author, base_doc, new_doc):
         return False, "provenance.notes may only be appended to"
 
     bd, nd = base_doc.get("distance") or {}, new_doc.get("distance") or {}
+    for side in ("X", "Z"):
+        if not (bd.get(side) and nd.get(side)):
+            return False, f"distance.{side} is missing"
     tightened = 0
     for side in ("X", "Z"):
-        bs, ns = bd.get(side) or {}, nd.get(side) or {}
+        bs, ns = bd[side], nd[side]
         if bs == ns:
             continue
         if author not in found_by_handles(ns):
             return False, (f"distance.{side} changed but its witness_provenance"
                            f".found_by does not list @{author}")
-        if bs.get("confidence") != ns.get("confidence"):
-            return False, f"distance.{side}.confidence changed"
         if ns.get("value", 0) < bs.get("value", 0):
+            # A falsified claim can only be an upper bound now: a refuted
+            # 'exact' must demote, and nothing may claim 'exact' at the new
+            # value without going through certification.
+            if ns.get("confidence") != "upper_bound":
+                return False, (f"distance.{side}.confidence must become "
+                               "upper_bound when the value is corrected")
             tightened += 1
         elif (ns.get("value") == bs.get("value")
-              and ns.get("witness") == bs.get("witness")):
+              and ns.get("witness") == bs.get("witness")
+              and ns.get("confidence") == bs.get("confidence")):
             pass  # survival stamp: witness_provenance recorded, claim untouched
         else:
             return False, (f"distance.{side}.value did not strictly decrease "
-                           "and its witness changed")
+                           "and its witness or confidence changed")
     if tightened == 0:
         return False, "no side's distance strictly decreased"
-    if nd.get("d") != min(nd.get(s, {}).get("value", 0) for s in ("X", "Z")):
+    if nd.get("d") != min(nd[s].get("value", 0) for s in ("X", "Z")):
         return False, "distance.d is not min(dX, dZ)"
     return True, ""
 
@@ -196,9 +207,12 @@ def main(argv):
         if author in hs:
             # Being listed binds -- but on a change to an existing code, the
             # author list itself may only be edited by an existing author.
-            # Otherwise swapping authors would grant edit rights (issue #611).
+            # Otherwise swapping (or first-claiming, on a no-handle baseline)
+            # your own handle would grant edit rights (issue #611). A genuine
+            # first @handle claim on a baseline needs a maintainer.
             base_hs = handles(base_doc) if base_doc is not None else None
-            if (base_hs and hs != base_hs and author not in base_hs):
+            if (base_hs is not None and hs != base_hs
+                    and author not in base_hs):
                 pass  # fall through to the refutation binding
             else:
                 print(f"ok    {f}: PR author @{author} is listed")

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -1,0 +1,197 @@
+"""Tests for check_authorship.py, including the refutation binding (#611).
+
+Builds a throwaway git repo, commits a code owned by @alice, then checks which
+edits @bob can and cannot land: a clean refutation (rename + strictly lighter
+witness credited to him in witness_provenance) binds; anything that also
+touches the construction, authorship, or credit does not. The gate does no
+code math, so the fixture code is synthetic.
+"""
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_authorship
+
+BASE_DOC = {
+    "schema_version": "0.1",
+    "name": "[[60,8,6]] synthetic test code",
+    "code_type": "CSS",
+    "n": 60, "k": 8,
+    "checks": {"X": [[0, 1, 2]], "Z": [[3, 4, 5]]},
+    "distance": {
+        "d": 6,
+        "X": {"value": 6, "confidence": "upper_bound",
+              "witness": [0, 1, 2, 3, 4, 5]},
+        "Z": {"value": 7, "confidence": "upper_bound",
+              "witness": [0, 1, 2, 3, 4, 5, 6]},
+    },
+    "provenance": {"authors": ["@alice"], "construction": "synthetic",
+                   "notes": "original."},
+}
+
+_fail = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'}  {name}")
+    if not cond:
+        _fail.append(name)
+
+
+def git(td, *args):
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    *args], cwd=td, check=True, capture_output=True)
+
+
+def write_code(td, fname, doc):
+    os.makedirs(os.path.join(td, "codes"), exist_ok=True)
+    with open(os.path.join(td, "codes", fname), "w") as f:
+        json.dump(doc, f)
+
+
+def make_repo(td):
+    git(td, "init", "-q", "-b", "main")
+    write_code(td, "60-8-6.json", BASE_DOC)
+    git(td, "add", "codes")
+    git(td, "commit", "-q", "-m", "base")
+    git(td, "checkout", "-q", "-b", "change")
+
+
+def refuted(with_wp=True, found_by="@bob"):
+    doc = copy.deepcopy(BASE_DOC)
+    doc["name"] = "[[60,8,5]] synthetic test code"
+    doc["schema_version"] = "0.2"
+    doc["distance"]["X"] = {"value": 5, "confidence": "upper_bound",
+                            "witness": [0, 1, 2, 3, 4]}
+    if with_wp:
+        doc["distance"]["X"]["witness_provenance"] = {
+            "found_by": [found_by], "date": "2026-08-19", "samples": 10 ** 9}
+    doc["distance"]["d"] = 5
+    doc["provenance"]["notes"] += " Refuted."
+    return doc
+
+
+def run_case(name, edit, expect_ok, author="bob", rename=True):
+    with tempfile.TemporaryDirectory() as td:
+        make_repo(td)
+        doc = edit()
+        if rename:
+            git(td, "rm", "-q", "codes/60-8-6.json")
+            write_code(td, "60-8-5.json", doc)
+        else:
+            write_code(td, "60-8-6.json", doc)
+        git(td, "add", "codes")
+        git(td, "commit", "-q", "-m", "change")
+        rc = check_authorship.main(
+            ["--author", author, "--root", td, "--base", "main"])
+        check(name, (rc == 0) == expect_ok)
+
+
+def main():
+    print("refutation binding (issue #611):")
+    run_case("clean refutation by @bob binds", refuted, True)
+    run_case("in-place (no rename) refutation binds",
+             refuted, True, rename=False)
+    run_case("owner @alice still binds via authors",
+             refuted, True, author="alice")
+
+    def no_wp():
+        return refuted(with_wp=False)
+    run_case("lighter witness without witness_provenance rejected",
+             no_wp, False)
+
+    def wrong_credit():
+        return refuted(found_by="@carol")
+    run_case("witness_provenance crediting someone else rejected",
+             wrong_credit, False)
+
+    def touches_checks():
+        doc = refuted()
+        doc["checks"]["X"] = [[0, 1, 3]]
+        return doc
+    run_case("refutation that also edits checks rejected", touches_checks,
+             False)
+
+    def appends_author():
+        doc = refuted()
+        doc["provenance"]["authors"].append("@bob")
+        return doc
+    run_case("refutation that also appends to authors rejected",
+             appends_author, False)
+
+    def swaps_author():
+        doc = copy.deepcopy(BASE_DOC)
+        doc["provenance"]["authors"] = ["@bob"]
+        return doc
+    run_case("author swap on someone else's code rejected", swaps_author,
+             False, rename=False)
+
+    def owner_adds_coauthor():
+        doc = copy.deepcopy(BASE_DOC)
+        doc["provenance"]["authors"] = ["@alice", "@carol"]
+        return doc
+    run_case("existing author may edit the author list",
+             owner_adds_coauthor, True, author="alice", rename=False)
+
+    def rewrites_notes():
+        doc = refuted()
+        doc["provenance"]["notes"] = "Mine now."
+        return doc
+    run_case("refutation that rewrites notes rejected", rewrites_notes, False)
+
+    def loosens():
+        doc = refuted()
+        doc["distance"]["X"]["value"] = 8
+        doc["distance"]["X"]["witness"] = list(range(8))
+        doc["distance"]["d"] = 7
+        doc["name"] = BASE_DOC["name"]
+        return doc
+    run_case("loosened bound rejected (no strict decrease)", loosens, False)
+
+    def stamp_only():
+        doc = copy.deepcopy(BASE_DOC)
+        doc["schema_version"] = "0.2"
+        doc["distance"]["X"]["witness_provenance"] = {
+            "found_by": ["@bob"], "date": "2026-08-19", "samples": 10 ** 9}
+        return doc
+    run_case("survival stamp alone does not grant edit rights", stamp_only,
+             False, rename=False)
+
+    def stamp_riding_along():
+        doc = refuted()
+        doc["distance"]["Z"]["witness_provenance"] = {
+            "found_by": ["@bob"], "date": "2026-08-19", "samples": 10 ** 9}
+        return doc
+    run_case("survival stamp riding on a real refutation binds",
+             stamp_riding_along, True)
+
+    print("\nplain submissions (original binding):")
+    def new_code():
+        return copy.deepcopy(BASE_DOC)
+    with tempfile.TemporaryDirectory() as td:
+        make_repo(td)
+        write_code(td, "61-9-6.json", new_code())
+        git(td, "add", "codes")
+        git(td, "commit", "-q", "-m", "new")
+        rc = check_authorship.main(
+            ["--author", "bob", "--root", td, "--base", "main"])
+        check("new code by non-author still rejected", rc == 1)
+        rc = check_authorship.main(
+            ["--author", "alice", "--root", td, "--base", "main"])
+        check("new code by its author still accepted", rc == 0)
+
+    print()
+    if _fail:
+        print(f"FAILED: {_fail}")
+        return 1
+    print("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -70,7 +70,7 @@ def refuted(with_wp=True, found_by="@bob"):
                             "witness": [0, 1, 2, 3, 4]}
     if with_wp:
         doc["distance"]["X"]["witness_provenance"] = {
-            "found_by": [found_by], "date": "2026-08-19", "samples": 10 ** 9}
+            "found_by": [found_by], "date": "2026-08-19", "found_at_samples": 10 ** 9}
     doc["distance"]["d"] = 5
     doc["provenance"]["notes"] += " Refuted."
     return doc
@@ -157,7 +157,7 @@ def main():
         doc = copy.deepcopy(BASE_DOC)
         doc["schema_version"] = "0.2"
         doc["distance"]["X"]["witness_provenance"] = {
-            "found_by": ["@bob"], "date": "2026-08-19", "samples": 10 ** 9}
+            "found_by": ["@bob"], "date": "2026-08-19", "found_at_samples": 10 ** 9}
         return doc
     run_case("survival stamp alone does not grant edit rights", stamp_only,
              False, rename=False)
@@ -165,7 +165,7 @@ def main():
     def stamp_riding_along():
         doc = refuted()
         doc["distance"]["Z"]["witness_provenance"] = {
-            "found_by": ["@bob"], "date": "2026-08-19", "samples": 10 ** 9}
+            "found_by": ["@bob"], "date": "2026-08-19", "found_at_samples": 10 ** 9}
         return doc
     run_case("survival stamp riding on a real refutation binds",
              stamp_riding_along, True)

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -54,9 +54,9 @@ def write_code(td, fname, doc):
         json.dump(doc, f)
 
 
-def make_repo(td):
+def make_repo(td, base_doc=None):
     git(td, "init", "-q", "-b", "main")
-    write_code(td, "60-8-6.json", BASE_DOC)
+    write_code(td, "60-8-6.json", base_doc or BASE_DOC)
     git(td, "add", "codes")
     git(td, "commit", "-q", "-m", "base")
     git(td, "checkout", "-q", "-b", "change")
@@ -76,9 +76,10 @@ def refuted(with_wp=True, found_by="@bob"):
     return doc
 
 
-def run_case(name, edit, expect_ok, author="bob", rename=True):
+def run_case(name, edit, expect_ok, author="bob", rename=True,
+             base_doc=None):
     with tempfile.TemporaryDirectory() as td:
-        make_repo(td)
+        make_repo(td, base_doc=base_doc)
         doc = edit()
         if rename:
             git(td, "rm", "-q", "codes/60-8-6.json")
@@ -169,6 +170,68 @@ def main():
         return doc
     run_case("survival stamp riding on a real refutation binds",
              stamp_riding_along, True)
+
+    print("\nexact-claim corrections (PR review round 2):")
+    EXACT_BASE = copy.deepcopy(BASE_DOC)
+    EXACT_BASE["distance"]["X"]["confidence"] = "exact"
+
+    def demotes_exact():
+        doc = refuted()
+        doc["distance"]["X"]["confidence"] = "upper_bound"
+        return doc
+    run_case("refuted exact claim demoting to upper_bound binds",
+             demotes_exact, True, base_doc=EXACT_BASE)
+
+    def keeps_exact():
+        doc = refuted()
+        doc["distance"]["X"]["confidence"] = "exact"
+        return doc
+    run_case("refuted exact claim keeping 'exact' rejected",
+             keeps_exact, False, base_doc=EXACT_BASE)
+
+    def upgrades_to_exact():
+        doc = refuted()
+        doc["distance"]["X"]["confidence"] = "exact"
+        return doc
+    run_case("correction claiming 'exact' at the new value rejected",
+             upgrades_to_exact, False)
+
+    def stamp_upgrades_conf():
+        doc = refuted()
+        doc["distance"]["Z"]["confidence"] = "exact"
+        doc["distance"]["Z"]["witness_provenance"] = {
+            "found_by": ["@bob"], "date": "2026-08-19",
+            "found_at_samples": 10 ** 9}
+        return doc
+    run_case("survival stamp that upgrades confidence rejected",
+             stamp_upgrades_conf, False)
+
+    print("\nbaselines (no @handle authors):")
+    BASELINE = copy.deepcopy(BASE_DOC)
+    BASELINE["provenance"]["authors"] = ["Kitaev"]
+
+    def claims_baseline():
+        doc = copy.deepcopy(BASELINE)
+        doc["provenance"]["authors"] = ["Kitaev", "@bob"]
+        doc["n"] = 61
+        return doc
+    run_case("first @handle claim on a baseline rejected",
+             claims_baseline, False, rename=False, base_doc=BASELINE)
+
+    def refutes_baseline():
+        doc = refuted()
+        doc["provenance"]["authors"] = ["Kitaev"]
+        return doc
+    run_case("pure refutation of a baseline still accepted (exempt)",
+             refutes_baseline, True, base_doc=BASELINE)
+
+    print("\nmalformed input:")
+    missing_side = copy.deepcopy(BASE_DOC)
+    del missing_side["distance"]["Z"]
+    ok, why = check_authorship.refutation_binding(
+        "bob", BASE_DOC, missing_side)
+    check("missing side named in the rejection reason",
+          not ok and "distance.Z is missing" in why)
 
     print("\nplain submissions (original binding):")
     def new_code():


### PR DESCRIPTION
## What

Second half of #611 (PR A: #612). `check_authorship.py` gains an alternative binding for third-party refutations, scoped exactly as @vprusso specified:

A PR author who is **not** in a code's `authors` binds iff:
1. **Confinement**: every difference from the base version is inside the `distance` block, plus the `name` string, `schema_version`, and an *append* to `provenance.notes`. Checks, n, k, authors, construction, model, family — byte-identical or rejected.
2. **Strict tightening**: at least one side's `value` strictly decreases, and every side the PR touches carries a `witness_provenance` whose `found_by` lists the PR author. A side may alternatively carry a survival stamp (provenance recorded, value and witness untouched) riding along with a real refutation.

Renamed files (d is in the filename) are paired with the deleted `codes/<n>-<k>-*.json` from the same diff. The witness itself is machine-verified by the distance checks, so the binding never has to trust the claim — together the conditions mean this path can only tighten a bound, never alter a construction or its authorship.

## Also: closes an author-swap hole

While wiring this up, the tests surfaced a pre-existing gap the new binding would have inherited: the gate only ever read the **new** file's author list, so modifying someone's code and swapping your own handle into `authors` passed. Now, on a change to an existing code, the author list may only be edited by someone already on it (new submissions unaffected; git/parse failures still fail open per the module's philosophy). Note this intentionally retires the append-yourself-as-author refutation path (#602 discussion, used by #605–#610) — `witness_provenance` becomes the sanctioned route, which is the point of #611.

## Tests

New `verify/test_check_authorship.py` (auto-discovered by `run_tests.py`) builds throwaway git repos and exercises 15 cases: clean rename + in-place refutations bind; missing/wrong credit, checks edits, author appends/swaps, notes rewrites, loosened bounds, and stamp-only changes are all rejected; owner flows are unchanged. Full suite 10/10.

Sequencing: independent of #612 code-wise (the gate only reads `found_by`), but both should land before the #605–#610 entries are migrated off the author-append style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)