### PR TITLE
Validate qldpc submit author attribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ submission.
 
 (or, without the launcher shim: `uv run python cli/qldpc.py submit ...`)
 
+The `@` in `@yourhandle` is required: it is what binds the submission to
+your GitHub account and prevents another account from editing the entry as its
+author. Plain names are still valid for co-authors without GitHub accounts,
+provided at least one author is an `@handle`. To intentionally submit with no
+GitHub handle, pass `--anonymous`; the CLI warns that the resulting entry will
+not be bound to an account.
+
 `mycode.npz` holds your parity checks under keys `hx` and `hz` (dense 0/1
 arrays or scipy sparse). The tool:
 
@@ -36,6 +43,8 @@ Useful flags:
   class (single / bilayer / unrestricted) from it, you do not declare a track.
   `layers` is required alongside the coordinates (the CLI defaults it to 1);
 - `--open-pr` create the branch, commit, push, and open the PR for you;
+- `--anonymous` explicitly proceed without an `@handle` (the submission will
+  not be bound to a GitHub account);
 - `--dry-run` build and verify without writing.
 
 Either way — `--open-pr`, or the commands it prints for you to run — the PR

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -47,6 +47,7 @@ sys.path.insert(0, os.path.join(_ROOT, "site"))
 
 import gf2                       # noqa: E402
 import heuristic_distance as hd  # noqa: E402
+from check_authorship import HANDLE  # noqa: E402
 from qldpc_verify import verify  # noqa: E402
 # Reuse the site's computed-cell + Pareto-frontier helpers so the PR body
 # states exactly what the board will show (no drift between the two).
@@ -356,7 +357,45 @@ def frontier_summary(doc, report):
 # ----------------------------------------------------------------------------
 # submit command
 # ----------------------------------------------------------------------------
+def validate_authors(authors, anonymous=False):
+    """Fail fast when submit would produce an unbound authorship record."""
+    normalized = [str(author).strip() for author in authors]
+    malformed = [
+        author for author in normalized
+        if author.startswith("@") and HANDLE.fullmatch(author) is None
+    ]
+    if malformed:
+        values = ", ".join(repr(author) for author in malformed)
+        raise SystemExit(
+            f"Invalid author {values}. GitHub authors must use @yourhandle "
+            "with letters, numbers, or hyphens only."
+        )
+
+    has_handle = any(HANDLE.fullmatch(author) for author in normalized)
+    if has_handle and anonymous:
+        raise SystemExit(
+            "--anonymous cannot be combined with a GitHub @handle; remove "
+            "--anonymous to keep the submission bound to that account."
+        )
+    if has_handle:
+        return
+
+    if not anonymous:
+        raise SystemExit(
+            "No GitHub @handle found in --authors. Add @yourhandle (the @ is "
+            "required), or pass --anonymous to confirm that the submission "
+            "will not be bound to a GitHub account."
+        )
+
+    print(
+        "  WARNING: no GitHub @handle was provided. This submission will be "
+        "recorded as anonymous and will not be bound to a GitHub account.",
+        flush=True,
+    )
+
+
 def cmd_submit(args):
+    validate_authors(args.authors, args.anonymous)
     HX, HZ, coords, _draft = load_checks(args.code)
     if args.coords:                      # explicit coords file overrides
         cz = np.load(args.coords) if args.coords.endswith(".npz") else None
@@ -521,6 +560,9 @@ def main(argv=None):
                                 ".json draft")
     s.add_argument("--authors", nargs="+", required=True,
                    help="one or more: @github-handle and/or 'First Last'")
