### PR TITLE
Backfill witness_provenance on the five merged refutation entries

### DIFF
--- a/codes/390-82-38.json
+++ b/codes/390-82-38.json
@@ -1,5 +1,5 @@
 {
- "schema_version": "0.1",
+ "schema_version": "0.2",
  "name": "[[380,82,38]]",
  "code_type": "CSS",
  "n": 390,
@@ -13359,19 +13359,28 @@
     357,
     373,
     388
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@seunomonije"
+    ],
+    "date": "2026-07-20",
+    "found_at_samples": 24000000,
+    "seeds": [
+     31415
+    ]
+   }
   }
  },
  "provenance": {
   "authors": [
-   "@mathysrennela",
-   "@seunomonije"
+   "@mathysrennela"
   ],
   "construction": "Generalized bicycle (2BGA on Z_195), circulant size 195, a(x) weight 16, b(x) weight 16, both multiples of degree-41 divisor g of x^195-1 (k=82). Symmetric high-distance variant of [[390,82,27]].",
   "origin": "submission",
   "date": "2026-07-19",
   "model": "Tencent Hy3",
-  "notes": "Distance corrected 39 -> 38 (2026-07-20): an independent deep-refutation pass by @seunomonije's verification harness (Claude Fable 5) found a weight-38 Z logical (RIS, 24M trials, seed 31415, pair_depth 8; ~129M trials total across 7 fresh seeds and pair-depth 16/24 passes, readings 38-41). The original weight-39 X witness remains valid; the embedded Z witness is the new lightest known."
+  "notes": "Distance corrected 39 -> 38 (2026-07-20): an independent deep-refutation pass by @seunomonije's verification harness (Claude Fable 5) found a weight-38 Z logical (RIS, 24M trials, seed 31415, pair_depth 8; ~129M trials total across 7 fresh seeds and pair-depth 16/24 passes, readings 38-41). The original weight-39 X witness remains valid; the embedded Z witness is the new lightest known. Migrated 2026-08-19 (issue #611): refutation credit moved from provenance.authors to witness_provenance on the refuted side(s); authors again lists only the constructor."
  },
  "family": "generalized-bicycle"
 }

--- a/codes/666-150-76.json
+++ b/codes/666-150-76.json
@@ -21400,7 +21400,17 @@
     622,
     653,
     657
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@vprusso"
+    ],
+    "date": "2026-08-18",
+    "found_at_samples": 40000000,
+    "seeds": [
+     901
+    ]
+   }
   },
   "Z": {
    "value": 77,
@@ -21483,7 +21493,17 @@
     645,
     656,
     664
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@vprusso"
+    ],
+    "date": "2026-08-18",
+    "found_at_samples": 20000000,
+    "seeds": [
+     77
+    ]
+   }
   }
  },
  "k": 150,
@@ -21491,14 +21511,13 @@
  "name": "[[666,150,76]] designed-divisor generalized-bicycle CSS code",
  "provenance": {
   "authors": [
-   "@npdeep",
-   "@vprusso"
+   "@npdeep"
   ],
   "construction": "Designed-divisor generalized-bicycle search at lift 333, with 16-term a(x) and 14-term b(x); a CI RIS-fast refutation of the original d<=82 submission supplied the retained weight-79 Z logical witness.",
   "date": "2026-08-15",
   "model": "Magic State Labs (Custom) v0.1",
-  "notes": "The weight-82 X witness and the corrected weight-79 Z witness were independently validated. The original d<=82 claim was corrected after CI found the lighter Z logical. The distance is a witness-backed upper bound, not an exact-distance claim. Distance revised 2026-08-18. @npdeep constructed the code; @vprusso is added as an author for the refutation that tightened the claim, following the board's precedent for refutation contributions. The refutation ran on independent hardware: 105M RIS samples across four fresh seeds found a weight-76 X logical (seed 901, 40M samples) and a weight-77 Z logical (seed 77, 20M samples), both recorded here as the new per-side witnesses; two further 20M/40M rungs found nothing lighter. This tightens d<=79 to d<=76 and the score to 150*76^2/666 = 1300.90."
+  "notes": "The weight-82 X witness and the corrected weight-79 Z witness were independently validated. The original d<=82 claim was corrected after CI found the lighter Z logical. The distance is a witness-backed upper bound, not an exact-distance claim. Distance revised 2026-08-18. @npdeep constructed the code; @vprusso is added as an author for the refutation that tightened the claim, following the board's precedent for refutation contributions. The refutation ran on independent hardware: 105M RIS samples across four fresh seeds found a weight-76 X logical (seed 901, 40M samples) and a weight-77 Z logical (seed 77, 20M samples), both recorded here as the new per-side witnesses; two further 20M/40M rungs found nothing lighter. This tightens d<=79 to d<=76 and the score to 150*76^2/666 = 1300.90. Migrated 2026-08-19 (issue #611): refutation credit moved from provenance.authors to witness_provenance on the refuted side(s); authors again lists only the constructor."
  },
