### PR TITLE
Circuit tier: structural lint of the derived DEM (#690)

### DIFF
--- a/verify/circuit_tools.py
+++ b/verify/circuit_tools.py
@@ -268,6 +268,53 @@ def dem_columns(dem):
     return cols
 
 
+def dem_lint(dem):
+    """Structural-integrity errors of a derived DEM, [] iff well formed.
+
+    The three error-severity properties from emlint's check taxonomy
+    (github.com/MathysRennela/emlint; implemented here on dem_columns rather
+    than imported, so the trusted closure gains no dependency -- issue #690):
+
+    - detectability: a mechanism that flips an observable while firing no
+      detector is a weight-1 undetected logical, i.e. the circuit has
+      d_circ = 1 regardless of any claim. The refutation gate finds these
+      probabilistically; this makes the verdict deterministic and extends it
+      to every fast-path run.
+    - observable coverage: a declared observable no mechanism flips is a
+      miswired OBSERVABLE_INCLUDE; the code-binding check counts observables
+      but does not confirm reachability.
+    - probability bounds: every mechanism probability must be a finite value
+      in (0, 1). d_circ never reads probabilities, but the measured-rate
+      tier hands them to the pinned decoder as its channel prior, where a
+      NaN corrupts silently.
+
+    All three are single linear scans over the sparse columns; distance
+    enters only through DEM length, which MAX_DEM_MECHANISMS bounds.
+    """
+    errs = []
+    cols = dem_columns(dem)
+    probs = [inst.args_copy()[0] for inst in dem.flattened()
+             if inst.type == "error"]
+    bad_det = [j for j, (ds, ls) in enumerate(cols) if not ds and ls]
+    if bad_det:
+        errs.append(f"detectability: mechanism(s) {bad_det[:8]} flip an "
+                    f"observable with no detector (weight-1 undetected "
+                    f"logicals: the circuit has d_circ = 1)")
+    covered = set()
+    for _, ls in cols:
+        covered.update(ls)
+    missing = sorted(set(range(dem.num_observables)) - covered)
+    if missing:
+        errs.append(f"observable_coverage: observable(s) {missing} are "
+                    f"flipped by no mechanism (miswired OBSERVABLE_INCLUDE)")
+    bad_p = [j for j, p in enumerate(probs)
+             if not (p == p and 0.0 < p < 1.0)]
+    if bad_p:
+        errs.append(f"probability_bounds: mechanism(s) {bad_p[:8]} carry "
+                    f"probabilities outside (0, 1) or NaN")
+    return errs
+
+
 def dem_matrices(dem):
     """Dense (H_dem, L): detectors x mechanisms and observables x mechanisms.
     The search substrate; the witness CHECK never needs it (witness_errors is

--- a/verify/circuit_verify.py
+++ b/verify/circuit_verify.py
@@ -267,6 +267,17 @@ def verify_circuit(doc, circuits_dir):
                "regenerate it with the pinned stim version")
         if not dem_match:
             continue
+        # step 5.5 (issue #690): structural integrity of the derived DEM,
+        # the substrate every downstream consumer (witness check, refutation
+        # gate, measured-rate decoder prior) takes on faith. Deterministic
+        # linear scans; a malformed model fails here rather than corrupting
+        # a later verdict silently.
+        lint = ct.dem_lint(derived)
+        record(f"{side}_dem_structure", not lint,
+               "; ".join(lint) or "detectability, observable coverage and "
+               "probability bounds all hold")
+        if lint:
+            continue
         werrs = ct.witness_errors(derived, claim["witness"], claim["value"])
         if claim["value"] > d:
             werrs.append(f"claimed d_circ {claim['value']} exceeds code "

--- a/verify/test_circuit_verify.py
+++ b/verify/test_circuit_verify.py
@@ -263,3 +263,64 @@ def test_search_matches_witness_check():
     w, wit = ct.ris_dem(H, L, trials=8, seed=3)
     assert w is not None and w <= 5      # rounds-truncated: can only be <= d
     assert ct.witness_errors(dem, wit, w) == []
+
+
+def test_dem_lint_clean_on_reference():
+    """The reference builder's DEM must pass all three structural checks
+    (issue #690); a false positive here would block every honest entry."""
+    HX = _matrix(BASE_DOC["checks"]["X"], N)
+    HZ = _matrix(BASE_DOC["checks"]["Z"], N)
+    dem = ct.derive_dem(ct.apply_noise(
+        ct.build_css_memory(HX, HZ, rounds=2, basis="Z"), N))
+    assert ct.dem_lint(dem) == []
+
+
+def test_dem_lint_detectability():
+    # a mechanism flipping an observable with no detector = d_circ 1
+    dem = stim.DetectorErrorModel("""
+        error(0.001) D0 L0
+        error(0.001) L0
+        error(0.001) D0
+    """)
+    errs = ct.dem_lint(dem)
+    assert any(e.startswith("detectability") and "[1]" in e for e in errs), errs
+
+
+def test_dem_lint_observable_coverage():
+    # L1 declared (via the max observable index) but never flipped
+    dem = stim.DetectorErrorModel("""
+        error(0.001) D0 L0
+        detector D1
+        logical_observable L1
+    """)
+    errs = ct.dem_lint(dem)
+    assert any(e.startswith("observable_coverage") and "[1]" in e
+               for e in errs), errs
+
+
+def test_dem_lint_probability_bounds():
+    # stim refuses NaN at parse time, so construct the edge cases it allows:
+    # an exact-zero and an exact-one probability are both meaningless priors.
+    dem = stim.DetectorErrorModel("""
+        error(0) D0 L0
+        error(1) D0
+        error(0.001) D0 L0
+    """)
+    errs = ct.dem_lint(dem)
+    assert any(e.startswith("probability_bounds") and "[0, 1]" in e
+               for e in errs), errs
+
+
+def test_dem_lint_gates_the_verifier(seed, monkeypatch):
+    """A structurally broken derived DEM must fail circuit_verify at the new
+    step 5.5 and stop before the witness check."""
+    doc, cdir = seed
+    monkeypatch.setattr(ct, "dem_lint",
+                        lambda dem: ["detectability: injected failure"])
+    rep = cv.verify_circuit(doc, cdir)
+    assert not rep["ok"]
+    bad = {c["check"]: c["detail"] for c in rep["checks"] if not c["ok"]}
+    assert any(k.endswith("_dem_structure") for k in bad), bad
+    checked = [c["check"] for c in rep["checks"]]
+    assert not any(k.endswith("_witness_valid") for k in checked), (
+        "witness check ran on a malformed DEM")


### PR DESCRIPTION
Implements #690 as converged there: the three error-severity checks from emlint's taxonomy (detectability, observable coverage, probability bounds), implemented in-repo on `dem_columns` so the trusted closure gains no dependency, with emlint credited in the docstring as the source of the check taxonomy. Re-evaluating emlint as an import stays open per the issue, keyed to its certificate verifier and the warning-tier checks.

## Placement

`circuit_verify` step 5.5: after the committed `.dem` re-derivation check, before the witness check. The derived DEM is the substrate the witness check, the refutation gate, and the measured-rate tier's decoder prior all consume on faith; a malformed model now fails deterministically at the fast path instead of corrupting a later verdict. Framing per the issue discussion: the refutation gate already catches weight-1 undetected logicals probabilistically at PR time, so `detectability`'s value is determinism plus coverage on every `verify_all` run, where no search happens.

## Cost

Three linear scans over the sparse columns per basis; distance enters only through DEM length, which `MAX_DEM_MECHANISMS` bounds at 25k. Measured as part of the fast path on the seed entries: no visible change to `verify_all` wall time (369/369, both circuit entries passing through the new step).

## Tests

One synthetic violation per property, each caught by name; stim refuses NaN at parse time, so `probability_bounds` is exercised with exact 0 and exact 1, both meaningless as priors. A clean-reference test guards against false positives (a false positive here would block every honest entry), and a gating test asserts a lint failure stops the pipeline before the witness check runs.

Coordination: `circuit_verify.py`/`circuit_tools.py` are in #667's expanded manifest, so if that lands first this needs a re-pin; #684 touches `circuit_tools.py` nearby but not these lines.