+    s.add_argument("--anonymous", action="store_true",
+                   help="explicitly submit without a GitHub @handle; the "
+                        "entry will not be bound to an account")
     s.add_argument("--construction", default="",
                    help="how the code was built (family, polynomials, search)")
     s.add_argument("--model", default="",

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -358,8 +358,13 @@ def frontier_summary(doc, report):
 # submit command
 # ----------------------------------------------------------------------------
 def validate_authors(authors, anonymous=False):
-    """Fail fast when submit would produce an unbound authorship record."""
+    """Return normalized authors or fail before producing an unbound record."""
     normalized = [str(author).strip() for author in authors]
+    if any(not author for author in normalized):
+        raise SystemExit(
+            "Author values must not be empty or whitespace-only. Remove the "
+            "empty value or replace it with a name or @handle."
+        )
     malformed = [
         author for author in normalized
         if author.startswith("@") and HANDLE.fullmatch(author) is None
@@ -378,7 +383,7 @@ def validate_authors(authors, anonymous=False):
             "--anonymous to keep the submission bound to that account."
         )
     if has_handle:
-        return
+        return normalized
 
     if not anonymous:
         raise SystemExit(
@@ -392,10 +397,11 @@ def validate_authors(authors, anonymous=False):
         "recorded as anonymous and will not be bound to a GitHub account.",
         flush=True,
     )
+    return normalized
 
 
 def cmd_submit(args):
-    validate_authors(args.authors, args.anonymous)
+    args.authors = validate_authors(args.authors, args.anonymous)
     HX, HZ, coords, _draft = load_checks(args.code)
     if args.coords:                      # explicit coords file overrides
         cz = np.load(args.coords) if args.coords.endswith(".npz") else None

--- a/verify/test_cli_authors.py
+++ b/verify/test_cli_authors.py
@@ -1,0 +1,88 @@
+"""Regression tests for submit-time author validation (issue #636)."""
+
+import pytest
+
+import check_authorship
+import qldpc
+
+
+def _fail_if_code_is_loaded(_path):
+    raise AssertionError("author validation must run before loading the code")
+
+
+def test_submit_rejects_bare_handle_before_loading_code(monkeypatch):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"Add @yourhandle.*--anonymous"):
+        qldpc.main(["submit", "must-not-be-loaded.npz", "--authors", "vprusso"])
+
+
+@pytest.mark.parametrize("author", ["@", "@bad!", "@two handles"])
+def test_submit_rejects_malformed_at_handle_before_loading_code(monkeypatch, author):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"Invalid author.*@yourhandle"):
+        qldpc.main(["submit", "must-not-be-loaded.npz", "--authors", author])
+
+
+def test_submit_checks_every_author_value(monkeypatch):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"Invalid author.*@bad!"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "@bad!",
+        ])
+
+
+def test_valid_handle_and_plain_name_reach_code_loading(monkeypatch):
+    reached = []
+
+    def record_load(path):
+        reached.append(path)
+        raise RuntimeError("load reached")
+
+    monkeypatch.setattr(qldpc, "load_checks", record_load)
+
+    with pytest.raises(RuntimeError, match="load reached"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "Jane Roe",
+        ])
+
+    assert reached == ["must-not-be-loaded.npz"]
+
+
+def test_anonymous_opt_in_warns_and_reaches_code_loading(monkeypatch, capsys):
+    reached = []
+
+    def record_load(path):
+        reached.append(path)
+        raise RuntimeError("load reached")
+
+    monkeypatch.setattr(qldpc, "load_checks", record_load)
+
+    with pytest.raises(RuntimeError, match="load reached"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "Jane Roe", "--anonymous",
+        ])
+
+    assert reached == ["must-not-be-loaded.npz"]
+    warning = capsys.readouterr().out
+    assert "recorded as anonymous" in warning
+    assert "not be bound to a GitHub account" in warning
+
+
+def test_anonymous_flag_rejects_conflicting_handle(monkeypatch):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"--anonymous cannot be combined"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "--anonymous",
+        ])
+
+
+def test_cli_reuses_authorship_handle_pattern():
+    assert qldpc.HANDLE is check_authorship.HANDLE

--- a/verify/test_cli_authors.py
+++ b/verify/test_cli_authors.py
@@ -35,6 +35,38 @@ def test_submit_checks_every_author_value(monkeypatch):
         ])
 
 
+def test_submit_rejects_whitespace_only_author_before_loading_code(monkeypatch):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"empty or whitespace-only"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "   ",
+        ])
+
+
+def test_submit_persists_normalized_author_values(monkeypatch):
+    captured = []
+
+    monkeypatch.setattr(
+        qldpc, "load_checks", lambda _path: (None, None, None, None)
+    )
+
+    def capture_build(_hx, _hz, args):
+        captured.extend(args.authors)
+        raise RuntimeError("build reached")
+
+    monkeypatch.setattr(qldpc, "build_submission", capture_build)
+
+    with pytest.raises(RuntimeError, match="build reached"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "  @vprusso  ", "  Jane Roe  ",
+        ])
+
+    assert captured == ["@vprusso", "Jane Roe"]
+
+
 def test_valid_handle_and_plain_name_reach_code_loading(monkeypatch):
     reached = []
 


### PR DESCRIPTION
## What changed

`qldpc submit` now validates authorship before it loads a code or starts the
distance-witness search:

- imports the existing `HANDLE` pattern from `verify/check_authorship.py` so
  CLI validation and CI attribution use one contract;
- rejects every malformed `@...` author value with a focused error;
- rejects empty author values and persists trimmed author names and handles;
- requires at least one valid `@handle`, unless the contributor explicitly
  opts into an unbound submission with `--anonymous`;
- warns clearly when an anonymous submission proceeds and rejects the
  contradictory `--anonymous` plus `@handle` combination;
- preserves plain-name co-authors alongside a valid handle; and
- documents the `@` requirement and anonymous behavior in `CONTRIBUTING.md`.

Closes #636.

## Verification

- `python -m pytest verify/test_cli_authors.py -q` — 11 passed.
- Full current-main suite excluding one reproduced Windows-only baseline file:
  26 passed, 6 optional accelerator/GPU tests skipped.
- End-to-end `--dry-run` submissions completed verification for both a valid
  `@handle` plus plain-name co-author and an intentional anonymous submission.
- `python -m compileall -q cli verify` passed.
- `python verify/check_prose.py --files CONTRIBUTING.md` passed.
- `git diff --check` passed.
- The trusted validator blobs still match `verify/validator_manifest.json`;
  this change does not alter the trusted verifier.

## Local platform note

The unfiltered suite has one pre-existing Windows path-handling failure in
`verify/test_check_authorship.py`, reproduced on the pristine checkout before
this change. All other tests pass locally; GitHub Actions will run the complete
suite on Linux.
