### PR TITLE
gf2_fast: in-C++ DEM trial loop for the circuit-tier search (10–18×)

### DIFF
--- a/verify/circuit_tools.py
+++ b/verify/circuit_tools.py
@@ -332,11 +332,18 @@ def ris_dem(H, L, trials, seed=0, pair_top=24, max_seconds=None, threads=4):
 
     When gf2_fast provides dem_rand_witness, the whole trial loop runs in
     C++ (kernel packed once, pivot-order permutation instead of physical
-    column moves, `threads` workers) in fixed 64-trial chunks so the wall
-    cap is still enforced between chunks; results are deterministic given
-    (seed, trials, threads) whenever the cap does not truncate. Finds are
-    PROPOSALS either way -- callers validate with witness_errors. The numpy
-    loop below is the fallback and the audited reference implementation."""
+    column moves, `threads` workers), handed out in chunks. A chunk cannot
+    be aborted, so the wall cap is enforced by PROJECTION, not just by
+    checking between chunks (vprusso's #684 review: a blind 64-trial chunk
+    overshot a 0.5 s cap by ~140x at m~12k): the loop opens with a small
+    8-trial chunk to measure this machine's per-trial cost, then sizes every
+    later chunk to what the remaining budget can pay for (floor `threads`,
+    else stop), so the worst overshoot is one small chunk rather than one
+    arbitrarily expensive one. An unconstrained run always uses the fixed
+    (8, 64, 64, ...) sequence, so results stay deterministic given (seed,
+    trials, threads) whenever the cap does not truncate. Finds are PROPOSALS
+    either way -- callers validate with witness_errors. The numpy loop below
+    is the fallback and the audited reference implementation."""
     import time
     H = np.ascontiguousarray(np.asarray(H, dtype=np.int8))
     L = np.ascontiguousarray(np.asarray(L, dtype=np.int8))
@@ -344,12 +351,21 @@ def ris_dem(H, L, trials, seed=0, pair_top=24, max_seconds=None, threads=4):
         deadline = (time.monotonic() + max_seconds) if max_seconds else None
         best, wit = None, None
         done, chunk_i = 0, 0
+        per_trial = None            # measured; conservative running max
         while done < trials:
-            t = min(64, trials - done)
+            t = min(8 if chunk_i == 0 else 64, trials - done)
+            if deadline is not None and per_trial is not None:
+                afford = int((deadline - time.monotonic()) / per_trial)
+                if afford < max(threads, 1):
+                    break
+                t = min(t, afford)
+            t0 = time.monotonic()
             w, sup = _GF.dem_rand_witness(H, L, trials=t,
                                           seed=seed + 7919 * chunk_i,
                                           pair_depth=pair_top,
                                           threads=threads)
+            per_trial = max(per_trial or 0.0,
+                            (time.monotonic() - t0) / t, 1e-9)
             if w is not None and (best is None or w < best):
                 best, wit = int(w), [int(i) for i in sup]
             done += t

--- a/verify/circuit_tools.py
+++ b/verify/circuit_tools.py
@@ -322,15 +322,42 @@ def _rref(M):
     return gf2.rref(np.ascontiguousarray(M))[0]
 
 
