### PR TITLE
check_authorship: layout binding — first-layout additions may append their contributor

### DIFF
--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -64,6 +64,11 @@ Two principles drive the format:
   - `interaction_radius`: claimed max check diameter in the layout; the
     verifier recomputes the true max check diameter and requires
     `measured <= claim`.
+  - `contributed_by` (optional, schema 0.2): `{by, date, method?}` crediting
+    who contributed this layout. Layout credit lives here, beside the
+    artifact, not in `provenance.authors` — the same separation
+    `witness_provenance` uses for refutation credit — so adding a layout to
+    an existing entry never changes its author list.
 - `provenance`: `authors`, `construction` (how it was built), optional
   `references`, `date`, `notes`, `model`.
   - `origin`: `"baseline"` for a literature seed or `"submission"` for a code

--- a/schema/code.schema.json
+++ b/schema/code.schema.json
@@ -113,6 +113,35 @@
           "type": "number",
           "minimum": 0,
           "description": "claimed max check diameter in the layout; verifier recomputes"
+        },
+        "contributed_by": {
+          "type": "object",
+          "description": "who contributed this layout, and when. Layout credit lives here, on the artifact contributed, not in provenance.authors -- the same separation witness_provenance uses for refutation credit, so contributing a layout never widens edit rights over the code (issue #611).",
+          "required": [
+            "by",
+            "date"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "by": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^@[A-Za-z0-9-]+$"
+              },
+              "minItems": 1,
+              "description": "@handles of the people who contributed this layout"
+            },
+            "date": {
+              "type": "string",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "method": {
+              "type": "string",
+              "maxLength": 400,
+              "description": "optionally, how the layout was found (tool, model, search method)"
+            }
+          }
         }
       }
     },