- "schema_version": "0.1",
+ "schema_version": "0.2",
  "family": "generalized-bicycle"
 }

--- a/codes/674-128-80.json
+++ b/codes/674-128-80.json
@@ -21659,7 +21659,18 @@
     550,
     571,
     655
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@FarLab"
+    ],
+    "date": "2026-08-19",
+    "found_at_samples": 1000000000,
+    "tool": "sqetch",
+    "seeds": [
+     77000003
+    ]
+   }
   },
   "Z": {
    "confidence": "upper_bound",
@@ -21747,7 +21758,18 @@
     618,
     638,
     658
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@FarLab"
+    ],
+    "date": "2026-08-19",
+    "found_at_samples": 1000000000,
+    "tool": "sqetch",
+    "seeds": [
+     77000004
+    ]
+   }
   },
   "d": 80
  },
@@ -21756,13 +21778,12 @@
  "name": "[[674,128,d<=80]] designed-divisor generalized-bicycle code",
  "provenance": {
   "authors": [
-   "@npdeep",
-   "@FarLab"
+   "@npdeep"
   ],
   "construction": "Designed-divisor generalized-bicycle search at lift 337, with 16-term a(x) and 14-term b(x); a fresh 8,000,000-trial-per-direction RIS-fast gate supplied the retained weight-88 X and weight-87 Z logical witnesses.",
   "date": "2026-08-16",
   "model": "Magic State Labs (Custom) v0.1",
-  "notes": "The X and Z witnesses were independently validated. The distance is a witness-backed upper bound, not an exact-distance claim. Distance revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side first beat both claimed bounds, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z) committed a weight-80 X logical and a weight-82 Z logical, both re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new per-side witnesses. This tightens d<=87 to d<=80 and the score from 128*87^2/674 = 1437.44 to 128*80^2/674 = 1215.43. The distance remains a witness-backed upper bound, not an exact-distance claim. @npdeep constructed the code; @FarLab is added as an author for the refutation, following the board's precedent for refutation contributions."
+  "notes": "The X and Z witnesses were independently validated. The distance is a witness-backed upper bound, not an exact-distance claim. Distance revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side first beat both claimed bounds, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z) committed a weight-80 X logical and a weight-82 Z logical, both re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new per-side witnesses. This tightens d<=87 to d<=80 and the score from 128*87^2/674 = 1437.44 to 128*80^2/674 = 1215.43. The distance remains a witness-backed upper bound, not an exact-distance claim. @npdeep constructed the code; @FarLab is added as an author for the refutation, following the board's precedent for refutation contributions. Migrated 2026-08-19 (issue #611): refutation credit moved from provenance.authors to witness_provenance on the refuted side(s); authors again lists only the constructor."
  },
- "schema_version": "0.1"
+ "schema_version": "0.2"
 }

--- a/codes/674-86-89.json
+++ b/codes/674-86-89.json
@@ -1,5 +1,5 @@
 {
- "schema_version": "0.1",
+ "schema_version": "0.2",
  "name": "[[674,86,89]] generalized-bicycle code over Z_337",
  "code_type": "CSS",
  "n": 674,
@@ -17632,7 +17632,18 @@
     593,
     641,
     668
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@FarLab"
+    ],
+    "date": "2026-08-19",
+    "found_at_samples": 1000000000,
+    "tool": "sqetch",
+    "seeds": [
+     77000003
+    ]
+   }
   },
   "Z": {
    "value": 89,
@@ -17732,8 +17743,7 @@
  },
  "provenance": {
   "authors": [
-   "@kessler-frost",
-   "@FarLab"
+   "@kessler-frost"
   ],
   "origin": "submission",
   "novelty": "unknown",
@@ -17748,7 +17758,7 @@
    "https://arxiv.org/abs/2608.09115"
   ],
   "date": "2026-08-16",
