### PR TITLE
Harden generated site against stored XSS

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,8 @@
 """Run the test suite. A thin wrapper over pytest, kept as the documented entry
 point so CI and the README command do not change.
 
-Discovery is still by convention -- pytest collects verify/test_*.py and
-research/test_*.py -- so a new test joins the suite the moment it exists and
+Discovery is still by convention -- pytest collects test_*.py under verify/,
+research/, and site/ -- so a new test joins the suite the moment it exists and
 cannot be silently left out of CI the way a hand-listed step can (which is how
 two of five tests once went unrun).
 
@@ -34,7 +34,7 @@ def main(argv):
                     help="skip the tests listed in SLOW")
     args, extra = ap.parse_known_args(argv)
 
-    cmd = [sys.executable, "-m", "pytest", "verify", "research"]
+    cmd = [sys.executable, "-m", "pytest", "verify", "research", "site"]
     if args.skip_slow and SLOW:
         cmd += ["--deselect" if "::" in s else "--ignore=" + s for s in SLOW]
     cmd += extra

--- a/site/build.py
+++ b/site/build.py
@@ -110,11 +110,20 @@ def cite(s, rel=""):
     the paper on arXiv; any other reference that resolves to a bib entry links
     to its entry on the references page (reachable from the footer too)."""
     if s.lower().startswith("arxiv:"):
-        aid = s.split(":", 1)[1]
-        return f'<a href="https://arxiv.org/abs/{aid}">{html.escape(s)}</a>'
+        aid = s.split(":", 1)[1].strip()
+        # Link only a complete arXiv identifier.  Free-form provenance strings
+        # must never be allowed to supply part of an HTML attribute.
+        if not re.fullmatch(
+                r"(?:\d{4}\.\d{4,5}|[a-z-]+(?:\.[a-z]{2})?/\d{7})(?:v\d+)?",
+                aid, re.IGNORECASE):
+            return html.escape(s)
+        href = safe_url(f"https://arxiv.org/abs/{aid}")
+        return f'<a href="{href}">{html.escape(s)}</a>'
     key = resolve_ref(s)
     if key:
-        return (f'<a href="{rel}references.html#{key}">{html.escape(s)}</a>')
+        fragment = urllib.parse.quote(key, safe="-._~")
+        href = safe_url(f"{rel}references.html#{fragment}")
+        return f'<a href="{href}">{html.escape(s)}</a>'
     return html.escape(s)
 
 
@@ -129,6 +138,55 @@ SITE_URL = "https://unitaryfoundation.github.io/qldpc-challenge"
 # the same committed pages.  The Plausible site ID is the path-qualified
 # ``unitaryfoundation.github.io/qldpc-challenge`` project site.
 PLAUSIBLE_SCRIPT_SRC = "https://plausible.io/js/pa-BZqEmTRv5VBwv3HYwVpoB.js"
+
+_SAFE_SLUG = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+_SAFE_DATA_SCRIPT_ID = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+
+
+def safe_url(value, *, allow_relative=True):
+    """Return an attribute-escaped HTTP(S) or local URL, rejecting active
+    schemes and parser-confusing control characters.
+
+    Use this for submission-derived destinations; escaping alone does not
+    reject active schemes such as ``javascript:``.
+    """
+    value = str(value)
+    if not value or any(ord(c) < 0x20 or ord(c) == 0x7f for c in value):
+        raise ValueError(f"unsafe URL: {value!r}")
+    if value.startswith("//") or "\\" in value:
+        raise ValueError(f"unsafe URL: {value!r}")
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme:
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"unsafe URL scheme: {value!r}")
+    elif not allow_relative:
+        raise ValueError(f"relative URL not allowed: {value!r}")
+    return html.escape(value, quote=True)
+
+
+def json_for_html(value, **kwargs):
+    """Serialize JSON for an HTML raw-text context.
+
+    JSON string escaping alone does not protect a ``<script>`` element because
+    the HTML parser recognizes ``</script>`` before JavaScript/JSON parsing.
+    Neutralize every HTML-significant character plus JavaScript's historical
+    line separators in one shared helper used by every embedded data block.
+    """
+    encoded = json.dumps(value, **kwargs)
+    for char, replacement in (
+            ("&", "\\u0026"), ("<", "\\u003c"), (">", "\\u003e"),
+            ("\u2028", "\\u2028"), ("\u2029", "\\u2029")):
+        encoded = encoded.replace(char, replacement)
+    return encoded
+
+
+def json_data_script(element_id, value, **kwargs):
+    """An inert, parseable JSON data element safe against ``</script>``."""
+    if not _SAFE_DATA_SCRIPT_ID.fullmatch(element_id):
+        raise ValueError(f"unsafe JSON data element id: {element_id!r}")
+    payload = json_for_html(value, **kwargs)
+    return (f'<script id="{element_id}" type="application/json">'
+            f'{payload}</script>')
 
 # Palette (single source of truth; the CSS :root and the inline SVGs all draw
 # from these). Adopts the Unitary Foundation brand: deep purple as the readable