-def ris_dem(H, L, trials, seed=0, pair_top=24, max_seconds=None):
+def ris_dem(H, L, trials, seed=0, pair_top=24, max_seconds=None, threads=4):
     """RIS upper-bound search for the lightest undetected logical fault set:
     min |e| with H e = 0, L e != 0. The code-tier searcher on the DEM's
     parity-check matrix -- hyperedge degree is irrelevant to it. Returns
     (weight, sorted column indices) or (None, None). Stops after `trials`
     permutations or `max_seconds` wall-clock, whichever comes first (the time
-    cap keeps the CI gate bounded when the size estimate is off)."""
+    cap keeps the CI gate bounded when the size estimate is off).
+
+    When gf2_fast provides dem_rand_witness, the whole trial loop runs in
+    C++ (kernel packed once, pivot-order permutation instead of physical
+    column moves, `threads` workers) in fixed 64-trial chunks so the wall
+    cap is still enforced between chunks; results are deterministic given
+    (seed, trials, threads) whenever the cap does not truncate. Finds are
+    PROPOSALS either way -- callers validate with witness_errors. The numpy
+    loop below is the fallback and the audited reference implementation."""
     import time
-    K = _kernel_basis(np.asarray(H, dtype=np.int8))
+    H = np.ascontiguousarray(np.asarray(H, dtype=np.int8))
+    L = np.ascontiguousarray(np.asarray(L, dtype=np.int8))
+    if _GF is not None and hasattr(_GF, "dem_rand_witness"):
+        deadline = (time.monotonic() + max_seconds) if max_seconds else None
+        best, wit = None, None
+        done, chunk_i = 0, 0
+        while done < trials:
+            t = min(64, trials - done)
+            w, sup = _GF.dem_rand_witness(H, L, trials=t,
+                                          seed=seed + 7919 * chunk_i,
+                                          pair_depth=pair_top,
+                                          threads=threads)
+            if w is not None and (best is None or w < best):
+                best, wit = int(w), [int(i) for i in sup]
+            done += t
+            chunk_i += 1
+            if deadline and time.monotonic() > deadline:
+                break
+        return best, wit
+    K = _kernel_basis(H)
     m = K.shape[1]
     if K.shape[0] == 0:
         return None, None

--- a/verify/circuit_verify.py
+++ b/verify/circuit_verify.py
@@ -57,12 +57,13 @@ MAX_CIRCUIT_FILE_BYTES = 5_000_000
 
 # Verification-budget cap for the circuit tier (the RFC's "cap the tier by
 # n*rounds", enforced on the actual cost driver): the refutation gate searches
-# ker(H_dem) by RIS, and per-trial cost fits ~1.2e-12 * mechanisms^3 seconds
-# with the gf2_fast extension (measured 2026-08-20: 8.4 ms at m=1651, 3.9 s at
-# m=15800, 25 s at m=34530). At this cap a basis costs the gate ~2 minutes at
-# minimum depth, keeping a circuit entry within the same ~10-minute budget a
-# deep code claim gets. Raise-only, as the search stack improves (GPU RIS /
-# sparse RREF are the known routes up).
+# ker(H_dem) by RIS, and per-trial cost fits ~2e-13 * mechanisms^3 seconds
+# with the in-C++ trial loop (gf2_fast.dem_rand_witness, measured 2026-08-21;
+# the 2026-08-20 numpy-orchestrated loop this cap was first sized against was
+# ~6x slower). At the cap a trial is ~3.1 s, so the gate's 120 s/basis target
+# buys ~38 trials -- searchable at full depth, keeping a circuit entry within
+# the same ~10-minute budget a deep code claim gets. Raise-only, as the
+# search stack improves (GPU RIS is the known route up).
 MAX_DEM_MECHANISMS = 25_000
 
 SIDE_FILES = {"X": "memory_x", "Z": "memory_z"}

--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -372,16 +372,20 @@ def _budget(n, deep, fast=False):
 
 
 # Circuit-tier refutation budget (RFC 0001 step 6). Per-trial RIS cost on
-# ker(H_dem) fits ~cost * mechanisms^3 (dominated by the packed RREF; measured
-# 2026-08-20 with gf2_fast: 8.4 ms at m=1651, 26 ms at m=2845, 3.9 s at
-# m=15800; python fallback ~10x). The budget targets a wall-clock per basis
-# and converts it to trials through that fit; the hard time cap inside
-# ris_dem bounds CI even where the fit is off. At MAX_DEM_MECHANISMS the
-# floor of 12 trials costs ~2 minutes per basis, which is what sized the cap.
-CIRCUIT_TRIAL_COST = 1.2e-12          # seconds per trial per mechanisms^3
-CIRCUIT_PY_FACTOR = 10                # python fallback slowdown, measured
+# ker(H_dem) fits ~cost * mechanisms^3, dominated by the packed RREF. With
+# the in-C++ DEM trial loop (gf2_fast.dem_rand_witness: kernel packed once,
+# pivot-order permutation instead of physical column moves, 4 threads;
+# measured 2026-08-21: 0.76 ms at m=1687, 10.8 ms at m=5353, 330 ms at
+# m=12411) the asymptotic constant is ~2e-13; the pure numpy fallback loop
+# measured ~1.9e-11 (85 ms at m=1651), hence the 100x factor. The budget
+# targets a wall-clock per basis and converts it to trials through the fit;
+# the hard time cap inside ris_dem bounds CI even where the fit is off. At
+# MAX_DEM_MECHANISMS (~3.1 s/trial) the 120 s target buys ~38 trials, so the
+# cap is genuinely searchable at full depth.
+CIRCUIT_TRIAL_COST = 2.0e-13          # seconds per trial per mechanisms^3
+CIRCUIT_PY_FACTOR = 100               # numpy-loop fallback slowdown, measured
 CIRCUIT_SECONDS = 120.0               # wall-clock target per basis
-CIRCUIT_MAX_TRIALS = 2000
+CIRCUIT_MAX_TRIALS = 20_000
 CIRCUIT_MIN_TRIALS = 12
 
 
@@ -439,7 +443,10 @@ def _circuit_refute(doc, circuits_dir, seed, trials_override=None):
             raise ValueError(f"{side}: {m} mechanisms exceeds the tier cap "
                              f"{MAX_DEM_MECHANISMS}")
         Hd, L = CT.dem_matrices(dem)
-        trials, cap = _circuit_budget(m, CT._GF is not None)
+        # `fast` keys on the DEM entry point specifically: a stale extension
+        # without it drops ris_dem to the numpy loop and must be budgeted so.
+        trials, cap = _circuit_budget(
+            m, CT._GF is not None and hasattr(CT._GF, "dem_rand_witness"))
         if trials_override:
             trials = trials_override
         w, wit = CT.ris_dem(Hd, L, trials, seed=seed, max_seconds=cap)

--- a/verify/gf2_fast.cpp
+++ b/verify/gf2_fast.cpp
@@ -1,12 +1,14 @@
 /**
  * gf2_fast.cpp — Bit-packed GF(2) linear algebra for quantum code search.
  *
- * OPTIONAL research accelerator for the RIS hot path in verify/gf2.py /
- * verify/heuristic_distance.py (which auto-uses it when importable, weights
- * only -- witnesses are always re-found and validated by the pinned Python
- * engine). NOT part of the trusted validation stack: the CI gate's
- * refute_check runs with fast_trials=0 and never imports this, and CI does
- * not build it, so gate verdicts are identical with or without it.
+ * OPTIONAL accelerator for the RIS hot paths (code-tier heuristic_distance,
+ * circuit-tier circuit_tools.ris_dem). NOT part of the trusted validation
+ * stack: everything here only PROPOSES candidates -- a find counts as a
+ * refutation or witness only after the pinned Python stack validates it
+ * (gate_changed._fast_refute, circuit_tools.witness_errors), and every gate
+ * degrades to the pure-Python search when this extension is absent (CI
+ * builds it via `make fast`, but a missing or broken build can only make
+ * the gate shallower-and-warned, never wrong).
  *
  * Build:  make fast        (or: python verify/setup_gf2_fast.py build_ext
  *                           --build-lib verify)
@@ -555,6 +557,49 @@ WitnessResult distance_rand_witness_cpp(const GF2Matrix& HX, const GF2Matrix& HZ
     return res;
 }
 
+// Circuit-tier (DEM) variant, RFC 0001 issue #505: min |e| with H e = 0 and
+// L e != 0, where H is a detector error model's detectors-by-mechanisms
+// parity-check matrix and L its observables-by-mechanisms matrix. This is the
+// SAME search as the CSS side: "flips a logical observable" (some row of L
+// has odd inner product with e) is the identical predicate the CSS
+// nontriviality check computes against a logical basis, so the trials core is
+// reused verbatim with L in the LZ seat. The kernel of H is computed and
+// packed once, shared read-only across threads; rref_perm randomizes the
+// information set by visiting columns in permuted PIVOT order, so nothing is
+// ever physically permuted or repacked per trial (the numpy path paid an
+// m x m column gather each trial -- ~130 MB at m~12k -- for the same effect).
+WitnessResult dem_rand_witness_cpp(const GF2Matrix& H, const GF2Matrix& L,
+                                   int trials, uint64_t seed, int pair_depth,
+                                   int n_threads) {
+    if (n_threads < 1) n_threads = 1;
+    int m = H.cols_;
+    WitnessResult res;
+    res.n = m;
+    GF2Matrix K = kernel_basis(H);        // hoisted: once, shared read-only
+    int per = (trials + n_threads - 1) / n_threads;
+    std::vector<int> results(n_threads, m + 1);
+    std::vector<std::vector<uint64_t>> wits(n_threads);
+    std::vector<std::thread> pool;
+    pool.reserve(n_threads);
+    for (int t = 0; t < n_threads; ++t) {
+        uint64_t s = seed + 0x9e3779b97f4a7c15ULL * (uint64_t)(t + 1);
+        pool.emplace_back([&, t, s]() {
+            results[t] = min_logical_weight_rand_core(m, K, L, per, s,
+                                                      pair_depth, &wits[t]);
+        });
+    }
+    for (auto& th : pool) th.join();
+    res.weight = m + 1;
+    res.side = -1;
+    for (int t = 0; t < n_threads; ++t)
+        if (results[t] < res.weight) {
+            res.weight = results[t];
+            res.side = 0;
+            res.witness = wits[t];
+        }
+    return res;
+}
+
 int compute_k_cpp(const GF2Matrix& HX, const GF2Matrix& HZ) {
     int n = (HX.rows_ > 0) ? HX.cols_ :
             (HZ.rows_ > 0) ? HZ.cols_ : 0;
@@ -635,6 +680,32 @@ static py::tuple py_distance_rand_witness(py::array_t<int8_t> HX_np,
     return py::make_tuple(res.weight, py::str(side), support);
 }
 
+static py::tuple py_dem_rand_witness(py::array_t<int8_t> H_np,
+                                     py::array_t<int8_t> L_np,
+                                     int trials, uint64_t seed,
+                                     int pair_depth, int threads) {
+    if (H_np.size() == 0 || L_np.size() == 0)
+        return py::make_tuple(py::none(), py::none());
+    auto H = GF2Matrix::from_numpy(H_np);
+    auto L = GF2Matrix::from_numpy(L_np);
+    if (H.cols_ != L.cols_)
+        throw std::runtime_error("dem_rand_witness: H and L must have the "
+                                 "same number of columns (mechanisms)");
+    WitnessResult res;
+    {   // workers touch no Python objects -> drop the GIL so they run in parallel
+        py::gil_scoped_release release;
+        res = dem_rand_witness_cpp(H, L, trials, seed, pair_depth, threads);
+    }
+    if (res.side < 0)
+        return py::make_tuple(py::none(), py::none());
+    py::list support;
+    for (int c = 0; c < res.n; ++c)
+        if ((res.witness[c / 64] >> (c % 64)) & 1)
+            support.append(c);
+    return py::make_tuple(res.weight, support);
+}
+
+
 static int py_compute_k(py::array_t<int8_t> HX_np, py::array_t<int8_t> HZ_np) {
     GF2Matrix HX = (HX_np.size() > 0) ? GF2Matrix::from_numpy(HX_np)
                                        : GF2Matrix(0, (HZ_np.ndim() == 2) ? (int)HZ_np.shape(1) : 0);
@@ -683,6 +754,15 @@ PYBIND11_MODULE(gf2_fast, m) {
           py::arg("HX"), py::arg("HZ"),
           py::arg("trials") = 300, py::arg("seed") = 0,
           py::arg("pair_depth") = 8, py::arg("threads") = 8);
+
+    m.def("dem_rand_witness", &py_dem_rand_witness,
+          py::arg("H"), py::arg("L"), py::arg("trials"),
+          py::arg("seed") = 0, py::arg("pair_depth") = 24,
+          py::arg("threads") = 4,
+          "Circuit-tier RIS (RFC 0001): min |e| with H e = 0, L e != 0 over "
+          "a DEM's parity-check and observable matrices. Returns (weight, "
+          "sorted mechanism indices) or (None, None). Proposes only -- "
+          "callers validate with circuit_tools.witness_errors.");
 
     m.def("compute_k", &py_compute_k,
           "Number of logical qubits: n - rank(HX) - rank(HZ).",

--- a/verify/test_circuit_gate.py
+++ b/verify/test_circuit_gate.py
@@ -145,3 +145,31 @@ def test_budget_shape():
     assert t_small == gc.CIRCUIT_MAX_TRIALS      # small DEMs get full depth
     assert t_cap >= gc.CIRCUIT_MIN_TRIALS        # cap sized to stay feasible
     assert 0 < t_py < t_mid <= t_small           # fallback shallower, never zero
+
+
+def test_dem_wall_cap_stops_after_opener(monkeypatch):
+    """#684 review regression, load-independent form (the first version
+    asserted wall-clock seconds, which asserts the speed of the box and
+    flaked on a loaded machine with the fix working correctly): a C++ chunk
+    cannot be aborted, so when the opener chunk reveals the cap is already
+    unaffordable the loop must stop after that single small chunk -- no
+    second chunk, ever. The pre-fix loop issued a blind 64-trial first
+    chunk, so this fails against it deterministically, in milliseconds."""
+    import time
+    import types
+    import numpy as np
+    calls = []
+
+    def stub(H, L, trials, seed, pair_depth, threads):
+        calls.append(trials)
+        time.sleep(0.05)              # any nonzero cost blows a 1 ms cap
+        return None, None
+
+    monkeypatch.setattr(ct, "_GF",
+                        types.SimpleNamespace(dem_rand_witness=stub))
+    H = np.zeros((2, 8), dtype=np.int8)
+    H[0, 0] = H[1, 1] = 1
+    L = np.zeros((1, 8), dtype=np.int8)
+    L[0, 7] = 1
+    ct.ris_dem(H, L, trials=20000, seed=3, max_seconds=0.001)
+    assert calls == [8], f"expected only the opener chunk, got {calls}"

--- a/verify/test_gf2_fast.py
+++ b/verify/test_gf2_fast.py
@@ -145,3 +145,24 @@ def test_dem_rand_witness_parity():
     # the wrapper takes the C++ path and self-agrees
     w2, wit2 = ct.ris_dem(H, L, trials=200, seed=7)
     assert w2 == 3 and ct.witness_errors(dem, wit2, w2) == []
+
+
+def test_dem_wall_cap_binds_on_large_dem():
+    """#684 review regression: a chunk of C++ trials cannot be aborted, so a
+    blind 64-trial chunk overshot a 0.5 s cap by ~140x at m~12k (one trial is
+    ~0.3-1 s there). With projection sizing the overshoot is bounded by the
+    small 8-trial opener: the wall must stay within a small multiple of the
+    cap, where the pre-fix behavior took 21-70 s."""
+    import time
+    import circuit_tools as ct
+    from qldpc_verify import _matrix as _m
+    ROOT = os.path.dirname(_HERE)
+    doc = json.load(open(os.path.join(ROOT, "codes", "81-1-9.json")))
+    n = doc["n"]
+    skel = ct.build_css_memory(_m(doc["checks"]["X"], n),
+                               _m(doc["checks"]["Z"], n), rounds=9, basis="Z")
+    H, L = ct.dem_matrices(ct.derive_dem(ct.apply_noise(skel, n)))
+    t0 = time.monotonic()
+    w, wit = ct.ris_dem(H, L, trials=200, seed=3, max_seconds=0.5)
+    wall = time.monotonic() - t0
+    assert wall < 15.0, f"wall {wall:.1f}s for a 0.5s cap: projection broken"

--- a/verify/test_gf2_fast.py
+++ b/verify/test_gf2_fast.py
@@ -111,3 +111,37 @@ check("distance_rand_witness returns a valid logical", ok,
 def test_gf2_fast_matches_reference():
     """pytest entry point: the checks above run at import, this reports them."""
     assert not FAILURES, FAILURES
+
+
+def test_dem_rand_witness_parity():
+    """The circuit-tier trial loop (dem_rand_witness) against the numpy
+    reference loop in circuit_tools.ris_dem: same hook-limited bound on the
+    greedy [[25,1,5]] Z-memory DEM, valid witness, deterministic given
+    (seed, trials, threads), and the guarded fallback path unchanged."""
+    import circuit_tools as ct
+    from qldpc_verify import _matrix as _m
+    ROOT = os.path.dirname(_HERE)
+    doc = json.load(open(os.path.join(ROOT, "codes", "25-1-5.json")))
+    n = doc["n"]
+    HX = _m(doc["checks"]["X"], n)
+    HZ = _m(doc["checks"]["Z"], n)
+    skel = ct.build_css_memory(HX, HZ, rounds=5, basis="Z")
+    dem = ct.derive_dem(ct.apply_noise(skel, n))
+    H, L = ct.dem_matrices(dem)
+
+    w, wit = gf2_fast.dem_rand_witness(H, L, trials=200, seed=7)
+    assert ct.witness_errors(dem, wit, w) == []
+    assert gf2_fast.dem_rand_witness(H, L, trials=200, seed=7) == (w, wit)
+
+    # reference: the numpy loop (force the fallback) finds the same bound
+    saved, ct._GF = ct._GF, None
+    try:
+        w_py, wit_py = ct.ris_dem(H, L, trials=50, seed=7)
+    finally:
+        ct._GF = saved
+    assert ct.witness_errors(dem, wit_py, w_py) == []
+    assert w == w_py == 3          # the greedy schedule's hook, both paths
+
+    # the wrapper takes the C++ path and self-agrees
+    w2, wit2 = ct.ris_dem(H, L, trials=200, seed=7)
+    assert w2 == 3 and ct.witness_errors(dem, wit2, w2) == []

--- a/verify/test_gf2_fast.py
+++ b/verify/test_gf2_fast.py
@@ -146,23 +146,3 @@ def test_dem_rand_witness_parity():
     w2, wit2 = ct.ris_dem(H, L, trials=200, seed=7)
     assert w2 == 3 and ct.witness_errors(dem, wit2, w2) == []
 
-
-def test_dem_wall_cap_binds_on_large_dem():
-    """#684 review regression: a chunk of C++ trials cannot be aborted, so a
-    blind 64-trial chunk overshot a 0.5 s cap by ~140x at m~12k (one trial is
-    ~0.3-1 s there). With projection sizing the overshoot is bounded by the
-    small 8-trial opener: the wall must stay within a small multiple of the
-    cap, where the pre-fix behavior took 21-70 s."""
-    import time
-    import circuit_tools as ct
-    from qldpc_verify import _matrix as _m
-    ROOT = os.path.dirname(_HERE)
-    doc = json.load(open(os.path.join(ROOT, "codes", "81-1-9.json")))
-    n = doc["n"]
-    skel = ct.build_css_memory(_m(doc["checks"]["X"], n),
-                               _m(doc["checks"]["Z"], n), rounds=9, basis="Z")
-    H, L = ct.dem_matrices(ct.derive_dem(ct.apply_noise(skel, n)))
-    t0 = time.monotonic()
-    w, wit = ct.ris_dem(H, L, trials=200, seed=3, max_seconds=0.5)
-    wall = time.monotonic() - t0
-    assert wall < 15.0, f"wall {wall:.1f}s for a 0.5s cap: projection broken"


### PR DESCRIPTION
Follow-up to #663/#682: ports the circuit tier's RIS trial loop into `gf2_fast`, removing the per-trial overhead that made the DEM search 10–100× more expensive than it needed to be.

## What was wrong

`ris_dem` orchestrated trials from numpy: each trial materialized an m×m column permutation (~130 MB allocation + cache-hostile gather at m≈12k) and re-packed it into bitsets before any elimination ran — and the loop was single-threaded. Invisible at code-tier sizes (kernels ≤ 0.5 MB); dominant at DEM widths.

## Why the port is small

The machinery already existed: `min_logical_weight_rand_core`'s CSS nontriviality test (odd inner product against any row of a basis) **is** the circuit tier's `L·e ≠ 0` predicate verbatim, and `rref_perm` already randomizes the information set by pivot *order* with zero data movement. `dem_rand_witness` packs `ker(H_dem)` once, fans out across 4 threads, and returns (weight, mechanism indices). `circuit_tools.ris_dem` consumes it in fixed 64-trial chunks so the wall cap still binds; deterministic given (seed, trials, threads).

Trust layering unchanged: the C++ side proposes, `witness_errors` validates, and the numpy loop remains the audited reference and fallback — with a parity test asserting both paths find the same hook-limited bound (3) on the greedy [[25,1,5]] DEM with valid witnesses. The gate's budget flag keys on the new symbol specifically, so a stale extension is budgeted as the fallback it would actually run.

## Measured effect (same machine as the #663 calibration)

| m | before | after | |
|---|---|---|---|
| 1,687 (d=5 seed) | 8.4 ms/trial | 0.76 ms | 120 s buys 20,000 trials (was 2,000) |
| 5,353 (d=7) | ~197 ms | 10.8 ms | ~11,000 trials (was 609) |
| 12,411 (d=9) | ~2.5 s | 330 ms | ~360 trials (was 48) |
| 25,000 (tier cap) | ~19 s (extrap.) | ~3.1 s | ~38 trials — the cap is now genuinely searchable |

Budget constants re-fit (`2e-13·m³` C++, `1.9e-11` numpy fallback → factor 100), trial ceiling 2,000 → 20,000. `MAX_DEM_MECHANISMS` stays 25,000 — raising it is a submission-surface decision for its own PR, now that the search could afford it. Verified end-to-end: the gate re-searched the merged 25-1-5 artifact at 20,000 trials/basis (~17 s each), nothing below the claimed 5/5.

Suite: 68 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)