-  "notes": "Submitted by @kessler-frost, who designed and ran the candidate search. The retained b polynomial is credited to @vprusso and the pinned source above; the a polynomial was found in the new search. The original d <= 95 submission was refuted by public CI seed 147873169, whose RIS-fast pass found the retained weight-89 Z logical. This revision therefore makes only the corrected witness-backed claims d_X <= 98, d_Z <= 89, and d <= 89; no lower bound or exact-distance claim is made. No exact or WL-equivalent current-board entry was found, but no exhaustive literature classification is known, so novelty is unknown. X-side bound revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z), committed a weight-92 X logical, re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new X witness, tightening dX<=98 to dX<=92. The same budget found no Z logical lighter than weight 90, so the claimed dZ<=89 and the overall d<=89 stand unchanged (the deep run corroborates rather than refutes the headline distance; score unchanged at 86*89^2/674 = 1010.55). All distances remain witness-backed upper bounds, not exact-distance claims. @kessler-frost constructed the code; @FarLab is added as an author for the bound revision, following the board's precedent for refutation contributions."
+  "notes": "Submitted by @kessler-frost, who designed and ran the candidate search. The retained b polynomial is credited to @vprusso and the pinned source above; the a polynomial was found in the new search. The original d <= 95 submission was refuted by public CI seed 147873169, whose RIS-fast pass found the retained weight-89 Z logical. This revision therefore makes only the corrected witness-backed claims d_X <= 98, d_Z <= 89, and d <= 89; no lower bound or exact-distance claim is made. No exact or WL-equivalent current-board entry was found, but no exhaustive literature classification is known, so novelty is unknown. X-side bound revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z), committed a weight-92 X logical, re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new X witness, tightening dX<=98 to dX<=92. The same budget found no Z logical lighter than weight 90, so the claimed dZ<=89 and the overall d<=89 stand unchanged (the deep run corroborates rather than refutes the headline distance; score unchanged at 86*89^2/674 = 1010.55). All distances remain witness-backed upper bounds, not exact-distance claims. @kessler-frost constructed the code; @FarLab is added as an author for the bound revision, following the board's precedent for refutation contributions. Migrated 2026-08-19 (issue #611): refutation credit moved from provenance.authors to witness_provenance on the refuted side(s); authors again lists only the constructor."
  },
  "family": "generalized-bicycle"
 }

