### PR TITLE
test: follow #610 rename in test_ris_gpu.py (514-162-41 -> 514-162-29)

### DIFF
--- a/verify/test_ris_gpu.py
+++ b/verify/test_ris_gpu.py
@@ -266,7 +266,7 @@ def test_gpu_pair_stage_matters():
     binary = os.path.join(ROOT, "build", "ris_gpu")
     if not gpu_available(binary):
         pytest.skip("no ris_gpu binary or no GPU")
-    with open(os.path.join(ROOT, "codes", "514-162-41.json")) as f:
+    with open(os.path.join(ROOT, "codes", "514-162-29.json")) as f:
         doc = json.load(f)
     n = doc["n"]
     HX = ris_gpu.checks_matrix(doc["checks"]["X"], n)


### PR DESCRIPTION
One-line path fix: the pair-stage test referenced `codes/514-162-41.json`, renamed by the #610 refutation. CPU-only CI never noticed (the GPU skip guard fires before the file open), but any GPU machine running the suite would crash. Matrices are unchanged by a refutation rename, so the calibrated deterministic expectation (pd24=54 < pd1=56 at 20k trials, seed 11) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)