### PR TITLE
authorship gate: renames must not bypass the check

### DIFF
--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -44,10 +44,18 @@ HANDLE = re.compile(r"^@([A-Za-z0-9-]+)$")
 
 
 def changed_codes(base, root=ROOT):
-    """{path: status} for codes changed vs base; status is A, M, or D."""
+    """{path: status} for codes changed vs base; status is A, M, or D.
+
+    --no-renames matters: a refutation renames codes/<n>-<k>-<d>.json to the
+    new d while changing only the distance block, which git otherwise folds
+    into a single R line (98% similar on a real board file) that used to
+    parse as neither added nor modified -- the gate then checked nothing at
+    all. Splitting renames back into D + A keeps every path visible; the R
+    branch below is belt-and-braces in case the flag is ever lost."""
     try:
         out = subprocess.check_output(
-            ["git", "diff", "--name-status", f"{base}...HEAD", "--", "codes"],
+            ["git", "diff", "--name-status", "--no-renames",
+             f"{base}...HEAD", "--", "codes"],
             cwd=root, text=True)
     except Exception as e:
         print(f"(could not diff vs {base}: {e}); skipping authorship check")
@@ -55,8 +63,16 @@ def changed_codes(base, root=ROOT):
     changes = {}
     for line in out.splitlines():
         parts = line.split("\t")
-        if len(parts) >= 2 and parts[1].endswith(".json"):
-            changes[parts[1]] = parts[0][:1]
+        if len(parts) < 2:
+            continue
+        status = parts[0][:1]
+        if status == "R" and len(parts) >= 3:
+            if parts[1].endswith(".json"):
+                changes[parts[1]] = "D"
+            if parts[2].endswith(".json"):
+                changes[parts[2]] = "A"
+        elif parts[1].endswith(".json"):
+            changes[parts[1]] = status
     return changes
 
 

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -51,7 +51,7 @@ def git(td, *args):
 def write_code(td, fname, doc):
     os.makedirs(os.path.join(td, "codes"), exist_ok=True)
     with open(os.path.join(td, "codes", fname), "w") as f:
-        json.dump(doc, f)
+        json.dump(doc, f, indent=1)  # multi-line, like real board files
 
 
 def make_repo(td, base_doc=None):
@@ -224,6 +224,34 @@ def main():
         return doc
     run_case("pure refutation of a baseline still accepted (exempt)",
              refutes_baseline, True, base_doc=BASELINE)
+
+    print("\nrename detection (a real refutation is ~98% similar, which git "
+          "folds\ninto an R line unless the gate splits renames):")
+    BIG = copy.deepcopy(BASE_DOC)
+    BIG["checks"]["X"] = [[i, i + 1, i + 2] for i in range(500)]
+
+    def refuted_big():
+        doc = copy.deepcopy(BIG)
+        doc["name"] = "[[60,8,5]] synthetic test code"
+        doc["schema_version"] = "0.2"
+        doc["distance"]["X"] = {"value": 5, "confidence": "upper_bound",
+                                "witness": [0, 1, 2, 3, 4],
+                                "witness_provenance": {
+                                    "found_by": ["@bob"],
+                                    "date": "2026-08-19",
+                                    "found_at_samples": 10 ** 9}}
+        doc["distance"]["d"] = 5
+        doc["provenance"]["notes"] += " Refuted."
+        return doc
+    run_case("high-similarity rename: clean refutation still binds",
+             refuted_big, True, base_doc=BIG)
+
+    def refuted_big_tampered():
+        doc = refuted_big()
+        doc["provenance"]["authors"] = ["@bob"]
+        return doc
+    run_case("high-similarity rename: tampered refutation still caught",
+             refuted_big_tampered, False, base_doc=BIG)
 
     print("\nmalformed input:")
     missing_side = copy.deepcopy(BASE_DOC)


### PR DESCRIPTION
## The bug

Found while migrating #608–#610 to the new schema: the gate merged in #613 **fails open on renamed code files** — the exact case it was built for.

`changed_codes` parses `git diff --name-status` for `A`/`M` lines, but git folds a rename plus a small edit into a single `R` line when similarity is high. A real refutation renames `codes/<n>-<k>-<d>.json` to the new d while touching only the distance block — `R098` (98% similar) on an actual board file. The parser recognizes neither field of the `R` line, so the gate sees no changed files, prints "no submissions to check", and passes vacuously. Anyone could rename-and-edit another person's entry and skip authorship checking entirely (schema and distance checks still apply, but the authorship property is gone).

#613's 22 test cases missed it because the fixtures were tiny single-line JSONs — below git's 50% similarity threshold, so their renames decomposed into `D`+`A` naturally and the pairing logic worked. Live demonstration: the authorship step on #608–#610 is currently passing without inspecting them.

## The fix

- `--no-renames` on the diff, so renames always decompose into `D` + `A` — which `base_counterpart` already pairs correctly.
- Defensive parsing of `R old new` lines anyway (old → `D`, new → `A`), in case the flag is ever lost.
- Two new test cases on a padded, multi-line fixture (500 checks, `json.dump(indent=1)`) that genuinely triggers git's rename folding: the clean refutation binds, the tampered one is caught. 24/24; full suite 11/11.

cc @vprusso — smallest possible follow-up to your #613 review; the binding logic itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)