--- a/codes/674-86-90.json
+++ b/codes/674-86-90.json
@@ -1,5 +1,5 @@
 {
- "schema_version": "0.1",
+ "schema_version": "0.2",
  "name": "[[674,86,90]] generalized-bicycle code over Z_337",
  "code_type": "CSS",
  "n": 674,
@@ -21674,7 +21674,18 @@
     564,
     628,
     640
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@FarLab"
+    ],
+    "date": "2026-08-19",
+    "found_at_samples": 1000000000,
+    "tool": "sqetch",
+    "seeds": [
+     77000003
+    ]
+   }
   },
   "Z": {
    "value": 91,
@@ -21771,19 +21782,29 @@
     584,
     609,
     656
-   ]
+   ],
+   "witness_provenance": {
+    "found_by": [
+     "@FarLab"
+    ],
+    "date": "2026-08-19",
+    "found_at_samples": 1000000000,
+    "tool": "sqetch",
+    "seeds": [
+     77000004
+    ]
+   }
   }
  },
  "family": "generalized-bicycle",
  "provenance": {
   "authors": [
-   "@vprusso",
-   "@FarLab"
+   "@vprusso"
   ],
   "construction": "Generalized bicycle code over the cyclic group Z_337 (m = 337 prime): H_X = [circ(a) | circ(b)], H_Z = [circ(b)^T | circ(a)^T] with a = x^[0, 2, 36, 41, 67, 95, 98, 132, 136, 201, 234, 254, 260, 287, 294, 321] and b = x^[63, 105, 112, 144, 215, 241, 253, 267, 276, 300, 312, 316, 317, 320] (exponent lists over Z_337). k = 2 deg gcd(a, b, x^337 - 1) = 86. Prime m makes x^m - 1 factor as (x - 1) times irreducibles of degree ord_337(2), which pins the attainable k and concentrates the search on the pair (a, b) within the ideal.",
   "references": [],
   "date": "2026-08-15",
-  "notes": "Found by a prime-m GB sweep with a screening ladder of randomized information-set passes (4k to 20M samples), then confirmed at 20M twice and independently re-attacked with 47M samples across four fresh seeds; the bound converged to d <= 92 and no lighter logical was found in roughly 87M samples across six seeds total. Witness weights match the per-side claims exactly (X: 92, Z: 93). Distance claims are upper bounds; no exactness is claimed at this size. Distance revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side first beat both claimed bounds, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z) committed a weight-90 X logical and a weight-91 Z logical, both re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new per-side witnesses. This tightens d<=92 to d<=90 and the score from 86*92^2/674 = 1079.98 to 86*90^2/674 = 1033.53. The distance remains a witness-backed upper bound, not an exact-distance claim. @vprusso constructed the code; @FarLab is added as an author for the refutation, following the board's precedent for refutation contributions.",
+  "notes": "Found by a prime-m GB sweep with a screening ladder of randomized information-set passes (4k to 20M samples), then confirmed at 20M twice and independently re-attacked with 47M samples across four fresh seeds; the bound converged to d <= 92 and no lighter logical was found in roughly 87M samples across six seeds total. Witness weights match the per-side claims exactly (X: 92, Z: 93). Distance claims are upper bounds; no exactness is claimed at this size. Distance revised 2026-08-19 by GPU deep refutation. Random-ISD runs with the sqetch GPU kernels (Muzhou Ma, MIT) on an NVIDIA L40S: a 50M-trial x 3-seed triage per side first beat both claimed bounds, then a 1,000,000,000-trial recovery ladder per side (seed 77000003 for X, 77000004 for Z) committed a weight-90 X logical and a weight-91 Z logical, both re-verified on the CPU with the repo's GF(2) arithmetic and recorded here as the new per-side witnesses. This tightens d<=92 to d<=90 and the score from 86*92^2/674 = 1079.98 to 86*90^2/674 = 1033.53. The distance remains a witness-backed upper bound, not an exact-distance claim. @vprusso constructed the code; @FarLab is added as an author for the refutation, following the board's precedent for refutation contributions. Migrated 2026-08-19 (issue #611): refutation credit moved from provenance.authors to witness_provenance on the refuted side(s); authors again lists only the constructor.",
   "model": "Claude Fable 5"
  }
 }


### PR DESCRIPTION
## What

The one-time migration completing #611, now that #612/#613/#616 are merged: the five board entries that carry a refuter in `provenance.authors` move to the `witness_provenance` style. Authors again lists only the constructor; the refuter, date, budget, and seeds are recorded on the side(s) whose witness they found, reconstructed from each entry's own provenance notes:

| entry | authors after | credit moved |
|---|---|---|
| [[674,128,80]] | @npdeep | X+Z → @FarLab (sqetch, 10⁹/side, seeds 77000003/4) |
| [[674,86,90]] | @vprusso | X+Z → @FarLab (same run) |
| [[674,86,89]] | @kessler-frost | X only → @FarLab; the Z witness is the constructor's own |
| [[666,150,76]] | @npdeep | X → @vprusso (seed 901, 4×10⁷), Z → @vprusso (seed 77, 2×10⁷) |
| [[390,82,38]] | @mathysrennela | Z → @seunomonije (RIS 2.4×10⁷, seed 31415) |

Each file bumps to schema 0.2 and gains one migration sentence in its notes. All five pass `verify/qldpc_verify.py`; the site builds.

## The authorship check WILL be red — that is correct

This PR removes handles from `authors`, which is precisely what the #613 binding forbids (and for 666/390 the removed handle is not the PR author's). The gate failing closed here is it working as designed on a deliberate one-time migration; there is no legitimate automated path for this change, which is rather the point. **Needs a maintainer merge over the failing authorship check.** Every other check should be green.

cc @vprusso @seunomonije — this touches credit for your refutations; the recorded budgets/seeds come from the entries' notes, flag anything that doesn't match your records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)