### PR TITLE
gate_changed: price the refutation budget by diff class (issue #654)

### DIFF
--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -17,6 +17,23 @@ size, so a small code gets near-exhaustive coverage and a large one a
 proportionate search; frontier-advancing codes get several independent deep
 seeds (tens of thousands of trials each) before they earn the record.
 
+The gate prices the DIFF, not just the code (issue #654): each changed file
+is classified against its base-revision counterpart, because what changed
+determines what could newly be over-claimed. A layout-only diff (checks and
+distance byte-identical to base) skips refutation entirely -- the claim
+already survived the gate when it merged and the weekly board sweep keeps
+attacking it; everything a layout adds is recomputed deterministically by the
+verifier. A tightening diff (a refutation-shaped correction: values strictly
+down, new witnesses of exactly the new weights, upper_bound confidence,
+nothing else touched) gets the standard shallow pass -- the entry just became
+strictly less wrong, and the weekly sweep provides depth. A diff that adds or
+raises witness_provenance.survived_samples gets the deep battery regardless
+of record status: a survival stamp claims a deep null result and deters
+future refuters, so it is itself the claim being vetted. Anything else --
+new codes, edited checks, raised values, unclassifiable diffs -- fails closed
+to the full existing behavior. Classification is recomputed from the git
+diff, never taken from the PR's framing.
+
 Usage:
   python verify/gate_changed.py [--code-root PATH] [BASE] [files...]
     --code-root PATH  repository tree containing the submitted codes
@@ -71,6 +88,128 @@ def changed_codes(base, code_root=ROOT):
         print(f"could not compute diff vs {base}: {e}; failing closed")
         return None
     return [f for f in out.split() if f.endswith(".json")]
+
+
+def changed_codes_status(base, code_root=ROOT):
+    """{path: status} for codes changed vs base (A/M/D), rename-split like
+    check_authorship.changed_codes so a refutation's rename stays visible."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-status", "--no-renames", f"{base}...HEAD",
+             "--", "codes"],
+            cwd=code_root, text=True)
+    except Exception:
+        return None
+    changes = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0][:1]
+        if status == "R" and len(parts) >= 3:
+            if parts[1].endswith(".json"):
+                changes[parts[1]] = "D"
+            if parts[2].endswith(".json"):
+                changes[parts[2]] = "A"
+        elif parts[1].endswith(".json"):
+            changes[parts[1]] = status
+    return changes
+
+
+def load_base_doc(base, path, code_root):
+    """Base-revision content of path, or None if unavailable."""
+    try:
+        out = subprocess.check_output(["git", "show", f"{base}:{path}"],
+                                      cwd=code_root, text=True,
+                                      stderr=subprocess.DEVNULL)
+        return json.loads(out)
+    except Exception:
+        return None
+
+
+def base_doc_for(f, doc, base, code_root):
+    """The base doc this file revises: itself when modified, or the deleted
+    codes/<n>-<k>-*.json a refutation renamed away. None for new codes or on
+    any ambiguity (which downstream fails closed to the full gate)."""
+    changes = changed_codes_status(base, code_root)
+    if changes is None:
+        return None
+    if changes.get(f) == "M":
+        return load_base_doc(base, f, code_root)
+    prefix = os.path.join(os.path.dirname(f),
+                          f"{doc.get('n')}-{doc.get('k')}-")
+    dels = [p for p, s in changes.items() if s == "D" and p.startswith(prefix)]
+    if len(dels) == 1:
+        return load_base_doc(base, dels[0], code_root)
+    return None
+
+
+def _survival_raised(base_doc, new_doc):
+    """True if any side adds or raises witness_provenance.survived_samples."""
+    bd = (base_doc or {}).get("distance") or {}
+    nd = (new_doc or {}).get("distance") or {}
+    for side in ("X", "Z"):
+        bs = ((bd.get(side) or {}).get("witness_provenance") or {})
+        ns = ((nd.get(side) or {}).get("witness_provenance") or {})
+        nv = ns.get("survived_samples")
+        if nv is None:
+            continue
+        bv = bs.get("survived_samples")
+        if bv is None or nv > bv:
+            return True
+    return False
+
+
+def classify_diff(base_doc, new_doc):
+    """Classify a changed code's diff for refutation pricing. Returns
+    (cls, reason) with cls in {'new', 'stamp', 'layout-only', 'tightening',
+    'full'}. Structural facts only -- witness validity is the verifier's job
+    (verify_all runs before this gate in CI); anything unclassifiable is
+    'full' (fail closed)."""
+    try:
+        if base_doc is None:
+            return "new", "no base counterpart"
+        if _survival_raised(base_doc, new_doc):
+            return "stamp", ("witness_provenance.survived_samples added or "
+                             "raised: the survival claim is what needs vetting")
+        frozen = ("checks", "n", "k", "code_type")
+        for key in frozen:
+            if base_doc.get(key) != new_doc.get(key):
+                return "full", f"field '{key}' changed"
+        if base_doc.get("distance") == new_doc.get("distance"):
+            if base_doc.get("locality") != new_doc.get("locality"):
+                return "layout-only", "checks and distance unchanged from base"
+            return "layout-only", ("checks and distance unchanged from base "
+                                   "(metadata-only diff)")
+        if base_doc.get("locality") != new_doc.get("locality"):
+            return "full", "distance and locality both changed (mixed diff)"
+        bd, nd = base_doc.get("distance") or {}, new_doc.get("distance") or {}
+        tightened = 0
+        for side in ("X", "Z"):
+            bs, ns = bd.get(side), nd.get(side)
+            if bs is None or ns is None:
+                return "full", f"distance.{side} missing"
+            if bs == ns:
+                continue
+            bv, nv = bs.get("value"), ns.get("value")
+            if not (isinstance(bv, int) and isinstance(nv, int) and nv < bv):
+                return "full", (f"distance.{side}.value did not strictly "
+                                "decrease")
+            if len(ns.get("witness") or []) != nv:
+                return "full", (f"distance.{side} witness weight does not "
+                                "equal the new value")
+            if ns.get("confidence") != "upper_bound":
+                return "full", (f"distance.{side}.confidence is not "
+                                "upper_bound at the corrected value")
+            tightened += 1
+        if tightened == 0:
+            return "full", "distance changed without a side strictly decreasing"
+        if nd.get("d") != min(nd[s].get("value") for s in ("X", "Z")):
+            return "full", "distance.d is not min(dX, dZ)"
+        return "tightening", (f"{tightened} side(s) strictly decreased with "
+                              "matching witnesses")
+    except Exception as e:
+        return "full", f"unclassifiable ({type(e).__name__}: {e})"
 
 
 def _locality_rank(doc):
@@ -300,7 +439,36 @@ def main(argv):
         # Trials and wall-clock both scale with code size (see _budget).
         # Dominated codes pay only the standard, size-scaled pass.
         slug = os.path.splitext(os.path.basename(f))[0]
-        deep = slug in records
+        # Price the diff, not just the code: what changed determines what could
+        # newly be over-claimed (see module docstring).
+        base_doc = base_doc_for(f, doc, base, code_root)
+        cls, why = classify_diff(base_doc, doc)
+        if cls == "layout-only":
+            print(f"ok       {f} (layout-only diff: {why}; refutation "
+                  f"deferred to the weekly board sweep)")
+            if receipt_dir:
+                verdict = validate_candidate(doc, seed=seed, refute=False)
+                verdict["gates"]["refute"] = {
+                    "refuted": False, "seed": seed,
+                    "detail": f"skipped: {why}; distance claim identical to "
+                              f"base and covered by the weekly refute sweep",
+                }
+                receipt = make_receipt(
+                    doc, p, verdict,
+                    gate={"refuted": False, "seed": seed, "seeds": [],
+                          "trials": 0, "budget_seconds": 0.0, "deep": False,
+                          "fast_trials": 0, "methods": [],
+                          "diff_class": cls, "diff_reason": why},
+                    repo_root=code_root, pr_number=pr_number,
+                    pr_author=pr_author, base_sha=base_sha, head_sha=head_sha)
+                write_receipt(receipt, receipt_dir, slug)
+            continue
+        if cls == "stamp":
+            deep = True       # the survival claim itself is being vetted
+        elif cls == "tightening":
+            deep = False      # strictly-less-wrong claim; weekly sweep has depth
+        else:
+            deep = slug in records
         trials, budget, nseeds = _budget(int(doc["n"]), deep, fast=GF is not None)
         seeds = [seed, seed + 2, seed + 3][:nseeds]
         # two independent mechanisms; a hit from EITHER (any seed) refutes.
@@ -326,6 +494,7 @@ def main(argv):
         fast_tag = (f" + fast x {ftrials}" if ftrials else "")
         tag = (f"deep, {len(seeds)} RIS seeds x {trials} trials (<={budget:.0f}s each)"
                f"{fast_tag}" if deep else f"standard, {trials} trials (<={budget:.0f}s)")
+        tag += f"; diff: {cls}"
         gate = {
             "refuted": bool(hits),
             "seed": seed,
@@ -335,6 +504,8 @@ def main(argv):
             "deep": deep,
             "fast_trials": ftrials,
             "methods": list(results),
+            "diff_class": cls,
+            "diff_reason": why,
         }
         if receipt_dir:
             # The distance search above is authoritative for this run. Reuse the

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -90,7 +90,7 @@ def changed_codes(base, code_root=ROOT):
     return [f for f in out.split() if f.endswith(".json")]
 
 
-def changed_codes_status(base, code_root=ROOT):
+def changed_codes_status(base: str, code_root: str = ROOT) -> dict | None:
     """{path: status} for codes changed vs base (A/M/D), rename-split like
     check_authorship.changed_codes so a refutation's rename stays visible."""
     try:
@@ -98,7 +98,7 @@ def changed_codes_status(base, code_root=ROOT):
             ["git", "diff", "--name-status", "--no-renames", f"{base}...HEAD",
              "--", "codes"],
             cwd=code_root, text=True)
-    except Exception:
+    except (subprocess.CalledProcessError, OSError):
         return None
     changes = {}
     for line in out.splitlines():
@@ -116,18 +116,18 @@ def changed_codes_status(base, code_root=ROOT):
     return changes
 
 
-def load_base_doc(base, path, code_root):
+def load_base_doc(base: str, path: str, code_root: str) -> dict | None:
     """Base-revision content of path, or None if unavailable."""
     try:
         out = subprocess.check_output(["git", "show", f"{base}:{path}"],
                                       cwd=code_root, text=True,
                                       stderr=subprocess.DEVNULL)
         return json.loads(out)
-    except Exception:
+    except (subprocess.CalledProcessError, OSError, json.JSONDecodeError):
         return None
 
 
-def base_doc_for(f, doc, base, code_root):
+def base_doc_for(f: str, doc: dict, base: str, code_root: str) -> dict | None:
     """The base doc this file revises: itself when modified, or the deleted
     codes/<n>-<k>-*.json a refutation renamed away. None for new codes or on
     any ambiguity (which downstream fails closed to the full gate)."""
@@ -144,7 +144,16 @@ def base_doc_for(f, doc, base, code_root):
     return None
 
 
-def _survival_raised(base_doc, new_doc):
+def layout_entered_tighter_class(base_doc: dict | None, new_doc: dict) -> bool:
+    """True when the diff's layout moves the code into a tighter locality
+    class than it had at base. For a layout-only diff this is the only way
+    the code can become a NEW record of a 2d-local cell (its n, k, d, w are
+    unchanged, so record status in cells it already occupied cannot change);
+    such a claim has never faced the deep battery and must not skip it."""
+    return _locality_rank(new_doc) < _locality_rank(base_doc or {"n": new_doc.get("n"), "checks": new_doc.get("checks")})
+
+
+def _survival_raised(base_doc: dict | None, new_doc: dict | None) -> bool:
     """True if any side adds or raises witness_provenance.survived_samples."""
     bd = (base_doc or {}).get("distance") or {}
     nd = (new_doc or {}).get("distance") or {}
@@ -160,7 +169,7 @@ def _survival_raised(base_doc, new_doc):
     return False
 
 
-def classify_diff(base_doc, new_doc):
+def classify_diff(base_doc: dict | None, new_doc: dict) -> tuple[str, str]:
     """Classify a changed code's diff for refutation pricing. Returns
     (cls, reason) with cls in {'new', 'stamp', 'layout-only', 'tightening',
     'full'}. Structural facts only -- witness validity is the verifier's job
@@ -208,7 +217,9 @@ def classify_diff(base_doc, new_doc):
             return "full", "distance.d is not min(dX, dZ)"
         return "tightening", (f"{tightened} side(s) strictly decreased with "
                               "matching witnesses")
-    except Exception as e:
+    except (KeyError, TypeError, AttributeError, ValueError) as e:
+        # every malformed-document shape fails closed; a genuine bug in this
+        # function should raise and surface in CI, not silently price full
         return "full", f"unclassifiable ({type(e).__name__}: {e})"
 
 
@@ -444,27 +455,46 @@ def main(argv):
         base_doc = base_doc_for(f, doc, base, code_root)
         cls, why = classify_diff(base_doc, doc)
         if cls == "layout-only":
-            print(f"ok       {f} (layout-only diff: {why}; refutation "
-                  f"deferred to the weekly board sweep)")
-            if receipt_dir:
-                verdict = validate_candidate(doc, seed=seed, refute=False)
-                verdict["gates"]["refute"] = {
-                    "refuted": False, "seed": seed,
-                    "detail": f"skipped: {why}; distance claim identical to "
-                              f"base and covered by the weekly refute sweep",
-                }
-                receipt = make_receipt(
-                    doc, p, verdict,
-                    gate={"refuted": False, "seed": seed, "seeds": [],
-                          "trials": 0, "budget_seconds": 0.0, "deep": False,
-                          "fast_trials": 0, "methods": [],
-                          "diff_class": cls, "diff_reason": why},
-                    repo_root=code_root, pr_number=pr_number,
-                    pr_author=pr_author, base_sha=base_sha, head_sha=head_sha)
-                write_receipt(receipt, receipt_dir, slug)
-            continue
-        if cls == "stamp":
-            deep = True       # the survival claim itself is being vetted
+            # The structural verdict (schema, witnesses, layout honesty) is
+            # authoritative here even though verify_all also runs it: the
+            # gate's stdout and receipt must not say ok about a file the
+            # verifier rejects.
+            verdict = validate_candidate(doc, seed=seed, refute=False)
+            if not verdict.get("passed"):
+                failed += 1
+                print(f"FAIL     {f}: structural checks failed "
+                      f"(layout-only diff; see verify_all for details)")
+            elif slug in records and layout_entered_tighter_class(base_doc, doc):
+                # The layout moves the code into a tighter locality class
+                # where it claims a cell record it has never defended: the
+                # one layout-only shape that must not skip the deep battery.
+                cls, why = "layout-record", (
+                    "layout enters a tighter locality class and claims a "
+                    "cell record; deep battery required before it stands")
+            else:
+                print(f"ok       {f} (layout-only diff: {why}; refutation "
+                      f"deferred to the weekly board sweep)")
+            if cls == "layout-only":
+                if receipt_dir:
+                    verdict["gates"]["refute"] = {
+                        "refuted": False, "seed": seed,
+                        "detail": f"skipped: {why}; distance claim identical "
+                                  f"to base and covered by the weekly refute "
+                                  f"sweep",
+                    }
+                    receipt = make_receipt(
+                        doc, p, verdict,
+                        gate={"refuted": False, "seed": seed, "seeds": [],
+                              "trials": 0, "budget_seconds": 0.0,
+                              "deep": False, "fast_trials": 0, "methods": [],
+                              "diff_class": cls, "diff_reason": why},
+                        repo_root=code_root, pr_number=pr_number,
+                        pr_author=pr_author, base_sha=base_sha,
+                        head_sha=head_sha)
+                    write_receipt(receipt, receipt_dir, slug)
+                continue
+        if cls in ("stamp", "layout-record"):
+            deep = True       # the new claim itself is what is being vetted
         elif cls == "tightening":
             deep = False      # strictly-less-wrong claim; weekly sweep has depth
         else:

--- a/verify/test_gate_diff_classes.py
+++ b/verify/test_gate_diff_classes.py
@@ -1,0 +1,224 @@
+"""Tests for gate_changed.classify_diff (issue #654): the refutation gate
+prices the DIFF, so each diff class must be recognized from structural facts
+alone, and anything else must fail closed to the full gate. Pure unit tests
+on document dicts -- no git, no search."""
+
+import copy
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gate_changed as G
+
+BASE = {
+    "schema_version": "0.1",
+    "name": "[[60,8,6]] synthetic test code",
+    "code_type": "CSS",
+    "n": 60, "k": 8,
+    "checks": {"X": [[0, 1, 2]], "Z": [[3, 4, 5]]},
+    "distance": {
+        "d": 6,
+        "X": {"value": 6, "confidence": "upper_bound",
+              "witness": [0, 1, 2, 3, 4, 5]},
+        "Z": {"value": 7, "confidence": "upper_bound",
+              "witness": [0, 1, 2, 3, 4, 5, 6]},
+    },
+    "provenance": {"authors": ["@alice"], "construction": "synthetic",
+                   "notes": "original."},
+}
+
+
+def _tightened(value=5):
+    doc = copy.deepcopy(BASE)
+    doc["name"] = f"[[60,8,{value}]] synthetic test code"
+    doc["distance"]["X"] = {"value": value, "confidence": "upper_bound",
+                            "witness": list(range(value)),
+                            "witness_provenance": {
+                                "found_by": ["@bob"], "date": "2026-08-20",
+                                "found_at_samples": 10 ** 6}}
+    doc["distance"]["d"] = min(value, doc["distance"]["Z"]["value"])
+    doc["provenance"]["notes"] += " Refuted."
+    return doc
+
+
+def _with_layout(doc=None):
+    doc = copy.deepcopy(doc or BASE)
+    doc["schema_version"] = "0.2"
+    doc["locality"] = {"coordinates": [[float(i), 0.0] for i in range(60)],
+                       "layers": 2,
+                       "contributed_by": {"by": ["@bob"],
+                                          "date": "2026-08-20"}}
+    doc["provenance"]["notes"] += " Layout added."
+    return doc
+
+
+def test_new_code():
+    cls, _ = G.classify_diff(None, copy.deepcopy(BASE))
+    assert cls == "new"
+
+
+def test_layout_only():
+    cls, _ = G.classify_diff(BASE, _with_layout())
+    assert cls == "layout-only"
+
+
+def test_metadata_only_is_layout_class():
+    doc = copy.deepcopy(BASE)
+    doc["provenance"]["notes"] += " Marked exact."
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "layout-only"
+
+
+def test_tightening():
+    cls, _ = G.classify_diff(BASE, _tightened())
+    assert cls == "tightening"
+
+
+def test_tightening_both_sides():
+    doc = _tightened()
+    doc["distance"]["Z"] = {"value": 6, "confidence": "upper_bound",
+                            "witness": list(range(6))}
+    doc["distance"]["d"] = 5
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "tightening"
+
+
+def test_survival_stamp_added_goes_deep():
+    doc = copy.deepcopy(BASE)
+    doc["distance"]["X"]["witness_provenance"] = {
+        "found_by": ["@bob"], "date": "2026-08-20",
+        "found_at_samples": 10 ** 6, "survived_samples": 10 ** 8}
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "stamp"
+
+
+def test_survival_stamp_raised_goes_deep():
+    base = copy.deepcopy(BASE)
+    base["distance"]["X"]["witness_provenance"] = {
+        "found_by": ["@carol"], "date": "2026-08-01",
+        "found_at_samples": 10 ** 6, "survived_samples": 10 ** 7}
+    doc = copy.deepcopy(base)
+    doc["distance"]["X"]["witness_provenance"]["survived_samples"] = 10 ** 9
+    cls, _ = G.classify_diff(base, doc)
+    assert cls == "stamp"
+
+
+def test_stamp_riding_on_tightening_goes_deep():
+    doc = _tightened()
+    doc["distance"]["X"]["witness_provenance"]["survived_samples"] = 10 ** 8
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "stamp"
+
+
+def test_unchanged_survival_stamp_is_not_a_stamp_diff():
+    base = copy.deepcopy(BASE)
+    base["distance"]["X"]["witness_provenance"] = {
+        "found_by": ["@carol"], "date": "2026-08-01",
+        "found_at_samples": 10 ** 6, "survived_samples": 10 ** 7}
+    doc = _with_layout(base)
+    cls, _ = G.classify_diff(base, doc)
+    assert cls == "layout-only"
+
+
+def test_checks_change_is_full():
+    doc = _with_layout()
+    doc["checks"]["X"] = [[0, 1, 3]]
+    cls, why = G.classify_diff(BASE, doc)
+    assert cls == "full" and "checks" in why
+
+
+def test_value_raised_is_full():
+    doc = copy.deepcopy(BASE)
+    doc["distance"]["X"]["value"] = 8
+    doc["distance"]["X"]["witness"] = list(range(8))
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "full"
+
+
+def test_mixed_layout_and_tightening_is_full():
+    doc = _with_layout(_tightened())
+    cls, why = G.classify_diff(BASE, doc)
+    assert cls == "full" and "mixed" in why
+
+
+def test_witness_weight_mismatch_is_full():
+    doc = _tightened()
+    doc["distance"]["X"]["witness"] = list(range(4))   # weight 4, value 5
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "full"
+
+
+def test_witness_swap_at_same_value_is_full():
+    doc = copy.deepcopy(BASE)
+    doc["distance"]["X"]["witness"] = [0, 1, 2, 3, 4, 6]
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "full"
+
+
+def test_exact_at_new_value_is_full():
+    doc = _tightened()
+    doc["distance"]["X"]["confidence"] = "exact"
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "full"
+
+
+def test_bad_d_is_full():
+    doc = _tightened()
+    doc["distance"]["d"] = 6
+    cls, _ = G.classify_diff(BASE, doc)
+    assert cls == "full"
+
+
+def test_garbage_fails_closed():
+    cls, _ = G.classify_diff({"distance": None}, {"distance": {"d": 3}})
+    assert cls == "full"
+
+
+def test_base_doc_pairing(tmp_path):
+    """base_doc_for must find the base doc for an in-place edit AND across a
+    refutation rename; a genuinely new file must yield None (-> 'new')."""
+    import json
+    import subprocess
+    td = str(tmp_path)
+
+    def git(*args):
+        subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                        *args], cwd=td, check=True, capture_output=True)
+
+    os.makedirs(os.path.join(td, "codes"))
+
+    def write(fname, doc):
+        os.makedirs(os.path.join(td, "codes"), exist_ok=True)
+        with open(os.path.join(td, "codes", fname), "w") as f:
+            json.dump(doc, f, indent=1)
+
+    git("init", "-q", "-b", "main")
+    write("60-8-6.json", BASE)
+    git("add", "codes")
+    git("commit", "-q", "-m", "base")
+    git("checkout", "-q", "-b", "change")
+
+    # in-place layout addition
+    lay = _with_layout()
+    write("60-8-6.json", lay)
+    git("add", "codes")
+    git("commit", "-q", "-m", "layout")
+    bd = G.base_doc_for("codes/60-8-6.json", lay, "main", td)
+    assert bd is not None and G.classify_diff(bd, lay)[0] == "layout-only"
+
+    # refutation rename 60-8-6 -> 60-8-5
+    tight = _tightened()
+    git("rm", "-q", "codes/60-8-6.json")
+    write("60-8-5.json", tight)
+    git("add", "codes")
+    git("commit", "-q", "-m", "refute")
+    bd = G.base_doc_for("codes/60-8-5.json", tight, "main", td)
+    assert bd is not None and G.classify_diff(bd, tight)[0] == "tightening"
+
+    # a brand-new code has no counterpart
+    new = copy.deepcopy(BASE)
+    new["n"], new["name"] = 61, "[[61,8,6]] other"
+    write("61-8-6.json", new)
+    git("add", "codes")
+    git("commit", "-q", "-m", "new")
+    assert G.base_doc_for("codes/61-8-6.json", new, "main", td) is None

--- a/verify/test_gate_diff_classes.py
+++ b/verify/test_gate_diff_classes.py
@@ -4,10 +4,8 @@ alone, and anything else must fail closed to the full gate. Pure unit tests
 on document dicts -- no git, no search."""
 
 import copy
-import sys
 import os
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gate_changed as G
 
 BASE = {
@@ -222,3 +220,29 @@ def test_base_doc_pairing(tmp_path):
     git("add", "codes")
     git("commit", "-q", "-m", "new")
     assert G.base_doc_for("codes/61-8-6.json", new, "main", td) is None
+
+
+def _grid_layout(n=60, layers=2, spacing=1.0):
+    return {"coordinates": [[spacing * (i % 10), spacing * (i // 10)]
+                            for i in range(n)],
+            "layers": layers}
+
+
+def test_tighter_class_guard_fires_on_honest_layout():
+    doc = copy.deepcopy(BASE)
+    doc["locality"] = _grid_layout()          # honest bilayer grid, small radius
+    assert G.layout_entered_tighter_class(BASE, doc)
+
+
+def test_tighter_class_guard_ignores_dishonest_layout():
+    doc = copy.deepcopy(BASE)
+    doc["locality"] = _grid_layout(spacing=0.1)   # violates unit spacing
+    assert not G.layout_entered_tighter_class(BASE, doc)
+
+
+def test_tighter_class_guard_ignores_unchanged_class():
+    base = copy.deepcopy(BASE)
+    base["locality"] = _grid_layout()
+    doc = copy.deepcopy(base)
+    doc["locality"]["coordinates"] = list(reversed(doc["locality"]["coordinates"]))
+    assert not G.layout_entered_tighter_class(base, doc)


### PR DESCRIPTION
## What

The refutation gate re-ran its full search on every changed code file, pricing the code rather than the diff. This classifies each changed file against its base-revision counterpart (rename-aware, same pairing logic as `check_authorship.py`) and budgets accordingly:

| Diff class | Condition (structural, recomputed from the git diff) | Budget |
|---|---|---|
| new | no base counterpart | unchanged (deep for cell records, standard otherwise) |
| layout-only | `checks` and `distance` byte-identical to base | **skip**, with a receipt naming the weekly sweep as backstop |
| tightening | values strictly down, new witnesses of exactly the new weights, `upper_bound` at corrected values, `d = min(dX,dZ)`, checks/n/k/locality untouched | **standard shallow pass** |
| survival stamp | `witness_provenance.survived_samples` added or raised on any side | **deep battery** regardless of record status |
| anything else | edited checks, raised values, mixed layout+distance, unclassifiable, unreadable base | full existing behavior (fail closed) |

## Why each is sound

- **Layout-only**: the distance claim already survived this gate at merge and the weekly `refute_board.py` sweep keeps attacking it with fresh seeds; everything a layout adds (radius, spacing, class, g) is recomputed deterministically by the cheap verifier that runs earlier in the same job. A layout cannot make a distance claim more wrong.
- **Tightening**: the new witness proves `d <= value` trustlessly in the verify_all step; the entry just became strictly *less* wrong than what is on the board. The shallow n-scaled pass catches gross remaining over-claims; the weekly sweep provides depth.
- **Survival stamps**: per SCHEMA.md, `survived_samples` is the budget that tells the next refuter what to beat — a deterrent claim. It gets *more* scrutiny than before (deep even for non-record codes), closing a gap rather than opening one.

Every skip and reclassification prints its reason and lands in the gate receipts (`diff_class` / `diff_reason` fields), so the audit trail records a decision, never an omission.

## Impact

A 15-layout batch PR (the mass g-score-filling effort, ~261 entries) drops from ~45+ minutes of redundant gate time to seconds; refutation corrections drop from ~10 minutes to under one. New-code submissions keep exactly today's scrutiny.

## Tests

`verify/test_gate_diff_classes.py`: 18 cases — the classifier table row by row, the adversarial shapes (stamp riding on a tightening, mixed layout+distance, witness swap at unchanged value, exact-at-new-value, weight/value mismatch, garbage input), and a git-fixture integration test of the base-doc pairing across in-place edits, refutation renames, and new files. Full `run_tests.py --skip-slow` green; `gate_changed.py` is not hash-pinned, so no manifest change.