### PR TITLE
gate_changed: layout-only structural verdict must come from the verify gate (fixes #674 CI)

### DIFF
--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -144,6 +144,17 @@ def base_doc_for(f: str, doc: dict, base: str, code_root: str) -> dict | None:
     return None
 
 
+def structural_ok(verdict: dict) -> bool:
+    """The structural soundness of a board edit, from a validate_candidate
+    verdict. validate_candidate is the NEW-candidate pipeline: its overall
+    'passed' includes gates that are meaningless for an in-place edit of a
+    file already on the board -- dedup flags the code as an exact duplicate
+    of itself, and novelty judges board advancement. What the gate must not
+    say ok about is a file the VERIFIER rejects, so only gates.verify.ok is
+    authoritative here."""
+    return bool(((verdict.get("gates") or {}).get("verify") or {}).get("ok"))
+
+
 def layout_entered_tighter_class(base_doc: dict | None, new_doc: dict) -> bool:
     """True when the diff's layout moves the code into a tighter locality
     class than it had at base. For a layout-only diff this is the only way
@@ -460,7 +471,7 @@ def main(argv):
             # gate's stdout and receipt must not say ok about a file the
             # verifier rejects.
             verdict = validate_candidate(doc, seed=seed, refute=False)
-            if not verdict.get("passed"):
+            if not structural_ok(verdict):
                 failed += 1
                 print(f"FAIL     {f}: structural checks failed "
                       f"(layout-only diff; see verify_all for details)")
@@ -476,11 +487,16 @@ def main(argv):
                       f"deferred to the weekly board sweep)")
             if cls == "layout-only":
                 if receipt_dir:
+                    # The receipt's headline verdict must reflect structural
+                    # soundness of the edit, not the new-candidate gates
+                    # (dedup self-matches by construction on an in-place edit).
+                    verdict["passed"] = structural_ok(verdict)
                     verdict["gates"]["refute"] = {
                         "refuted": False, "seed": seed,
                         "detail": f"skipped: {why}; distance claim identical "
                                   f"to base and covered by the weekly refute "
-                                  f"sweep",
+                                  f"sweep; dedup self-match is expected for "
+                                  f"an in-place edit",
                     }
                     receipt = make_receipt(
                         doc, p, verdict,

--- a/verify/test_gate_diff_classes.py
+++ b/verify/test_gate_diff_classes.py
@@ -246,3 +246,18 @@ def test_tighter_class_guard_ignores_unchanged_class():
     doc = copy.deepcopy(base)
     doc["locality"]["coordinates"] = list(reversed(doc["locality"]["coordinates"]))
     assert not G.layout_entered_tighter_class(base, doc)
+
+
+def test_structural_ok_ignores_candidate_pipeline_gates():
+    """An in-place board edit self-matches dedup and advances nothing; only
+    the verifier gate decides structural soundness (#674 regression)."""
+    self_dup = {"passed": False,
+                "gates": {"verify": {"ok": True, "failed_checks": []},
+                          "dedup": {"exact_duplicate_of": "40-10-4.json"},
+                          "novelty": {"board_advancing": False}}}
+    assert G.structural_ok(self_dup)
+    rejected = {"passed": False,
+                "gates": {"verify": {"ok": False,
+                                     "failed_checks": ["coordinates_cover_all_qubits"]}}}
+    assert not G.structural_ok(rejected)
+    assert not G.structural_ok({})


### PR DESCRIPTION
## The bug

#655's layout-only branch runs `validate_candidate(doc, refute=False)` and treated the overall `passed` as the structural verdict (the receipt-honesty fix from review). But `validate_candidate` is the **new-candidate** pipeline: on an in-place edit of a file already on the board, its dedup gate flags the code as an exact duplicate *of itself* (`exact_duplicate_of: '<slug>.json'`) and novelty reports no board advancement — so `passed` is `False` for every modified code regardless of correctness. Result: all ten layouts in #674 FAILed with 'structural checks failed' while `verify_all` passed them in the same job. The normal gate path never surfaced this because it never counted the verdict toward the exit code (the pre-existing gap noted in #655's review).

## The fix

New `structural_ok(verdict)` helper: the authoritative structural signal for an in-place edit is `gates.verify.ok` — the thing the gate must not say ok about is a file the VERIFIER rejects; dedup/novelty are meaningless for a file that is on the board by definition. The layout-only branch uses it for the FAIL decision, and the receipt's headline `passed` is set from it with the dedup self-match noted as expected in the refute detail.

Regression test added (verify-ok-but-dedup-self-dup must pass; verifier-rejected must fail; empty verdict fails). 22 classifier tests + full `run_tests.py --skip-slow` green.

After merge: re-run CI on #674 and #675 — their layouts are unaffected (all pass `qldpc_verify` locally, including layout honesty); only this gate misjudgment blocked them.