@@ -1186,8 +1244,7 @@ def plausible_snippet(custom_properties=None):
     options = {"outboundLinks": True, "fileDownloads": True}
     if custom_properties:
         options["customProperties"] = custom_properties
-    encoded = json.dumps(options, sort_keys=True, separators=(",", ":"))
-    encoded = encoded.replace("<", "\\u003c")
+    encoded = json_for_html(options, sort_keys=True, separators=(",", ":"))
     return (
         '<!-- Privacy-friendly analytics by Plausible -->'
         f'<script async src="{html.escape(PLAUSIBLE_SCRIPT_SRC, quote=True)}">'
@@ -1311,6 +1368,8 @@ def load_entries():
     entries = []
     for p in sorted(glob.glob(os.path.join(ROOT, "codes", "*.json"))):
         slug = os.path.splitext(os.path.basename(p))[0]
+        if not _SAFE_SLUG.fullmatch(slug):
+            raise ValueError(f"unsafe code filename: {slug!r}")
         ferr = file_size_error(p)
         if ferr:
             print(f"  warning: {slug}: {ferr}; skipping")
@@ -1935,10 +1994,11 @@ def detail_page(e):
         P.append(f'<div class=kv><b>novelty</b> '
                  f'{html.escape(novelty_label(pr.get("novelty", "unknown")))}</div>')
     P.append(f'<div class=kv><b>construction</b> {mathfmt(pr.get("construction",""))}</div>')
-    if pr.get("model"):
-        mark = f'{CLAUDE_MARK} ' if pr["model"].startswith("Claude") else ""
+    model = _model_str(pr.get("model", ""))
+    if model:
+        mark = f'{CLAUDE_MARK} ' if model.startswith("Claude") else ""
         P.append('<div class=kv><b>model</b> '
-                 f'<span class=modelmark>{mark}</span>{html.escape(pr["model"])} '
+                 f'<span class=modelmark>{mark}</span>{html.escape(model)} '
                  '<span class=claimed>(claimed, not verified)</span></div>')
     elif pr.get("origin") == "baseline":
         P.append('<div class=kv><b>model</b> '
@@ -2445,11 +2505,11 @@ def contributors_panel(entries):
         lbidx.append(seen[sig])
     # Contributor modal: row click opens a summary card; inner links still
     # navigate (profile, filtered board, code pages).
-    cdata = json.dumps({s["handle"]: {
+    cdata = {s["handle"]: {
         "codes": s["codes"], "front": s["front"], "exact": s["exact"],
         "eff": s["eff"], "geo": geo_disp(s["geo"], s["geo_tier"]),
         "list": sorted(s["list"], key=lambda c: -c["eff"])}
-        for _, s in order})
+        for _, s in order}
     cmodal = (
         '<dialog id=cmodal class=cmodal>'
         '<div class=cmhead><img id=cmav alt="">'
@@ -2460,8 +2520,8 @@ def contributors_panel(entries):
         '<div class=cmstats id=cmstats></div>'
         '<div class=cmlist id=cmlist></div>'
         '</dialog>'
-        f'<script id=cmdata type="application/json">{cdata}</script>'
-        '<script>(function(){'
+        + json_data_script("cmdata", cdata)
+        + '<script>(function(){'
         'var D=JSON.parse(document.getElementById("cmdata").textContent);'
         'var dlg=document.getElementById("cmodal");if(!dlg)return;'
         'dlg.addEventListener("click",function(e){if(e.target===dlg)dlg.close();});'
@@ -2512,9 +2572,9 @@ def contributors_panel(entries):
     # data-grank), so this cannot disagree with the Python comparators.
     # Reordering and value swapping only: every (weight cap x metric) ranking is
     # server-computed, so this cannot disagree with the Python comparators.
-    lbdata = json.dumps({"wmin": wmin, "wmax": wmax, "idx": lbidx, "b": lbw})
-    lbjs = ('<script id=lbwdata type="application/json">' + lbdata + '</script>'
-            '<script>(function(){'
+    lbdata = {"wmin": wmin, "wmax": wmax, "idx": lbidx, "b": lbw}
+    lbjs = (json_data_script("lbwdata", lbdata)
+            + '<script>(function(){'
             'var sec=document.getElementById("leaderboard");if(!sec)return;'
             'var D=JSON.parse(document.getElementById("lbwdata").textContent);'
             'var WMIN=D.wmin,WMAX=D.wmax,SPAN=(WMAX-WMIN)||1;'
@@ -2812,6 +2872,7 @@ var plot=document.getElementById('rcplot');if(!plot)return;
 var init=plot.innerHTML, leg=document.getElementById('rclegend'), legInit=leg.innerHTML;
 var MC=['#6d28d9','#0369a1','#b45309','#15803d','#be185d','#475569'];
 var st={m:'record',s:'log',w:'all',y:'eff'};
+function esc(v){return String(v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
 function mv(r){return st.y==='geo'?r.geo:r.eff;}
 function days(t){return Date.parse(t)/864e5;}
 function windowed(){
@@ -2904,16 +2965,16 @@ function draw(){
    var le=s.rows[s.rows.length-1];
    endlist.push({y:fy(mv(le)),lab:s.lab,eff:mv(le)});}
   P.forEach(function(p){var r=p[2];
-   var tp=('[['+r.n+','+r.k+','+r.d+']] · w='+r.w+' · kd²/n='+r.eff+(r.geo!=null?' · g='+r.geo:'')+' · '+r.t+' · '+r.model).replace(/"/g,'&quot;');
+   var tp=esc('[['+r.n+','+r.k+','+r.d+']] · w='+r.w+' · kd²/n='+r.eff+(r.geo!=null?' · g='+r.geo:'')+' · '+r.t+' · '+r.model);
    body+='<circle cx="'+p[0]+'" cy="'+p[1]+'" r="'+(s.step?4:3.4)+'" fill="'+(s.step?'#fff':s.col)+'" fill-opacity="'+(s.step?1:0.55)+'" stroke="'+s.col+'" stroke-width="'+(s.step?2:0)+'" pointer-events="none"/>'
     +'<circle class=hit data-code="'+r.slug+'" data-tip="'+tp+'" cx="'+p[0]+'" cy="'+p[1]+'" r="9" fill="transparent"/>';});
  });
  endlist.sort(function(a,b){return a.y-b.y;});
  for(var i=1;i<endlist.length;i++)if(endlist[i].y-endlist[i-1].y<15)endlist[i].y=endlist[i-1].y+15;
- endlist.forEach(function(e){var lab=e.lab.length>18?e.lab.slice(0,17)+'…':e.lab;
+ endlist.forEach(function(e){var lab=esc(e.lab.length>18?e.lab.slice(0,17)+'…':e.lab);
   ends+='<text x="'+(W-pr+8)+'" y="'+e.y+'" dy="4" font-size="12" fill="#334155">'+lab+' &#183; <tspan font-weight="700">'+e.eff+'</tspan></text>';});
  plot.innerHTML='<svg viewBox="0 0 '+W+' '+H+'" style="width:100%;height:auto">'+g+body+ends+'</svg>';
- leg.innerHTML=series.map(function(s){return '<span class=ci><span class=cdot style="background:'+s.col+'"></span>'+s.lab+'</span>';}).join('')
+ leg.innerHTML=series.map(function(s){return '<span class=ci><span class=cdot style="background:'+s.col+'"></span>'+esc(s.lab)+'</span>';}).join('')
   +(st.y==='geo'?'<span class=ci title="the surface/toric reference codes sit at the conjectured f ceiling and are drawn as the dashed line, not raced">&#8213; surface code = 1</span>':'');
 }
 document.querySelectorAll('.rcbtn').forEach(function(b){
@@ -3047,8 +3108,7 @@ def record_chart(entries):
              "ref": geo_reference(e),
              "sub": e["origin"] != "baseline"}
             for e in entries if e["date"]]
-    rcjson = json.dumps(data)
-    rcseries = json.dumps([[lab, cap, col] for lab, cap, col in RC_SERIES])
+    rcseries = [[lab, cap, col] for lab, cap, col in RC_SERIES]
     controls = (
         '<div class=rcbar>'
         '<span class=rcgroup>'
@@ -3084,8 +3144,8 @@ def record_chart(entries):
             '<span class=ci title="board-relative: among the seeded literature '
             'baselines and challenge entries listed here">&#9675; new record'
             '</span></div>'
-            f'<script id=rcdata type="application/json">{rcjson}</script>'
-            f'<script id=rcseries type="application/json">{rcseries}</script>'
+            + json_data_script("rcdata", data)
+            + json_data_script("rcseries", rcseries)
             + _RC_JS +
             '</section>')
 

--- a/site/test_security.py
+++ b/site/test_security.py
@@ -1,0 +1,165 @@
+"""Adversarial regression tests for the static site's untrusted data."""
+
+import copy
+import glob
+import importlib.util
+import json
+import os
+import re
+
+import pytest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_SCRIPT = re.compile(
+    r'<script id="([A-Za-z][A-Za-z0-9_-]*)" '
+    r'type="application/json">(.*?)</script>', re.DOTALL)
+
+
+def load_site_build():
+    spec = importlib.util.spec_from_file_location(
+        "site_build_security", os.path.join(ROOT, "site", "build.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def unrestricted_string_paths(node, path=()):
+    """Find free-form schema strings that must stay covered by the XSS test."""
+    found = set()
+    if (isinstance(node, dict) and node.get("type") == "string"
+            and not {"enum", "const", "pattern"}.intersection(node)):
+        found.add("/".join(path))
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(value, (dict, list)):
+                found.update(unrestricted_string_paths(value, path + (key,)))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found.update(unrestricted_string_paths(value, path + (str(index),)))
+    return found
+
+
+def test_free_form_schema_fields_are_deliberately_covered():
+    with open(os.path.join(ROOT, "schema", "code.schema.json")) as f:
+        schema = json.load(f)
+
+    assert unrestricted_string_paths(schema) == {
+        "properties/circuit/properties/notes",
+        "properties/locality/properties/contributed_by/properties/method",
+        "properties/name",
+        "properties/provenance/properties/authors/items",
+        "properties/provenance/properties/construction",
+        "properties/provenance/properties/model/oneOf/0",
+        "properties/provenance/properties/model/oneOf/1/items",
+        "properties/provenance/properties/notes",
+        "properties/provenance/properties/references/items",
+        # Deprecated and ignored by the site, but intentionally classified.
+        "properties/tracks/items",
+        "$defs/sideDistance/properties/witness_provenance/properties/tool",
+    }
+
+
+def test_context_helpers_reject_active_content():
+    build = load_site_build()
+    payload = '</script><script>globalThis.qldpcXssRegression=1</script>\u2028&<>'
+
+    encoded = build.json_for_html({"future_field": payload})
+    assert "</script>" not in encoded.lower()
+    assert "\u2028" not in encoded
+    assert "\\u003c/script\\u003e" in encoded.lower()
+    assert json.loads(encoded)["future_field"] == payload
+
+    assert 'href="https://arxiv.org/abs/2504.08887v2"' in build.cite(
+        "arXiv:2504.08887v2")
+    malformed = build.cite('arxiv:\"><img src=x onerror=alert(1)>')
+    assert "href=" not in malformed
+    assert "<img" not in malformed
+
+    with pytest.raises(ValueError, match="unsafe URL scheme"):
+        build.safe_url("javascript:alert(1)")
+
+
+def test_code_filenames_must_be_safe_slugs(tmp_path):
+    build = load_site_build()
+    codes = tmp_path / "codes"
+    codes.mkdir()
+    (codes / 'unsafe"name.json').write_text("{}")
+    build.ROOT = str(tmp_path)
+
+    with pytest.raises(ValueError, match="unsafe code filename"):
+        build.load_entries()
+
+
+@pytest.mark.parametrize("model_as_list", [False, True])
+def test_free_text_submission_payloads_render_inert(tmp_path, model_as_list):
+    build = load_site_build()
+    fixture = os.path.join(ROOT, "verify", "fixtures", "72-6-6.json")
+    with open(fixture) as f:
+        doc = copy.deepcopy(json.load(f))
+
+    close_script = (
+        '</script><script>globalThis.qldpcXssRegression=1</script>')
+    attr_breakout = (
+        '\"><img src=x onerror=globalThis.qldpcXssRegression=2>')
+    doc["name"] = f"Future code {attr_breakout}"
+    model = f"Model 5.1 {close_script}\u2028"
+    doc["provenance"].update({
+        "authors": ["@safe-author", f"Alice {close_script}"],
+        "construction": f"New construction {attr_breakout}",
+        "model": [model, "Model 6.0"] if model_as_list else model,
+        "references": [f"arxiv:{attr_breakout}"],
+        "notes": f"Notes {attr_breakout}",
+    })
+    doc["distance"]["X"]["witness_provenance"] = {
+        "found_by": ["@safe-author"],
+        "date": "2026-08-20",
+        "found_at_samples": 1,
+        "tool": f"tool {attr_breakout}",
+    }
+    doc["locality"]["contributed_by"] = {
+        "by": ["@safe-author"],
+        "date": "2026-08-20",
+        "method": f"layout method {attr_breakout}",
+    }
+    doc["circuit"] = {
+        "d_circ": {
+            side: {"value": 1, "confidence": "upper_bound", "witness": [0]}
+            for side in ("X", "Z")
+        },
+        "rounds": 6,
+        "stim_version": "1.15.0",
+        "notes": f"circuit notes {close_script}",
+    }
+    doc["tracks"] = [close_script]
+    doc["schema_version"] = "0.2"
+
+    codes = tmp_path / "codes"
+    codes.mkdir()
+    with open(codes / "72-6-6.json", "w") as f:
+        json.dump(doc, f)
+
+    build.ROOT = str(tmp_path)
+    build.DOCS = str(tmp_path / "docs")
+    build.CERTS = str(tmp_path / "certs")
+    build.build()
+
+    pages = []
+    for path in glob.glob(os.path.join(build.DOCS, "**", "*.html"),
+                          recursive=True):
+        with open(path) as f:
+            pages.append(f.read())
+
+    rendered = "\n".join(pages)
+    index = (tmp_path / "docs" / "index.html").read_text()
+    data = {match.group(1): json.loads(match.group(2))
+            for match in DATA_SCRIPT.finditer(index)}
+
+    assert pages
+    assert close_script not in rendered
+    assert attr_breakout not in rendered
+    assert "<script>globalThis.qldpcXssRegression" not in rendered
+    assert "<img src=x onerror=" not in rendered
+    assert "\\u003c/script\\u003e" in index.lower()
+    assert {"cmdata", "lbwdata", "rcdata", "rcseries"} <= data.keys()
+    assert "qldpcXssRegression" in json.dumps(data["rcdata"])


### PR DESCRIPTION
## Summary

- validate submission-derived reference links and code slugs before placing them in HTML attributes
- serialize every embedded JSON data block through one HTML-safe helper and escape model labels inserted by the client-side chart
- add adversarial coverage for every free-form schema string, with a schema inventory that fails when future fields are added without classification
- include site security tests in the documented test runner

This intentionally keeps the current string-based generator. Template-engine and broader CSP changes remain separate follow-ups.

## Verification

- `uv run --frozen python run_tests.py` (37 passed, 6 skipped)
- clean temporary site build (345 detail pages)

Closes #649