### PR TITLE
Test scaffolding: adopt pytest, centralise import paths (#614)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+"""Import paths for the test suite.
+
+This repo is deliberately not installable (`[tool.uv] package = false`), so
+`verify/` and `research/kit/` are plain directories rather than packages and
+nothing in them is importable by name. Every test used to open with its own
+`sys.path.insert` pair to work around that. pytest imports this file before
+collecting anything, so the fix belongs here once instead of in every test.
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+for _rel in ("verify", os.path.join("research", "kit"), "research", "cli", "site"):
+    _p = os.path.join(ROOT, _rel)
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ research = ["scipy>=1.11", "ldpc>=2.0"]
 [tool.uv]
 # scripts-only repo: manage the environment, do not try to build/install it
 package = false
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]

--- a/research/test_smoke.py
+++ b/research/test_smoke.py
@@ -13,9 +13,6 @@ Run: uv run python research/test_smoke.py   (exit 0 = pass)
 import os
 import sys
 
-_HERE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(_HERE, "kit"))              # research/kit modules
-sys.path.insert(0, os.path.join(_HERE, "..", "verify"))    # the verifier
 
 from bb import build_bb, KNOWN
 from css import compute_k, verify_css
@@ -67,6 +64,11 @@ def main():
 
     print("PASS" if not _fail else "FAIL: " + ", ".join(_fail))
     return 0 if not _fail else 1
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
+    assert main() == 0
 
 
 if __name__ == "__main__":

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,62 +1,44 @@
-"""Run every test in the repo, discovered by convention -- not by a hand-kept list.
+"""Run the test suite. A thin wrapper over pytest, kept as the documented entry
+point so CI and the README command do not change.
 
-Any file matching verify/test_*.py or research/test_*.py is part of the suite the
-moment it exists; it cannot be silently left out of CI the way a hand-listed step
-can (which is how two of five tests once went unrun). Each test stays a standalone
-script (plain python, exit 0 = pass) so it can still be run and audited on its own.
+Discovery is still by convention -- pytest collects verify/test_*.py and
+research/test_*.py -- so a new test joins the suite the moment it exists and
+cannot be silently left out of CI the way a hand-listed step can (which is how
+two of five tests once went unrun).
 
   uv run --frozen python run_tests.py              # everything (what CI runs)
   uv run --frozen python run_tests.py --skip-slow  # quick local iteration
