### PR TITLE
Site: render the circuit tier

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -657,6 +657,12 @@ font-variant-numeric:tabular-nums}}
 max-width:220px}}
 .etal{{color:var(--mut)}}
 .hexwrap{{display:inline-flex;align-items:center;margin-left:8px}}
+/* circuit-tier chip (issue #505): gear + min d_circ on rows whose
+   entry ships verified memory circuits */
+.circchip{{display:inline-flex;align-items:center;margin-left:8px;
+font-size:11px;color:var(--mut);border:1px solid var(--ln);
+border-radius:999px;padding:0 7px;line-height:16px;
+font-variant-numeric:tabular-nums}}
 .hexmark{{color:var(--ac);vertical-align:-2px}}
 .novelty{{display:inline-block;margin-left:7px;font-size:10px;line-height:1;
 padding:3px 6px;border-radius:5px;background:#fef3c7;color:#92400e;
@@ -1418,6 +1424,12 @@ def load_entries():
             "date": doc["provenance"].get("date", ""),
             "construction": doc["provenance"].get("construction", ""),
             "note_md": load_note(slug),
+            # circuit tier (issue #505): min d_circ when the entry ships
+            # verified memory circuits, plus whether a measured rate exists.
+            "d_circ": (min(v["value"] for v in
+                           (doc.get("circuit", {}).get("d_circ") or {}).values())
+                       if doc.get("circuit") else None),
+            "has_ler": bool((doc.get("circuit") or {}).get("ler")),
             "doc": doc, "cert": cert,
         })
     return entries
@@ -1973,6 +1985,59 @@ def detail_page(e):
                  '<span class=cert-no>none yet &middot; distance stands as a '
                  'self-certified upper bound (d &le;)</span></div>')
     P.append('</section>')
+
+    # circuit tier (RFC 0001, issue #505): the entry ships syndrome-extraction
+    # memory circuits and a witness-backed circuit-level distance; render what
+    # the verifier established, in the same shape as the distance section.
+    circ = doc.get("circuit")
+    if circ:
+        P.append('<section class=blk><h3>Circuit tier</h3>')
+        P.append('<div class=kv style="color:var(--mut)">syndrome-extraction '
+                 'memory circuits committed under '
+                 f'<a href="{REPO}/circuits/{e["slug"]}">circuits/'
+                 f'{e["slug"]}/</a> &middot; canonical noise recipe, '
+                 f'{circ.get("rounds")} rounds, stim '
+                 f'{html.escape(str(circ.get("stim_version", "?")))}</div>')
+        dc = circ.get("d_circ") or {}
+        vals = [dc[s]["value"] for s in ("X", "Z") if s in dc]
+        if vals:
+            eff_c = min(vals)
+            P.append(f'<div class=kv><b>d_circ</b> &le; {eff_c} '
+                     '<span class=claimed>(min over bases; penalty-only, '
+                     'clamped to &le; d)</span></div>')
+        for s in ("X", "Z"):
+            claim = dc.get(s)
+            if not claim:
+                continue
+            wit = claim.get("witness") or []
+            P.append(f'<div class=kv><b>d_circ^{s}</b> {claim["value"]} '
+                     f'&middot; fault-set witness of {len(wit)} mechanisms '
+                     f'({"claimed " + claim.get("confidence", "?")})</div>')
+            P.append(f'<details><summary>witness fault set (mechanism '
+                     f'indices in the committed .dem, {len(wit)})</summary>'
+                     f'<div class=wit>{wit}</div></details>')
+        ler = circ.get("ler")
+        if ler:
+            # measured logical error rate: the prefactor d_circ cannot see.
+            # Values verified by independent re-measurement (ler_verify).
+            for s in ("X", "Z"):
+                blk = ler.get(s)
+                if not blk:
+                    continue
+                lo, hi = blk.get("ci95", ["?", "?"])
+                P.append(
+                    f'<div class=kv><b>ler/round ({s})</b> '
+                    f'{blk["ler_per_round"]:.3g} '
+                    f'<span class=claimed>95% CI [{lo:.3g}, {hi:.3g}] '
+                    f'&middot; {blk["failures"]}/{sci_int(blk["shots"])} '
+                    f'shots &middot; decoder {html.escape(blk["decoder"])} '
+                    f'at p={blk["p"]}</span></div>')
+        else:
+            P.append('<div class=kv style="color:var(--mut)">no measured '
+                     'logical error rate yet; d_circ is a floor, and the '
+                     'measured tier records the prefactor it cannot see'
+                     '</div>')
+        P.append('</section>')
 
     # verified 2D layout (issue #289): draw the layout the locality class was
     # earned from, not just its numbers
@@ -3595,6 +3660,11 @@ def board_table(entries, records):
                f'not a novelty claim">{HEX_MARK}</span>'
                if e["origin"] != "baseline" else "")
             + novelty
+            + ((f'<span class=circchip title="circuit tier: verified '
+                f'syndrome-extraction circuits, d_circ&le;{e["d_circ"]}'
+                f'{" + measured logical error rate" if e["has_ler"] else ""}'
+                f'">&#9881;{e["d_circ"]}</span>')
+               if e["d_circ"] is not None else "")
             + f'</td><td class="typecell col-type" data-label="type">{chips(e)}</td>'
             f'<td class="num col-n" data-label="n">{e["n"]}</td>'
             f'<td class="num col-k" data-label="k">{e["k"]}</td>'


### PR DESCRIPTION
The circuit tier has been merged and verified since #646, and three entries (`25-1-5`, `49-1-7`, `81-1-9`) carry full circuit blocks, but `site/build.py` never learned the tier exists, so nothing shows on the page. This is the deferred display follow-up from #646/#680.

## What renders

Detail pages gain a Circuit tier section after the distance section, in its shape: link to the committed `circuits/<slug>/` artifacts, recipe/rounds/pinned-stim line, min d_circ with the penalty-only note, per-basis values with collapsible witness fault sets (mechanism indices in the committed `.dem`, exactly what the verifier checked). When an entry carries a measured rate, per-basis `ler/round` with 95% CI, raw counts, and the pinned decoder render below; until then the section says the floor exists and the prefactor is unmeasured.

Board rows whose entry ships circuits get a small gear chip next to the code name showing min d_circ (tooltip notes a measured rate when present). No new column, no ranking change; the chip is a pointer, not a score.

## Verification

Headless renders inspected, not just built: the `25-1-5` detail section and its board row from the real build, and the measured-rate branch against a synthetic block with the exact shape the verified end-to-end run produces (127/10^5 shots, CI, decoder id), since no merged entry can carry one until #680 and its seed measurement land. Entries without a circuit block are byte-unchanged.

Not in scope: the RFC's full presentation design (green/amber chip states, unclaimed-schedule bounty counts, a circuit score toggle). Those want the tier populated by more than seeds first.