@@ -241,6 +270,28 @@
         },
         "required": [
           "distance"
+        ]
+      },
+      "then": {
+        "properties": {
+          "schema_version": {
+            "const": "0.2"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "locality.contributed_by (a 0.2 feature) likewise requires schema_version 0.2",
+      "if": {
+        "properties": {
+          "locality": {
+            "required": [
+              "contributed_by"
+            ]
+          }
+        },
+        "required": [
+          "locality"
         ]
       },
       "then": {

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -23,14 +23,14 @@ refutation binding exists to avoid. A refuted 'exact' claim must demote to
 upper_bound, and no correction may claim 'exact' at the new value without going
 through certification. New submissions are unaffected.
 
-One more binding exists for layouts: a change that ONLY adds a first `locality`
-block (the code had none) may also append the contributor to `authors` and set
-a previously-absent `model`, with everything else -- checks, distance, and the
-original provenance -- byte-identical (notes append-only). The layout is a
-separate verifiable artifact (the verifier recomputes the radius and locality
-class from the coordinates), so crediting its contributor does not grant edit
-rights over the code itself: any later change by them still has to pass one of
-these bindings or be a pure layout replacement they authored.
+One more binding exists for layouts, and it mirrors the refutation binding's
+credit model exactly: a change that ONLY adds a first `locality` block (the
+code had none) binds when the block's `contributed_by.by` lists the PR author.
+`provenance` must be byte-identical apart from an append to notes -- in
+particular `authors` and `model` never change, so layout credit lives beside
+the artifact (like witness_provenance.found_by) and can never widen the
+contributor's edit rights over the code: they are still not a listed author
+on the next PR, and any later change must itself pass a binding.
 
 Fails CLOSED only on a definite author/PR-author mismatch. Anything ambiguous
 (no author info, git/parse error) fails OPEN with a warning -- a bug here must
@@ -179,17 +179,28 @@ def refutation_binding(author, base_doc, new_doc):
     return True, ""
 
 
+def contributed_by_handles(loc):
+    cb = (loc or {}).get("contributed_by") or {}
+    out = []
+    for a in cb.get("by") or []:
+        m = HANDLE.match(str(a).strip())
+        if m:
+            out.append(m.group(1).lower())
+    return out
+
+
 def layout_binding(author, base_doc, new_doc):
     """Does new_doc differ from base_doc by exactly the addition of a first
     layout credited to author? Returns (ok, reason-if-not).
 
-    Allowed: add `locality` where none existed, append entries (including
-    @author) to provenance.authors, set a previously-absent provenance.model,
-    append to provenance.notes, and change `name`. Everything else -- checks,
-    distance, and the remaining provenance -- must be untouched, so the
-    binding grants credit for the layout artifact without granting edit
-    rights over the code (issue #611's concern). The layout's own validity
-    (spacing, layers, radius, class) is the verifier's job, not this gate's."""
+    Allowed: add `locality` where none existed, with the PR author listed in
+    locality.contributed_by.by; append to provenance.notes; change `name` and
+    `schema_version`. Everything else -- checks, distance, and ALL other
+    provenance including authors and model -- must be byte-identical. Credit
+    lives beside the artifact (as witness_provenance.found_by does for
+    refutations), so the binding never widens the contributor's edit rights
+    over the code (issue #611). The layout's own validity (spacing, layers,
+    radius, class) is the verifier's job, not this gate's."""
     if "locality" in (base_doc or {}):
         return False, ("the entry already has a layout; replacing one is "
                        "reserved to its listed authors")
@@ -203,29 +214,17 @@ def layout_binding(author, base_doc, new_doc):
                            "only add locality)")
 
     bp, np_ = base_doc.get("provenance") or {}, new_doc.get("provenance") or {}
-    for key in (set(bp) | set(np_)) - {"authors", "notes", "model"}:
+    for key in (set(bp) | set(np_)) - {"notes"}:
         if bp.get(key) != np_.get(key):
-            return False, (f"provenance.{key} changed (only authors may be "
-                           "appended, notes appended, and an absent model set)")
-    ba, na = bp.get("authors") or [], np_.get("authors") or []
-    if na[:len(ba)] != ba or len(na) <= len(ba):
-        return False, ("provenance.authors must keep the original list and "
-                       "append the layout contributor")
-    appended = [a for a in na[len(ba):]]
-    appended_handles = []
-    for a in appended:
-        m = HANDLE.match(str(a).strip())
-        if m:
-            appended_handles.append(m.group(1).lower())
-    if author not in appended_handles:
-        return False, (f"appended authors {appended} do not include the PR "
-                       f"author @{author}")
+            return False, (f"provenance.{key} changed (layout credit lives in "
+                           "locality.contributed_by, not in provenance)")
     old_notes, new_notes = bp.get("notes", ""), np_.get("notes", "")
     if not new_notes.startswith(old_notes):
         return False, "provenance.notes may only be appended to"
-    if "model" in bp and bp.get("model") != np_.get("model"):
-        return False, ("provenance.model was already set and may not be "
-                       "changed by a layout addition")
+
+    if author not in contributed_by_handles(new_doc.get("locality")):
+        return False, ("locality.contributed_by.by does not list the PR "
+                       f"author @{author}")
     return True, ""
 
 
@@ -302,8 +301,15 @@ def main(argv):
                 print(f"ok    {f}: @{author} binds via layout addition "
                       f"(first locality block on {base_path})")
                 continue
-            violations.append((f, hs, f"refutation binding failed: {why}; "
-                                      f"layout binding failed: {why2}"))
+            # Lead with the binding the change was evidently aiming for, so a
+            # plain unauthorized edit reads one relevant rejection, not two.
+            layoutish = ("locality" in doc) and ("locality" not in base_doc)
+            first, second = ((f"layout binding failed: {why2}",
+                              f"refutation binding failed: {why}")
+                             if layoutish else
+                             (f"refutation binding failed: {why}",
+                              f"layout binding failed: {why2}"))
+            violations.append((f, hs, f"{first} ({second})"))
         else:
             violations.append((f, hs, None))
 

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -19,10 +19,18 @@ distance checks, so a bogus claim cannot pass regardless.
 Relatedly, on a change to an existing code the author list itself may only be
 edited by someone already on it: without that, adding (or swapping in) your own
 handle would grant edit rights over anyone's entry, which is the hole the
-refutation binding exists to avoid. This includes first-claiming an @handle on
-a no-handle literature baseline (that needs a maintainer); a refuted 'exact'
-claim must demote to upper_bound, and no correction may claim 'exact' at the
-new value without going through certification. New submissions are unaffected.
+refutation binding exists to avoid. A refuted 'exact' claim must demote to
+upper_bound, and no correction may claim 'exact' at the new value without going
+through certification. New submissions are unaffected.
+
+One more binding exists for layouts: a change that ONLY adds a first `locality`
+block (the code had none) may also append the contributor to `authors` and set
+a previously-absent `model`, with everything else -- checks, distance, and the
+original provenance -- byte-identical (notes append-only). The layout is a
+separate verifiable artifact (the verifier recomputes the radius and locality
+class from the coordinates), so crediting its contributor does not grant edit
+rights over the code itself: any later change by them still has to pass one of
+these bindings or be a pure layout replacement they authored.
 
 Fails CLOSED only on a definite author/PR-author mismatch. Anything ambiguous
 (no author info, git/parse error) fails OPEN with a warning -- a bug here must
@@ -171,6 +179,56 @@ def refutation_binding(author, base_doc, new_doc):
     return True, ""
 
 
+def layout_binding(author, base_doc, new_doc):
+    """Does new_doc differ from base_doc by exactly the addition of a first
+    layout credited to author? Returns (ok, reason-if-not).
+
+    Allowed: add `locality` where none existed, append entries (including
+    @author) to provenance.authors, set a previously-absent provenance.model,
+    append to provenance.notes, and change `name`. Everything else -- checks,
+    distance, and the remaining provenance -- must be untouched, so the
+    binding grants credit for the layout artifact without granting edit
+    rights over the code (issue #611's concern). The layout's own validity
+    (spacing, layers, radius, class) is the verifier's job, not this gate's."""
+    if "locality" in (base_doc or {}):
+        return False, ("the entry already has a layout; replacing one is "
+                       "reserved to its listed authors")
+    if "locality" not in new_doc:
+        return False, "no locality block was added"
+    for key in (set(base_doc) | set(new_doc)) - {"locality", "name",
+                                                 "schema_version",
+                                                 "provenance"}:
+        if base_doc.get(key) != new_doc.get(key):
+            return False, (f"field '{key}' changed (a layout addition may "
+                           "only add locality)")
+
+    bp, np_ = base_doc.get("provenance") or {}, new_doc.get("provenance") or {}
+    for key in (set(bp) | set(np_)) - {"authors", "notes", "model"}:
+        if bp.get(key) != np_.get(key):
+            return False, (f"provenance.{key} changed (only authors may be "
+                           "appended, notes appended, and an absent model set)")
+    ba, na = bp.get("authors") or [], np_.get("authors") or []
+    if na[:len(ba)] != ba or len(na) <= len(ba):
+        return False, ("provenance.authors must keep the original list and "
+                       "append the layout contributor")
+    appended = [a for a in na[len(ba):]]
+    appended_handles = []
+    for a in appended:
+        m = HANDLE.match(str(a).strip())
+        if m:
+            appended_handles.append(m.group(1).lower())
+    if author not in appended_handles:
+        return False, (f"appended authors {appended} do not include the PR "
+                       f"author @{author}")
+    old_notes, new_notes = bp.get("notes", ""), np_.get("notes", "")
+    if not new_notes.startswith(old_notes):
+        return False, "provenance.notes may only be appended to"
+    if "model" in bp and bp.get("model") != np_.get("model"):
+        return False, ("provenance.model was already set and may not be "
+                       "changed by a layout addition")
+    return True, ""
+
+
 def main(argv):
     author = None
     if "--author" in argv:
@@ -239,14 +297,22 @@ def main(argv):
                 print(f"ok    {f}: @{author} binds via witness_provenance "
                       f"(refutation of {base_path})")
                 continue
-            violations.append((f, hs, f"refutation binding failed: {why}"))
+            ok2, why2 = layout_binding(author, base_doc, doc)
+            if ok2:
+                print(f"ok    {f}: @{author} binds via layout addition "
+                      f"(first locality block on {base_path})")
+                continue
+            violations.append((f, hs, f"refutation binding failed: {why}; "
+                                      f"layout binding failed: {why2}"))
         else:
             violations.append((f, hs, None))
 
     if violations:
         print("\nAuthorship mismatch: the PR author must be one of a code's "
               "@handle authors, or the change must be exactly a refutation "
-              "credited to them in witness_provenance.found_by (issue #611).")
+              "credited to them in witness_provenance.found_by (issue #611), "
+              "or exactly a first-layout addition that appends them to "
+              "provenance.authors.")
         for f, hs, extra in violations:
             print(f"  {f}: authors {['@' + h for h in hs]} do not include "
                   f"@{author}" + (f"; {extra}" if extra else ""))

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -317,8 +317,8 @@ def main(argv):
         print("\nAuthorship mismatch: the PR author must be one of a code's "
               "@handle authors, or the change must be exactly a refutation "
               "credited to them in witness_provenance.found_by (issue #611), "
-              "or exactly a first-layout addition that appends them to "
-              "provenance.authors.")
+              "or exactly a first-layout addition credited to them in "
+              "locality.contributed_by.by.")
         for f, hs, extra in violations:
             print(f"  {f}: authors {['@' + h for h in hs]} do not include "
                   f"@{author}" + (f"; {extra}" if extra else ""))

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -251,6 +251,84 @@ def main():
     run_case("high-similarity rename: tampered refutation still caught",
              refuted_big_tampered, False, base_doc=BIG)
 
+    print("\nlayout binding (first locality block):")
+    LAYOUT = {"coordinates": [[float(i), 0.0] for i in range(60)], "layers": 2}
+
+    def adds_layout(base=BASE_DOC, model=None, append="@bob"):
+        doc = copy.deepcopy(base)
+        doc["locality"] = copy.deepcopy(LAYOUT)
+        doc["name"] += ", two-layer layout"
+        if append:
+            doc["provenance"]["authors"] = (
+                list(doc["provenance"]["authors"]) + [append])
+        doc["provenance"]["notes"] += " Layout added."
+        if model:
+            doc["provenance"]["model"] = model
+        return doc
+    run_case("layout addition appending @bob binds",
+             lambda: adds_layout(model="TestModel 1.0"), True, rename=False)
+    run_case("layout addition on a no-handle baseline binds",
+             lambda: adds_layout(base=BASELINE), True, rename=False,
+             base_doc=BASELINE)
+
+    def layout_no_credit():
+        return adds_layout(append=None)
+    run_case("layout addition without appending the PR author rejected",
+             layout_no_credit, False, rename=False)
+
+    def layout_touches_checks():
+        doc = adds_layout()
+        doc["checks"]["X"] = [[0, 1, 3]]
+        return doc
+    run_case("layout addition that also edits checks rejected",
+             layout_touches_checks, False, rename=False)
+
+    def layout_touches_distance():
+        doc = adds_layout()
+        doc["distance"]["X"]["value"] = 5
+        doc["distance"]["X"]["witness"] = [0, 1, 2, 3, 4]
+        doc["distance"]["d"] = 5
+        return doc
+    run_case("layout addition that also edits distance rejected",
+             layout_touches_distance, False, rename=False)
+
+    def layout_rewrites_notes():
+        doc = adds_layout()
+        doc["provenance"]["notes"] = "Mine now."
+        return doc
+    run_case("layout addition that rewrites notes rejected",
+             layout_rewrites_notes, False, rename=False)
+
+    def layout_swaps_authors():
+        doc = adds_layout(append=None)
+        doc["provenance"]["authors"] = ["@bob"]
+        return doc
+    run_case("layout addition that swaps the author list rejected",
+             layout_swaps_authors, False, rename=False)
+
+    HAS_LAYOUT = copy.deepcopy(BASE_DOC)
+    HAS_LAYOUT["locality"] = copy.deepcopy(LAYOUT)
+
+    def layout_replaces():
+        doc = copy.deepcopy(HAS_LAYOUT)
+        doc["locality"] = {"coordinates": [[0.0, float(i)] for i in range(60)],
+                           "layers": 1}
+        doc["provenance"]["authors"] = (
+            list(doc["provenance"]["authors"]) + ["@bob"])
+        doc["provenance"]["notes"] += " Better layout."
+        return doc
+    run_case("replacing an existing layout rejected",
+             layout_replaces, False, rename=False, base_doc=HAS_LAYOUT)
+
+    MODELED = copy.deepcopy(BASE_DOC)
+    MODELED["provenance"]["model"] = "Original Model 2.0"
+
+    def layout_changes_model():
+        doc = adds_layout(base=MODELED, model="Other Model 3.0")
+        return doc
+    run_case("layout addition changing an existing model rejected",
+             layout_changes_model, False, rename=False, base_doc=MODELED)
+
     print("\nmalformed input:")
     missing_side = copy.deepcopy(BASE_DOC)
     del missing_side["distance"]["Z"]

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -252,29 +252,50 @@ def main():
              refuted_big_tampered, False, base_doc=BIG)
 
     print("\nlayout binding (first locality block):")
-    LAYOUT = {"coordinates": [[float(i), 0.0] for i in range(60)], "layers": 2}
+    LAYOUT = {"coordinates": [[float(i), 0.0] for i in range(60)], "layers": 2,
+              "contributed_by": {"by": ["@bob"], "date": "2026-08-20"}}
 
-    def adds_layout(base=BASE_DOC, model=None, append="@bob"):
+    def adds_layout(base=BASE_DOC, credit=True):
         doc = copy.deepcopy(base)
         doc["locality"] = copy.deepcopy(LAYOUT)
+        if not credit:
+            del doc["locality"]["contributed_by"]
+        doc["schema_version"] = "0.2"
         doc["name"] += ", two-layer layout"
-        if append:
-            doc["provenance"]["authors"] = (
-                list(doc["provenance"]["authors"]) + [append])
         doc["provenance"]["notes"] += " Layout added."
-        if model:
-            doc["provenance"]["model"] = model
         return doc
-    run_case("layout addition appending @bob binds",
-             lambda: adds_layout(model="TestModel 1.0"), True, rename=False)
+    run_case("layout addition credited in contributed_by binds",
+             adds_layout, True, rename=False)
     run_case("layout addition on a no-handle baseline binds",
              lambda: adds_layout(base=BASELINE), True, rename=False,
              base_doc=BASELINE)
 
     def layout_no_credit():
-        return adds_layout(append=None)
-    run_case("layout addition without appending the PR author rejected",
+        return adds_layout(credit=False)
+    run_case("layout addition without contributed_by credit rejected",
              layout_no_credit, False, rename=False)
+
+    def layout_wrong_credit():
+        doc = adds_layout()
+        doc["locality"]["contributed_by"]["by"] = ["@carol"]
+        return doc
+    run_case("layout addition crediting someone else rejected",
+             layout_wrong_credit, False, rename=False)
+
+    def layout_appends_author():
+        doc = adds_layout()
+        doc["provenance"]["authors"] = (
+            list(doc["provenance"]["authors"]) + ["@bob"])
+        return doc
+    run_case("layout addition that also appends to authors rejected",
+             layout_appends_author, False, rename=False)
+
+    def layout_sets_model():
+        doc = adds_layout()
+        doc["provenance"]["model"] = "TestModel 1.0"
+        return doc
+    run_case("layout addition that also sets model rejected",
+             layout_sets_model, False, rename=False)
 
     def layout_touches_checks():
         doc = adds_layout()
@@ -299,35 +320,63 @@ def main():
     run_case("layout addition that rewrites notes rejected",
              layout_rewrites_notes, False, rename=False)
 
-    def layout_swaps_authors():
-        doc = adds_layout(append=None)
-        doc["provenance"]["authors"] = ["@bob"]
-        return doc
-    run_case("layout addition that swaps the author list rejected",
-             layout_swaps_authors, False, rename=False)
-
     HAS_LAYOUT = copy.deepcopy(BASE_DOC)
-    HAS_LAYOUT["locality"] = copy.deepcopy(LAYOUT)
+    HAS_LAYOUT["locality"] = {"coordinates": LAYOUT["coordinates"],
+                              "layers": 2}
 
     def layout_replaces():
         doc = copy.deepcopy(HAS_LAYOUT)
-        doc["locality"] = {"coordinates": [[0.0, float(i)] for i in range(60)],
-                           "layers": 1}
-        doc["provenance"]["authors"] = (
-            list(doc["provenance"]["authors"]) + ["@bob"])
+        doc["schema_version"] = "0.2"
+        doc["locality"] = copy.deepcopy(LAYOUT)
+        doc["locality"]["layers"] = 1
         doc["provenance"]["notes"] += " Better layout."
         return doc
     run_case("replacing an existing layout rejected",
              layout_replaces, False, rename=False, base_doc=HAS_LAYOUT)
 
-    MODELED = copy.deepcopy(BASE_DOC)
-    MODELED["provenance"]["model"] = "Original Model 2.0"
+    print("\nmerged-state escalation (the author list is the privilege "
+          "boundary;\na merged binding must not widen the contributor's "
+          "rights on the next PR):")
 
-    def layout_changes_model():
-        doc = adds_layout(base=MODELED, model="Other Model 3.0")
+    def merged_state_case(name, followup_edit, expect_ok, merged_doc=None):
+        with tempfile.TemporaryDirectory() as td:
+            make_repo(td)                       # base on main, branch 'change'
+            git(td, "checkout", "-q", "main")   # merge the binding into main
+            write_code(td, "60-8-6.json", merged_doc or adds_layout())
+            git(td, "add", "codes")
+            git(td, "commit", "-q", "-m", "layout binding merged")
+            git(td, "checkout", "-q", "-b", "followup")
+            write_code(td, "60-8-6.json", followup_edit())
+            git(td, "add", "codes")
+            git(td, "commit", "-q", "-m", "followup")
+            rc = check_authorship.main(
+                ["--author", "bob", "--root", td, "--base", "main"])
+            check(name, (rc == 0) == expect_ok)
+
+    def bob_rewrites_after_merge():
+        doc = adds_layout()
+        doc["checks"]["X"] = [[0, 1, 3]]
+        doc["distance"]["X"]["value"] = 9
+        doc["distance"]["d"] = 7
+        doc["provenance"]["construction"] = "bob's construction"
         return doc
-    run_case("layout addition changing an existing model rejected",
-             layout_changes_model, False, rename=False, base_doc=MODELED)
+    merged_state_case("after a merged layout binding, @bob still cannot "
+                      "edit the code", bob_rewrites_after_merge, False)
+
+    def bob_refutes_after_merge():
+        doc = adds_layout()
+        doc["name"] = "[[60,8,5]] synthetic test code, two-layer layout"
+        doc["distance"]["X"] = {
+            "value": 5, "confidence": "upper_bound",
+            "witness": [0, 1, 2, 3, 4],
+            "witness_provenance": {"found_by": ["@bob"],
+                                   "date": "2026-08-20",
+                                   "found_at_samples": 10 ** 9}}
+        doc["distance"]["d"] = 5
+        doc["provenance"]["notes"] += " Refuted."
+        return doc
+    merged_state_case("after a merged layout binding, a clean refutation "
+                      "by @bob still binds", bob_refutes_after_merge, True)
 
     print("\nmalformed input:")
     missing_side = copy.deepcopy(BASE_DOC)


### PR DESCRIPTION
## Policy extension: the layout binding

PR #642 (adding a verified 2-layer layout to the `codes/84-6-10.json` literature baseline) failed the authorship gate: a modification to an existing entry currently has only two doors — be a listed `@handle` author, or be exactly a refutation credited in `witness_provenance.found_by`. Retrofitting a layout onto a baseline fits neither, and first-claiming a handle on a no-handle baseline was reserved to maintainers. With the layout-filling effort ahead (most board entries lack a layout and therefore a g score), that path needs to be CI-passable.

This adds `layout_binding()` alongside `refutation_binding()` in `verify/check_authorship.py`. A modified entry passes when the diff is **exactly** a first-layout addition:

- adds `locality` where none existed (replacing an existing layout stays reserved to the entry's listed authors);
- `provenance.authors` keeps the original list and **appends** the contributor (the PR author must be among the appended handles);
- `provenance.notes` append-only; `provenance.model` may be set only if previously absent;
- `name` may change (e.g. a layout suffix);
- **everything else — checks, distance, and all other provenance — must be byte-identical.**

The layout itself is a separately verifiable artifact (the verifier recomputes radius, spacing, per-site occupancy, and locality class from the coordinates), so crediting its contributor grants no edit rights over the code: any later edit by them must still pass one of the bindings. The issue #611 concerns (author swaps, credit grabs, ride-along edits) are each covered by a test.

Tests: 10 new cases in `verify/test_check_authorship.py` (baseline and handle-owned targets, missing self-credit, ride-along check/distance/notes edits, author swaps, layout replacement, model overwrite); all 20 existing cases pass unchanged; `run_tests.py --skip-slow` green. `check_authorship.py` is not in `verify/validator_manifest.json`, so no manifest update is required.

Once merged, #642 can be re-run against the updated base and should pass as-is.