+
+To run or debug one test, call pytest directly; it replaces running a test file
+as a standalone script:
+
+  uv run pytest verify/test_verifier.py            # one file
+  uv run pytest verify/test_verifier.py::test_main # one test
+  uv run pytest -k refute -x --pdb                 # match, stop, drop into pdb
 """
 import argparse
-import glob
 import os
 import subprocess
 import sys
-import time
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
-# Slow tests (about a minute or more locally); skipped with --skip-slow.
-# Currently empty: test_heuristic_distance.py used to sweep every certified code
-# (O(board size)) but now checks a fixed panel and runs in seconds.
-SLOW = set()
-
-
-def collect():
-    tests = []
-    for pattern in ("verify/test_*.py", "research/test_*.py"):
-        tests += sorted(glob.glob(os.path.join(ROOT, pattern)))
-    return [os.path.relpath(t, ROOT) for t in tests]
+# Slow tests (about a minute or more locally); skipped with --skip-slow, by
+# pytest -k expression so the names stay readable here.
+SLOW = []
 
 
 def main(argv):
     ap = argparse.ArgumentParser()
     ap.add_argument("--skip-slow", action="store_true",
                     help="skip the tests listed in SLOW")
-    args = ap.parse_args(argv)
+    args, extra = ap.parse_known_args(argv)
 
-    tests = collect()
-    if args.skip_slow:
-        tests = [t for t in tests if t not in SLOW]
-    if not tests:
-        print("no tests found -- the glob conventions are broken")
-        return 1
-
-    failed = []
-    for t in tests:
-        print(f"\n=== {t} ===", flush=True)
-        t0 = time.time()
-        r = subprocess.run([sys.executable, os.path.join(ROOT, t)], cwd=ROOT)
-        dt = time.time() - t0
-        status = "PASS" if r.returncode == 0 else f"FAIL (exit {r.returncode})"
-        print(f"=== {t}: {status} in {dt:.1f}s ===", flush=True)
-        if r.returncode != 0:
-            failed.append(t)
-
-    print(f"\n{len(tests) - len(failed)}/{len(tests)} test files passed"
-          + (f"; FAILED: {', '.join(failed)}" if failed else ""))
-    return 1 if failed else 0
+    cmd = [sys.executable, "-m", "pytest", "verify", "research"]
+    if args.skip_slow and SLOW:
+        cmd += ["--deselect" if "::" in s else "--ignore=" + s for s in SLOW]
+    cmd += extra
+    return subprocess.run(cmd, cwd=ROOT).returncode
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -102,7 +102,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -193,7 +193,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -470,15 +470,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -546,15 +546,15 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -999,6 +999,11 @@ research = [
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.0" },
@@ -1008,6 +1013,9 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'research'", specifier = ">=1.11" },
 ]
 provides-extras = ["certify", "research"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "referencing"
@@ -1297,7 +1305,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1356,7 +1364,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -13,8 +13,6 @@ import os
 import subprocess
 import sys
 import tempfile
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import check_authorship
 
 BASE_DOC = {
@@ -254,6 +252,11 @@ def main():
         return 1
     print("ok")
     return 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
+    assert main() == 0
 
 
 if __name__ == "__main__":

--- a/verify/test_check_prose.py
+++ b/verify/test_check_prose.py
@@ -12,7 +12,6 @@ import tempfile
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(_HERE)
-sys.path.insert(0, _HERE)
 import check_prose
 
 FAILURES = []
@@ -119,6 +118,11 @@ def main():
         return 1
     print("all prose checks pass")
     return 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
+    assert main() == 0
 
 
 if __name__ == "__main__":

--- a/verify/test_frontier_summary.py
+++ b/verify/test_frontier_summary.py
@@ -13,9 +13,6 @@ import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "cli"))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "site"))
-
 import qldpc  # noqa: E402
 import qldpc_verify  # noqa: E402
 
@@ -74,6 +71,11 @@ def main():
 
     print(f"\n{'PASS' if not _fail else 'FAIL: ' + ', '.join(_fail)}")
     return 1 if _fail else 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
+    assert main() == 0
 
 
 if __name__ == "__main__":

--- a/verify/test_gf2_fast.py
+++ b/verify/test_gf2_fast.py
@@ -12,15 +12,15 @@ import sys
 import numpy as np
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, _HERE)
 import gf2
 
 try:
     import gf2_fast
-except ImportError:
-    print("SKIP: gf2_fast not built (run `make fast`); pure-Python fallback is "
-          "the reference and needs no test here.")
-    sys.exit(0)
+except ImportError:                      # pragma: no cover - depends on `make fast`
+    import pytest
+    pytest.skip("gf2_fast not built (run `make fast`); the pure-Python "
+                "fallback is the reference and needs no test here.",
+                allow_module_level=True)
 
 FAILURES = []
 
@@ -108,4 +108,6 @@ ok = (side in ("X", "Z")
 check("distance_rand_witness returns a valid logical", ok,
       f"w={w} side={side} |support|={len(support)}")
 
-sys.exit(1 if FAILURES else 0)
+def test_gf2_fast_matches_reference():
+    """pytest entry point: the checks above run at import, this reports them."""
+    assert not FAILURES, FAILURES

--- a/verify/test_heuristic_distance.py
+++ b/verify/test_heuristic_distance.py
@@ -19,8 +19,6 @@ import glob
 import json
 import os
 import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import heuristic_distance as H
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -130,6 +128,15 @@ def main(argv):
 
     print(f"\n{failures} failure(s)")
     sys.exit(1 if failures else 0)
+
+
+def test_main():
+    """pytest entry point. main() takes argv and reports by calling sys.exit,
+    including on success, so the exit status is what gets asserted."""
+    import pytest
+    with pytest.raises(SystemExit) as exc:
+        main([])
+    assert not exc.value.code, f"panel run exited {exc.value.code}"
 
 
 if __name__ == "__main__":

--- a/verify/test_receipt.py
+++ b/verify/test_receipt.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 
 import sys
-sys.path.insert(0, os.path.dirname(__file__))
 
 from build_receipt import make_receipt, write_receipt
 from validate_candidate import validate_candidate
@@ -36,6 +35,12 @@ def main():
         assert loaded["provenance"]["model"]["status"] == "self_reported"
         assert "board_advancing" in loaded["frontier"]
     print("receipt tests passed")
+
+
+def test_main():
+    """pytest entry point. main() returns None and signals failure by raising,
+    so a clean return is the pass condition."""
+    main()
 
 
 if __name__ == "__main__":

--- a/verify/test_refute_gate.py
+++ b/verify/test_refute_gate.py
@@ -19,8 +19,6 @@ import copy
 import json
 import os
 import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import numpy as np
 import gf2
 import qldpc_verify
@@ -158,6 +156,11 @@ def main():
 
 
 def test_refute_gate():
+    assert main() == 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
     assert main() == 0
 
 

--- a/verify/test_ris_gpu.py
+++ b/verify/test_ris_gpu.py
@@ -14,8 +14,6 @@ import sys
 import tempfile
 
 import numpy as np
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gf2
 import ris_gpu
 

--- a/verify/test_validate_candidate.py
+++ b/verify/test_validate_candidate.py
@@ -20,10 +20,6 @@ import json
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))          # verify/
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(       # research/kit (fixtures only)
-    os.path.abspath(__file__))), "research", "kit"))
-
 import numpy as np
 import gf2
 from bb import build_bb
@@ -113,6 +109,11 @@ def main():
 
 
 def test_validate_candidate():
+    assert main() == 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
     assert main() == 0
 
 

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -17,8 +17,6 @@ import json
 import os
 import sys
 import tempfile
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import qldpc_verify
 
 verify = qldpc_verify.verify
@@ -305,6 +303,11 @@ def main():
 
 # pytest entry points
 def test_adversarial():
+    assert main() == 0
+
+
+def test_main():
+    """pytest entry point; the suite body lives in main()."""
     assert main() == 0
 
 


### PR DESCRIPTION
Closes #614.

## The problem

11 test files carried 14 `sys.path.insert` lines between them, plus 8 private `check()` helpers, 6 `_fail` accumulators and a 63-line hand-rolled runner. The path boilerplate is not the tests' fault: `[tool.uv] package = false` means `verify/` and `research/kit/` are plain directories, and `run_tests.py` spawned each test with the test's own directory on `sys.path`, so `from bb import ...` could not resolve without help.

## What changed

- `conftest.py` at the root does the path setup once, before collection. The 14 inserts are gone.
- pytest added as a dev dependency group, so the verifier's runtime dependencies (numpy, jsonschema) are untouched. That surface is the one the trustless-verification promise rests on.
- `run_tests.py` is now a thin wrapper over pytest with the same CLI, so CI and the documented command do not change. Discovery is still by convention.
- Running or debugging a single test is now `pytest verify/test_verifier.py::test_main`, with `-k`, `-x` and `--pdb` available. This replaces `python verify/test_x.py`, which is a deliberate trade: the standalone-script property is dropped in exchange for a real runner.

## Two things worth knowing

`verify/test_gf2_fast.py` executed at module level and called `sys.exit()` twice. pytest hits that during collection, so it would have aborted the whole session. It now uses `pytest.skip(allow_module_level=True)` when the extension is unbuilt, and asserts its accumulated verdict.

Two entry points did not match the contract I first assumed. `test_receipt.main()` returns `None` and signals failure by raising; `test_heuristic_distance.main(argv)` takes arguments and calls `sys.exit` even on success. Both are now asserted against what they actually do. Both had been "passing" purely because the old runner checked the process exit code and never observed `main()`'s return value, so a `main()` that returned `None` looked identical to one that returned 0.

## Deliberately not in scope

The 8 duplicated `check()` helpers and 6 `_fail` accumulators stay. Sharing them is a trap now that all files run in one process: a shared mutable `_fail` would leak failures between files. Removing them properly means splitting each `main()` into granular `test_*` functions so pytest's assertion introspection does the job, which is per-file work better reviewed as separate diffs.

## Verification

Full suite run locally through the unchanged entry point (`uv run --frozen python run_tests.py`). CI runs the same command.