### PR TITLE
Fail verification on dishonest layouts instead of silent demotion

### DIFF
--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -419,8 +419,14 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
     #          radius cannot be faked by collapsing qubits onto a point;
     #      (c) short range: the measured interaction radius (largest check
     #          diameter) is within the class cap.
-    #    Codes that fail (b)/(c), or carry no layout, are simply `unrestricted`
-    #    (no 2D-local class), not rejected. "Short range" means a bounded,
+    #    A layout that fails (b) FAILS VERIFICATION: attaching coordinates is a
+    #    locality claim, and a dishonest layout that merges green while earning
+    #    nothing is a silent footgun for batch layout submissions. Codes that
+    #    pass (b) but miss every cap in (c), or carry no layout at all, are
+    #    simply `unrestricted` (an honest long-range layout is legitimate --
+    #    unrestricted g is well defined); the computed class is surfaced as a
+    #    named check either way, so demotion is never silent.
+    #    "Short range" means a bounded,
     #    n-independent check diameter. The bilayer cap admits the weight-8 planar
     #    (tile-code) family: bulk checks span ~5.83, open-boundary corners ~6.71,
     #    both constant in n; 7.0 covers the family while rejecting layouts whose
@@ -474,12 +480,25 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
                        radius <= loc["interaction_radius"] + 1e-9,
                        f"measured {radius:.4f} <= claim "
                        f"{loc['interaction_radius']}")
+            record("site_occupancy_within_layers", max_mult <= layers,
+                   f"max {max_mult} qubit(s) per site, layers={layers}")
+            record("site_spacing_at_least_one",
+                   min_spacing >= 1.0 - 1e-9,
+                   "single occupied site" if min_spacing == float("inf")
+                   else f"min spacing between distinct sites "
+                        f"{min_spacing:.4f} (>= 1.0 required)")
             honest = max_mult <= layers and min_spacing >= 1.0 - 1e-9
             if honest:
                 for cls, max_layers, cap in LOCALITY_CLASSES:
                     if layers <= max_layers and radius <= cap + 1e-9:
                         locality_class = cls
                         break
+                caps = ", ".join(f"{c} <= {cap} at <= {ml} layer(s)"
+                                 for c, ml, cap in LOCALITY_CLASSES)
+                record("locality_class_computed", True,
+                       locality_class if locality_class != "unrestricted"
+                       else f"unrestricted: radius {radius:.4f} at {layers} "
+                            f"layer(s) meets no class cap ({caps})")
     # Layer-1 locality class (computed) + Layer-3 flags (verifier-proven only;
     # the exact-d flag is added at site-build time from certs/, since exactness
     # is certified separately, not by this trustless check).

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -185,24 +185,43 @@ def main():
               not r["ok"] and "schema_valid" in failed_checks(r))
 
         # 7b. crammed layout: collapse qubits onto a sub-unit-spaced line so the
-        #     radius looks tiny -- cramming must DENY the 2d-local class, not earn
-        #     it (a fake short range cannot buy membership)
+        #     radius looks tiny -- a dishonest layout must FAIL verification,
+        #     not silently demote to unrestricted and merge green
         d = copy.deepcopy(GOOD)
         d["locality"]["coordinates"] = [[0.001 * i, 0.0] for i in range(d["n"])]
         d["locality"].pop("interaction_radius", None)
         r = rep(d)
-        check("crammed layout does not earn a 2d-local class",
-              r["computed"]["locality_class"] == "unrestricted")
+        check("crammed layout fails verification",
+              not r["ok"]
+              and "site_spacing_at_least_one" in failed_checks(r)
+              and r["computed"]["locality_class"] == "unrestricted")
 
-        # 7c. honest spacing but long range: a check spans far beyond any cap, so
-        #     the layout earns no 2d-local class
+        # 7b'. over-occupancy: more qubits stacked on one site than declared
+        #      layers -- same dishonesty, same hard failure
+        d = copy.deepcopy(GOOD)
+        d["locality"]["coordinates"] = [[float(i // 3), 0.0]
+                                        for i in range(d["n"])]
+        d["locality"].pop("interaction_radius", None)
+        r = rep(d)
+        check("over-occupied sites fail verification",
+              not r["ok"]
+              and "site_occupancy_within_layers" in failed_checks(r)
+              and r["computed"]["locality_class"] == "unrestricted")
+
+        # 7c. honest spacing but long range: a check spans far beyond any cap.
+        #     That is a legitimate unrestricted submission, so it stays valid --
+        #     but the demotion is surfaced as a named check, never silent.
         d = copy.deepcopy(GOOD)
         d["locality"]["coordinates"] = [[float(i), 0.0] for i in range(d["n"])]
         d["locality"]["layers"] = 1
         d["locality"].pop("interaction_radius", None)
         r = rep(d)
-        check("over-radius layout does not earn a 2d-local class",
-              r["computed"]["locality_class"] == "unrestricted")
+        check("over-radius layout stays valid but is named unrestricted",
+              r["ok"]
+              and r["computed"]["locality_class"] == "unrestricted"
+              and any(c["check"] == "locality_class_computed"
+                      and "unrestricted" in c["detail"]
+                      for c in r["checks"]))
 
     # 8. malformed: missing a required field, must not crash
     d = copy.deepcopy(GOOD)

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -2,7 +2,7 @@
   "_comment": "Pinned SHA-256 of the trusted autoresearch validation stack. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
     "validate_candidate.py": "54cc54f6282506baafe1ac8f97c9f479a017a25c66b0426172ca1a4799fa2892",
-    "qldpc_verify.py": "1281f4ae9f5662585905a9666e9bcab200908b1ec535d7783167c882162c9f37",
+    "qldpc_verify.py": "71308665b86762335d71300e4a8507fff9466986ee68a5fcd1c4df72406f946f",
     "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",
     "check_validator_integrity.py": "36c248ca70d0a64fdad5548a36b15e326ee4b24e60a20e08d37499428882a195"


### PR DESCRIPTION
Closes #661.

A layout that violates site spacing >= 1 or qubits-per-site <= layers previously demoted silently to `unrestricted` and merged green. It now fails verification with named checks (`site_spacing_at_least_one`, `site_occupancy_within_layers`). An honest layout above every class cap stays valid — unrestricted g is defined — but the demotion is now surfaced via a `locality_class_computed` check detail.

Tests: crammed layout upgraded to a hard-fail assertion, new over-occupancy case, over-radius case asserts the named demotion. Scanned all 356 merged codes: none change status. `validator_manifest.json` re-pinned for the `qldpc_verify.py` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)