### PR TITLE
Circuit-tier refutation in the gate: bounded RIS on H_dem (RFC 0001 step 6)

### DIFF
--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -141,6 +141,9 @@ limits are:
 - At most 200000 total support entries across all checks.
 - At most 600 locality coordinate entries.
 - Dense verifier intermediates capped at 50000000 cells.
+- Circuit tier: at most 25000 DEM error mechanisms per memory circuit
+  (verification-budget rule: the refutation gate must be able to search the
+  DEM; raise-only as the search stack improves).
 
 These are far above the current board entries. A larger code should be handled
 through a maintainer-run path until the verifier is sparse end-to-end.

--- a/verify/circuit_tools.py
+++ b/verify/circuit_tools.py
@@ -322,11 +322,14 @@ def _rref(M):
     return gf2.rref(np.ascontiguousarray(M))[0]
 
 
-def ris_dem(H, L, trials, seed=0, pair_top=24):
+def ris_dem(H, L, trials, seed=0, pair_top=24, max_seconds=None):
     """RIS upper-bound search for the lightest undetected logical fault set:
     min |e| with H e = 0, L e != 0. The code-tier searcher on the DEM's
     parity-check matrix -- hyperedge degree is irrelevant to it. Returns
-    (weight, sorted column indices) or (None, None)."""
+    (weight, sorted column indices) or (None, None). Stops after `trials`
+    permutations or `max_seconds` wall-clock, whichever comes first (the time
+    cap keeps the CI gate bounded when the size estimate is off)."""
+    import time
     K = _kernel_basis(np.asarray(H, dtype=np.int8))
     m = K.shape[1]
     if K.shape[0] == 0:
@@ -334,6 +337,7 @@ def ris_dem(H, L, trials, seed=0, pair_top=24):
     LT = np.asarray(L, dtype=np.int8).T
     rng = np.random.default_rng(seed)
     best, best_v = m + 1, None
+    deadline = (time.monotonic() + max_seconds) if max_seconds else None
 
     def consider(v, perm):
         nonlocal best, best_v
@@ -344,6 +348,8 @@ def ris_dem(H, L, trials, seed=0, pair_top=24):
             best, best_v = w, v[inv].copy()
 
     for _ in range(trials):
+        if deadline and time.monotonic() > deadline:
+            break
         perm = rng.permutation(m)
         R = _rref(K[:, perm])
         sig = (R @ LT[perm]) % 2

--- a/verify/circuit_verify.py
+++ b/verify/circuit_verify.py
@@ -55,6 +55,16 @@ from qldpc_verify import _matrix
 
 MAX_CIRCUIT_FILE_BYTES = 5_000_000
 
+# Verification-budget cap for the circuit tier (the RFC's "cap the tier by
+# n*rounds", enforced on the actual cost driver): the refutation gate searches
+# ker(H_dem) by RIS, and per-trial cost fits ~1.2e-12 * mechanisms^3 seconds
+# with the gf2_fast extension (measured 2026-08-20: 8.4 ms at m=1651, 3.9 s at
+# m=15800, 25 s at m=34530). At this cap a basis costs the gate ~2 minutes at
+# minimum depth, keeping a circuit entry within the same ~10-minute budget a
+# deep code claim gets. Raise-only, as the search stack improves (GPU RIS /
+# sparse RREF are the known routes up).
+MAX_DEM_MECHANISMS = 25_000
+
 SIDE_FILES = {"X": "memory_x", "Z": "memory_z"}
 SIDE_READOUT = {"X": "MX", "Z": "M"}
 
@@ -241,6 +251,13 @@ def verify_circuit(doc, circuits_dir):
                f"k observables, checks, and rounds bound to the declared code")
 
         derived = ct.derive_dem(circuit)        # step 5: witness
+        record(f"{side}_dem_within_budget",
+               derived.num_errors <= MAX_DEM_MECHANISMS,
+               f"{derived.num_errors} mechanisms (cap {MAX_DEM_MECHANISMS}: "
+               f"verification-budget rule; the refutation gate must be able "
+               f"to search this DEM)")
+        if derived.num_errors > MAX_DEM_MECHANISMS:
+            continue
         dem_match = ct.dem_matches(derived, committed)
         record(f"{side}_dem_reproduces", dem_match,
                "committed .dem re-derives mechanism-for-mechanism (exact "

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -34,6 +34,19 @@ new codes, edited checks, raised values, unclassifiable diffs -- fails closed
 to the full existing behavior. Classification is recomputed from the git
 diff, never taken from the PR's framing.
 
+Entries with a circuit block (RFC 0001, issue #505) additionally face the
+circuit-tier refutation (_circuit_refute): a bounded RIS search on each memory
+circuit's re-derived DEM, hunting an undetected logical fault set lighter than
+the claimed d_circ. The circuit search is priced by the same diff principle
+(circuit_gate_needed): it runs when the circuit claim surface changed -- the
+JSON's circuit block, or anything under circuits/<slug>/, whose diffs
+map_changed routes here even when the JSON is untouched -- or when the entry
+is new; an untouched circuit claim already survived its own gate. In
+particular a diff that only adds or edits a circuit block classifies as
+layout-only for the CODE tier (checks and distance are unchanged) yet still
+pays the circuit search: the code-tier skip must never skip the claim that
+actually changed.
+
 Usage:
   python verify/gate_changed.py [--code-root PATH] [BASE] [files...]
     --code-root PATH  repository tree containing the submitted codes
@@ -50,8 +63,10 @@ import sys
 import numpy as np
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import circuit_tools as CT
 import gf2
 import heuristic_distance as H
+from circuit_verify import MAX_DEM_MECHANISMS, SIDE_FILES
 from qldpc_verify import file_size_error
 from validate_candidate import validate_candidate
 from build_receipt import make_receipt, write_receipt
@@ -79,15 +94,30 @@ def _load_syndrome():
         return None
 
 
+def map_changed(paths):
+    """Changed paths -> the code JSONs the gate must run on. A change under
+    circuits/<slug>/ is a change to that entry's circuit-tier claim surface
+    (the DEM the witnesses live in), so it maps back to codes/<slug>.json --
+    a schedule swap cannot dodge the gate by leaving the JSON untouched."""
+    files = []
+    for p in paths:
+        if p.startswith("circuits/") and p.count("/") >= 2:
+            p = f"codes/{p.split('/')[1]}.json"
+        if p.endswith(".json") and p not in files:
+            files.append(p)
+    return files
+
+
 def changed_codes(base, code_root=ROOT):
     try:
         out = subprocess.check_output(
-            ["git", "diff", "--name-only", f"{base}...HEAD", "--", "codes", "verify/fixtures"],
+            ["git", "diff", "--name-only", f"{base}...HEAD", "--",
+             "codes", "verify/fixtures", "circuits"],
             cwd=code_root, text=True)
     except Exception as e:
         print(f"could not compute diff vs {base}: {e}; failing closed")
         return None
-    return [f for f in out.split() if f.endswith(".json")]
+    return map_changed(out.split())
 
 
 def changed_codes_status(base: str, code_root: str = ROOT) -> dict | None:
@@ -341,6 +371,87 @@ def _budget(n, deep, fast=False):
     return trials, seconds, 1
 
 
+# Circuit-tier refutation budget (RFC 0001 step 6). Per-trial RIS cost on
+# ker(H_dem) fits ~cost * mechanisms^3 (dominated by the packed RREF; measured
+# 2026-08-20 with gf2_fast: 8.4 ms at m=1651, 26 ms at m=2845, 3.9 s at
+# m=15800; python fallback ~10x). The budget targets a wall-clock per basis
+# and converts it to trials through that fit; the hard time cap inside
+# ris_dem bounds CI even where the fit is off. At MAX_DEM_MECHANISMS the
+# floor of 12 trials costs ~2 minutes per basis, which is what sized the cap.
+CIRCUIT_TRIAL_COST = 1.2e-12          # seconds per trial per mechanisms^3
+CIRCUIT_PY_FACTOR = 10                # python fallback slowdown, measured
+CIRCUIT_SECONDS = 120.0               # wall-clock target per basis
+CIRCUIT_MAX_TRIALS = 2000
+CIRCUIT_MIN_TRIALS = 12
+
+
+def _circuit_budget(m, fast):
+    per = CIRCUIT_TRIAL_COST * m ** 3 * (1 if fast else CIRCUIT_PY_FACTOR)
+    per = max(per, 0.002)
+    trials = int(max(CIRCUIT_MIN_TRIALS if fast else 3,
+                     min(CIRCUIT_MAX_TRIALS, CIRCUIT_SECONDS / per)))
+    return trials, CIRCUIT_SECONDS * 1.5
+
+
+def circuit_gate_needed(base_doc, doc, circuits_diffed):
+    """Diff-priced circuit gate decision: search only when the circuit claim
+    surface changed -- the JSON's circuit block or the artifacts under
+    circuits/<slug>/ -- or when there is no base to have gated it. An
+    untouched claim already survived its own gate and the code-tier skip
+    logic must never be the thing that skips a CHANGED circuit claim."""
+    if "circuit" not in doc:
+        return False
+    if base_doc is None:
+        return True
+    return base_doc.get("circuit") != doc.get("circuit") or circuits_diffed
+
+
+def _circuits_diffed(base, code_root, slug):
+    """Did anything under circuits/<slug>/ change vs base? Fails closed (True)
+    when the diff cannot be computed."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", f"{base}...HEAD", "--",
+             f"circuits/{slug}"], cwd=code_root, text=True)
+        return bool(out.strip())
+    except Exception:
+        return True
+
+
+def _circuit_refute(doc, circuits_dir, seed, trials_override=None):
+    """RFC 0001 step 6: independent bounded RIS on the DEM of each committed
+    memory circuit, hunting an undetected logical fault set lighter than the
+    claimed d_circ. The DEM is RE-DERIVED from the .stim with the pinned stim
+    -- the search substrate is never the committed .dem taken on faith -- and
+    a find only counts after the pinned witness check confirms it, exactly
+    the layering the code-distance gate uses. Returns (hits, notes): hits
+    maps basis -> (found_weight, witness, claimed); notes are per-basis "ok"
+    summaries. Raises on unreadable artifacts (caller fails closed)."""
+    import stim
+    hits, notes = {}, []
+    for side in ("X", "Z"):
+        claim = int(doc["circuit"]["d_circ"][side]["value"])
+        base = os.path.join(circuits_dir, SIDE_FILES[side])
+        circuit = stim.Circuit(open(base + ".stim").read())
+        dem = CT.derive_dem(circuit)
+        m = dem.num_errors
+        if m > MAX_DEM_MECHANISMS:
+            raise ValueError(f"{side}: {m} mechanisms exceeds the tier cap "
+                             f"{MAX_DEM_MECHANISMS}")
+        Hd, L = CT.dem_matrices(dem)
+        trials, cap = _circuit_budget(m, CT._GF is not None)
+        if trials_override:
+            trials = trials_override
+        w, wit = CT.ris_dem(Hd, L, trials, seed=seed, max_seconds=cap)
+        if w is not None and w < claim and \
+                not CT.witness_errors(dem, wit, w):
+            hits[side] = (w, wit, claim)
+        else:
+            notes.append(f"{side} ok (m={m}, {trials} trials, "
+                         f"lightest {w} vs claimed {claim})")
+    return hits, notes
+
+
 def _fast_refute(doc, seed, trials):
     """Deep RIS via the optional C++ accelerator, kept SOUND the same way the
     python passes are: the accelerator only proposes (weight, side, support);
@@ -464,7 +575,31 @@ def main(argv):
         # Price the diff, not just the code: what changed determines what could
         # newly be over-claimed (see module docstring).
         base_doc = base_doc_for(f, doc, base, code_root)
+        if base_doc is None:
+            status = changed_codes_status(base, code_root)
+            if status is not None and f not in status:
+                # The JSON itself is untouched -- this file was mapped in by
+                # a circuits/<slug>/ diff. Its base counterpart is simply
+                # itself at base, so the code tier classifies as unchanged
+                # (and skips) instead of pricing an unchanged claim as a new
+                # one. A None status (git failure) stays None: fail closed.
+                base_doc = load_base_doc(base, f, code_root)
         cls, why = classify_diff(base_doc, doc)
+        run_circuit = circuit_gate_needed(
+            base_doc, doc, _circuits_diffed(base, code_root, slug))
+
+        def run_circuit_gate():
+            """The circuit-tier search (RFC 0001 step 6); (hits, notes, err)."""
+            if not run_circuit:
+                return {}, (["circuit claim unchanged from base; already "
+                             "gated"] if "circuit" in doc else []), None
+            cdir = os.path.join(os.path.dirname(p), "..", "circuits", slug)
+            try:
+                h, nts = _circuit_refute(doc, cdir, seed + 11)
+                return h, nts, None
+            except Exception as e:
+                return {}, [], f"{type(e).__name__}: {e}"
+
         if cls == "layout-only":
             # The structural verdict (schema, witnesses, layout honesty) is
             # authoritative here even though verify_all also runs it: the
@@ -486,24 +621,55 @@ def main(argv):
                 print(f"ok       {f} (layout-only diff: {why}; refutation "
                       f"deferred to the weekly board sweep)")
             if cls == "layout-only":
+                # The CODE claim is unchanged and skips, but a changed
+                # circuit claim in the same diff must still be searched: a
+                # circuit-block-only edit classifies exactly here.
+                ok_struct = structural_ok(verdict)
+                circ_hits, circ_notes, circ_failed = ({}, [], None)
+                if ok_struct:
+                    circ_hits, circ_notes, circ_failed = run_circuit_gate()
+                if circ_failed:
+                    failed += 1
+                    print(f"FAIL     {f} [circuit]: gate could not search the "
+                          f"DEM ({circ_failed}); failing closed -- manual "
+                          f"review required")
+                elif circ_hits:
+                    refuted += 1
+                    for s, (w, wit, c) in circ_hits.items():
+                        print(f"REFUTED  {f} [circuit-{s}]: weight-{w} "
+                              f"undetected logical fault set < claimed "
+                              f"d_circ {c}\n         witness (dem error "
+                              f"indices) = {wit}")
+                elif ok_struct and run_circuit:
+                    print(f"ok       {f} [circuit]: {'; '.join(circ_notes)}")
                 if receipt_dir:
                     # The receipt's headline verdict must reflect structural
                     # soundness of the edit, not the new-candidate gates
                     # (dedup self-matches by construction on an in-place edit).
-                    verdict["passed"] = structural_ok(verdict)
+                    verdict["passed"] = bool(ok_struct and not circ_hits
+                                             and not circ_failed)
                     verdict["gates"]["refute"] = {
-                        "refuted": False, "seed": seed,
+                        "refuted": bool(circ_hits), "seed": seed,
                         "detail": f"skipped: {why}; distance claim identical "
                                   f"to base and covered by the weekly refute "
                                   f"sweep; dedup self-match is expected for "
                                   f"an in-place edit",
                     }
+                    gate = {"refuted": bool(circ_hits), "seed": seed,
+                            "seeds": [], "trials": 0, "budget_seconds": 0.0,
+                            "deep": False, "fast_trials": 0, "methods": [],
+                            "diff_class": cls, "diff_reason": why}
+                    if "circuit" in doc:
+                        gate["circuit"] = {
+                            "searched": run_circuit,
+                            "refuted": bool(circ_hits),
+                            "failed": circ_failed,
+                            "hits": {s: {"found": w, "claimed": c}
+                                     for s, (w, _, c) in circ_hits.items()},
+                            "notes": circ_notes,
+                        }
                     receipt = make_receipt(
-                        doc, p, verdict,
-                        gate={"refuted": False, "seed": seed, "seeds": [],
-                              "trials": 0, "budget_seconds": 0.0,
-                              "deep": False, "fast_trials": 0, "methods": [],
-                              "diff_class": cls, "diff_reason": why},
+                        doc, p, verdict, gate=gate,
                         repo_root=code_root, pr_number=pr_number,
                         pr_author=pr_author, base_sha=base_sha,
                         head_sha=head_sha)
@@ -537,12 +703,19 @@ def main(argv):
             ftrials = min(8_000_000, 150 * trials)
             results["RIS-fast"] = _fast_refute(doc, seed + 7, ftrials)
         hits = {m: (dh, wit) for m, (ref, dh, wit, _) in results.items() if ref}
+        # Circuit tier (RFC 0001 step 6): entries shipping syndrome circuits
+        # additionally face a bounded RIS search on each memory DEM when the
+        # circuit claim surface changed (circuit_gate_needed). A validated
+        # lighter fault set refutes the d_circ claim the same way a lighter
+        # logical refutes d. FAILS CLOSED: unreadable or over-cap artifacts
+        # are a gate failure, never a silent pass.
+        circ_hits, circ_notes, circ_failed = run_circuit_gate()
         fast_tag = (f" + fast x {ftrials}" if ftrials else "")
         tag = (f"deep, {len(seeds)} RIS seeds x {trials} trials (<={budget:.0f}s each)"
                f"{fast_tag}" if deep else f"standard, {trials} trials (<={budget:.0f}s)")
         tag += f"; diff: {cls}"
         gate = {
-            "refuted": bool(hits),
+            "refuted": bool(hits or circ_hits),
             "seed": seed,
             "seeds": seeds,
             "trials": trials,
@@ -553,6 +726,15 @@ def main(argv):
             "diff_class": cls,
             "diff_reason": why,
         }
+        if "circuit" in doc:
+            gate["circuit"] = {
+                "searched": run_circuit,
+                "refuted": bool(circ_hits),
+                "failed": circ_failed,
+                "hits": {s: {"found": w, "claimed": c}
+                         for s, (w, _, c) in circ_hits.items()},
+                "notes": circ_notes,
+            }
         if receipt_dir:
             # The distance search above is authoritative for this run. Reuse the
             # trusted structural/dedup/frontier checks without running refutation a
@@ -564,7 +746,8 @@ def main(argv):
                 "detail": "distance gate recorded by gate_changed.py",
             }
             verdict["passed"] = bool(
-                verdict.get("passed") and not hits)
+                verdict.get("passed") and not hits
+                and not circ_hits and not circ_failed)
             slug = os.path.splitext(os.path.basename(f))[0]
             receipt = make_receipt(
                 doc, p, verdict, gate=gate, repo_root=code_root,
@@ -579,6 +762,19 @@ def main(argv):
         else:
             print(f"ok       {f} ({tag}): no logical lighter than "
                   f"{doc['distance']['d']}")
+        if circ_failed:
+            failed += 1
+            print(f"FAIL     {f} [circuit]: gate could not search the DEM "
+                  f"({circ_failed}); failing closed -- manual review required")
+        elif circ_hits:
+            if not hits:
+                refuted += 1
+            for s, (w, wit, c) in circ_hits.items():
+                print(f"REFUTED  {f} [circuit-{s}]: weight-{w} undetected "
+                      f"logical fault set < claimed d_circ {c}\n"
+                      f"         witness (dem error indices) = {wit}")
+        elif circ_notes:
+            print(f"ok       {f} [circuit]: {'; '.join(circ_notes)}")
     if refuted:
         print(f"\n{refuted} submission(s) refuted: claimed distance is not supported "
               f"by an independent search. See witnesses above.")

--- a/verify/test_circuit_gate.py
+++ b/verify/test_circuit_gate.py
@@ -1,0 +1,147 @@
+"""
+Tests for the circuit-tier refutation gate (RFC 0001 step 6, gate_changed):
+an over-claimed d_circ must be caught by the bounded DEM search, an honest
+claim must survive it, circuits/-only changes must still trigger the gate,
+and unreadable artifacts must fail closed.
+
+The over-claim fixture is organic: the default greedy schedule on the
+[[25,1,5]] surface code has a hook error (true d_circ bound 3), and a
+shallow 1-trial search returns a heavier valid witness -- exactly the
+under-searched submission the gate exists to catch.
+
+Run: uv run pytest verify/test_circuit_gate.py
+"""
+
+import copy
+import json
+import os
+
+import pytest
+import stim
+
+import circuit_tools as ct
+import gate_changed as gc
+from qldpc_verify import _matrix
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DOC = json.load(open(os.path.join(ROOT, "codes", "25-1-5.json")))
+N = BASE_DOC["n"]
+
+
+@pytest.fixture(scope="module")
+def greedy(tmp_path_factory):
+    """(doc, circuits_dir) with the greedy-schedule circuits and, per basis,
+    the lightest witness a 1-trial search finds -- an honest artifact carrying
+    an under-searched claim wherever that weight exceeds the true bound."""
+    d = tmp_path_factory.mktemp("circuits")
+    HX = _matrix(BASE_DOC["checks"]["X"], N)
+    HZ = _matrix(BASE_DOC["checks"]["Z"], N)
+    doc = copy.deepcopy(BASE_DOC)
+    doc["schema_version"] = "0.2"
+    block = {"d_circ": {}, "rounds": 5, "stim_version": stim.__version__}
+    for basis in ("Z", "X"):
+        skel = ct.build_css_memory(HX, HZ, rounds=5, basis=basis)
+        noisy = ct.apply_noise(skel, N)
+        dem = ct.derive_dem(noisy)
+        H, L = ct.dem_matrices(dem)
+        w, wit = ct.ris_dem(H, L, trials=1, seed=2)
+        assert ct.witness_errors(dem, wit, w) == []
+        stem = os.path.join(d, f"memory_{basis.lower()}")
+        open(stem + ".stim", "w").write(str(noisy) + "\n")
+        open(stem + ".dem", "w").write(str(dem) + "\n")
+        block["d_circ"][basis] = {"value": w, "confidence": "upper_bound",
+                                  "witness": wit}
+    doc["circuit"] = block
+    return doc, str(d)
+
+
+def test_overclaim_refuted(greedy):
+    doc, d = greedy
+    deep = {}
+    for basis in ("Z", "X"):
+        circuit = stim.Circuit(
+            open(os.path.join(d, f"memory_{basis.lower()}.stim")).read())
+        H, L = ct.dem_matrices(ct.derive_dem(circuit))
+        deep[basis], _ = ct.ris_dem(H, L, trials=60, seed=9)
+    over = [s for s in ("Z", "X")
+            if doc["circuit"]["d_circ"][s]["value"] > deep[s]]
+    assert over, "1-trial search matched the 60-trial bound; fixture is moot"
+    hits, _ = gc._circuit_refute(doc, d, seed=9, trials_override=60)
+    for s in over:
+        assert s in hits
+        w, wit, claim = hits[s]
+        assert w < claim
+        circuit = stim.Circuit(
+            open(os.path.join(d, f"memory_{s.lower()}.stim")).read())
+        assert ct.witness_errors(ct.derive_dem(circuit), wit, w) == []
+
+
+def test_honest_claim_survives(greedy):
+    """Claiming the deep-searched bound itself must not be refuted by the
+    same search."""
+    doc, d = greedy
+    doc = copy.deepcopy(doc)
+    for basis in ("Z", "X"):
+        circuit = stim.Circuit(
+            open(os.path.join(d, f"memory_{basis.lower()}.stim")).read())
+        H, L = ct.dem_matrices(ct.derive_dem(circuit))
+        w, wit = ct.ris_dem(H, L, trials=60, seed=9)
+        doc["circuit"]["d_circ"][basis] = {
+            "value": w, "confidence": "upper_bound", "witness": wit}
+    hits, notes = gc._circuit_refute(doc, d, seed=9, trials_override=60)
+    assert hits == {} and len(notes) == 2
+
+
+def test_circuits_change_triggers_gate():
+    paths = ["circuits/25-1-5/memory_z.stim", "codes/72-6-6.json",
+             "circuits/25-1-5/memory_z.dem", "docs/index.html"]
+    assert gc.map_changed(paths) == ["codes/25-1-5.json", "codes/72-6-6.json"]
+
+
+def test_missing_artifacts_fail_closed(greedy, tmp_path):
+    doc, _ = greedy
+    with pytest.raises(Exception):
+        gc._circuit_refute(doc, str(tmp_path), seed=0)
+
+
+def test_circuit_gate_pricing():
+    """circuit_gate_needed follows the diff-pricing principle (issue #654):
+    search exactly when the circuit claim surface changed or never faced a
+    gate; in particular a circuit-block-only edit -- which classifies as
+    layout-only for the code tier -- must still be searched, and an untouched
+    claim must not be."""
+    blk = {"circuit": {"rounds": 5}, "distance": {}}
+    blk2 = {"circuit": {"rounds": 6}, "distance": {}}
+    plain = {"distance": {}}
+    assert not gc.circuit_gate_needed(blk, plain, True)     # no claim, no gate
+    assert gc.circuit_gate_needed(None, blk, False)         # new entry
+    assert gc.circuit_gate_needed(blk2, blk, False)         # block edited
+    assert gc.circuit_gate_needed(plain, blk, False)        # block added
+    assert gc.circuit_gate_needed(blk, blk, True)           # .stim/.dem edited
+    assert not gc.circuit_gate_needed(blk, blk, False)      # untouched claim
+
+
+def test_circuit_block_edit_skips_code_tier_but_is_searched():
+    """The load-bearing conjunction behind the main-loop wiring: a diff that
+    only adds a circuit block classifies as layout-only for the CODE tier
+    (checks and distance unchanged -- correct, that claim already survived),
+    while circuit_gate_needed still demands the circuit search. If either
+    half changes, the layout-only skip path must be re-examined so it never
+    skips the claim that actually changed."""
+    base = {"code_type": "CSS", "n": 25, "k": 1,
+            "checks": BASE_DOC["checks"], "distance": BASE_DOC["distance"]}
+    new = copy.deepcopy(base)
+    new["circuit"] = {"rounds": 5}
+    cls, _ = gc.classify_diff(base, new)
+    assert cls == "layout-only"
+    assert gc.circuit_gate_needed(base, new, False)
+
+
+def test_budget_shape():
+    t_small, _ = gc._circuit_budget(1700, fast=True)
+    t_mid, _ = gc._circuit_budget(8000, fast=True)
+    t_cap, _ = gc._circuit_budget(25_000, fast=True)
+    t_py, _ = gc._circuit_budget(8000, fast=False)
+    assert t_small == gc.CIRCUIT_MAX_TRIALS      # small DEMs get full depth
+    assert t_cap >= gc.CIRCUIT_MIN_TRIALS        # cap sized to stay feasible
+    assert 0 < t_py < t_mid <= t_small           # fallback shallower, never zero


### PR DESCRIPTION
Completes Phase A of #505: the adversarial half of the circuit tier. The fast path (#646) checks that a claimed witness is real; this PR makes the claim *contested* — `gate_changed.py` now independently searches every changed entry's memory DEMs for an undetected logical fault set lighter than the claimed d_circ, with the same trust layering as the code-distance gate:

- The DEM is **re-derived from the committed `.stim`** with the pinned stim — the search substrate is never the committed `.dem` taken on faith.
- A find counts **only after the pinned GF(2) witness check confirms it**; the printed witness is itself the corrected claim a follow-up submission can adopt.
- **Fails closed**: unreadable or over-cap artifacts are a gate failure, never a silent pass.
- **Schedule swaps can't dodge review**: `map_changed` maps `circuits/<slug>/*` diffs back to `codes/<slug>.json`, so a PR touching only the `.stim` files still pays the full gate.

## Budget (the RFC's "measure before inviting submissions" instruction)

Measured per-trial RIS cost on `ker(H_dem)` fits ~`1.2e-12 · m³` seconds with gf2_fast (8.4 ms at m=1651, 26 ms at m=2845, 3.9 s at m=15800, 25 s at m=34530; python fallback ~10×). The gate targets **120 s wall-clock per basis**, converted to trials through that fit (floor 12, cap 2000), with a hard time cap inside `ris_dem` for when the fit is off.

That measurement also sized the tier's new submission cap: **`MAX_DEM_MECHANISMS = 25 000`** (enforced in `circuit_verify`, raise-only) — at the cap the trial floor costs ~2 min/basis, keeping a circuit entry inside the same ~10-minute budget a deep code claim gets. This is the RFC's anticipated "cap the tier by n·rounds", enforced on the actual cost driver. A weight-6 BB entry at rounds=6 sits at m≈16k — inside the cap, ~30 gate trials/basis; the known routes up are GPU RIS and sparse RREF.

On the seed entry the gate runs 2000 trials/basis in ~17 s each and finds nothing below the claimed 5/5 (which incidentally deepens that claim's survived budget).

## Tests (5 new, suite 38 passed)

The over-claim fixture is organic rather than synthetic: the greedy schedule on [[25,1,5]] is hook-limited to a true bound of 3, and a 1-trial search returns a heavier valid witness — exactly the under-searched submission the RFC's convergence risk describes. The gate must refute it with a validated witness; claiming the deep-searched bound must survive the same search; circuits/-only diffs must map to the owning code; missing artifacts must raise; the budget curve must have full depth at small m, a feasible floor at the cap, and a strictly shallower python fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)