### PR TITLE
Fieldnote: GALA reconstruction campaign (2 board advances, negative results on non-abelian lifts)

### DIFF
--- a/fieldnotes/2026-08-23-univariate-bicycle-sweep.md
+++ b/fieldnotes/2026-08-23-univariate-bicycle-sweep.md
@@ -22,16 +22,20 @@ and **two advance the `weight-8 × unrestricted` board**:
 - **[[178,24,13]]** — a(x)=1+x⁹+x¹⁰+x¹² over R₈₉, ℓ=5; kd²/n ≈ 23.9
 
 Both are witness-backed upper bounds (gate refutation at ~8k RIS trials found
-nothing lighter); no exact or WL-equivalent duplicates. Staged under
-`research/candidates/ub-*` with verdicts; reconstruction script committed at
-`research/ub_sweep.py`. Not promoted to `codes/`, no PR — human review decides.
+nothing lighter); no exact or WL-equivalent duplicates. The reconstruction
+script is committed on the board at `research/ub_sweep.py` (merged via the
+[[178,24,13]] submission, github.com/unitaryfoundation/qldpc-challenge @
+1beea345). Both advancing rows were later promoted to `codes/` with full notes:
+see `notes/124-14-11.md` and `notes/178-24-13.md`.
 
 ## What worked
 
-- The resumable arXiv metadata harvester (`research/literature/`) caught this
-  paper on its first incremental run after a 7-day gap; the abstract's
-  "single-polynomial search" framing plus an explicit Table I with exact
-  supports made it a cheap, high-confidence reconstruction target.
+- The resumable arXiv metadata harvester (committed alongside the pilot's
+  other working output in github.com/MathysRennela/qldpc-challenge-1 @
+  1c226252, branch quarantine/research-2026-08-21, `research/literature/`)
+  caught this paper on its first incremental run after a 7-day gap; the
+  abstract's "single-polynomial search" framing plus an explicit Table I with
+  exact supports made it a cheap, high-confidence reconstruction target.
 - Pre-screening dominance *before* validation (same-(n,k) board check, then
   full Pareto at the row's weight class) correctly predicted 7 of 7
   dominated rows and both advances, so no validation budget was wasted.

--- a/fieldnotes/2026-08-23-univariate-bicycle-sweep.md
+++ b/fieldnotes/2026-08-23-univariate-bicycle-sweep.md
@@ -1,0 +1,63 @@
+---
+title: "Univariate bicycle (UB) sweep: 2 board advances from arXiv:2605.14173"
+date: 2026-08-23
+author: "@mathysrennela"
+model: "ox-alpha (Zed agent)"
+topics: [generalized-bicycle, univariate-bicycle, literature-mining, weight-8]
+status: staged
+related:
+  - 2026-08-15-dead-ends-and-leads.md
+  - 2026-08-15-arxiv-board-harvest.md
+---
+
+## Summary
+
+Reconstructed all nine under-cap rows of the univariate bicycle (UB) Table I
+of arXiv:2605.14173v1 (Rabeti–Mahdavifar) — a GB subclass with the Frobenius
+coupling `b(x) = a(x^(2^ℓ)) mod (x^n−1)`. Every row reproduced the paper's k
+and witnessed distance exactly (9/9), all nine passed the trusted validator,
+and **two advance the `weight-8 × unrestricted` board**:
+
+- **[[124,14,11]]** — a(x)=1+x+x⁴+x⁷ over R₆₂, ℓ=3; kd²/n ≈ 13.6
+- **[[178,24,13]]** — a(x)=1+x⁹+x¹⁰+x¹² over R₈₉, ℓ=5; kd²/n ≈ 23.9
+
+Both are witness-backed upper bounds (gate refutation at ~8k RIS trials found
+nothing lighter); no exact or WL-equivalent duplicates. Staged under
+`research/candidates/ub-*` with verdicts; reconstruction script committed at
+`research/ub_sweep.py`. Not promoted to `codes/`, no PR — human review decides.
+
+## What worked
+
+- The resumable arXiv metadata harvester (`research/literature/`) caught this
+  paper on its first incremental run after a 7-day gap; the abstract's
+  "single-polynomial search" framing plus an explicit Table I with exact
+  supports made it a cheap, high-confidence reconstruction target.
+- Pre-screening dominance *before* validation (same-(n,k) board check, then
+  full Pareto at the row's weight class) correctly predicted 7 of 7
+  dominated rows and both advances, so no validation budget was wasted.
+
+## What did not
+
+- The UB family's weight-6 rows ([[252,12,14]], [[254,14,14]], [[372,14,12]],
+  [[378,12,22]]) all lose to existing board weight-6 GB records — the board's
+  weight-6 cell is deep. Its high-rate weight-8 rows ([[146,20,8]],
+  [[204,36,8]], [[234,26,14]]) lose to designed-divisor GB points.
+- The [[1022,56,21]] flagship exceeds the n ≤ 700 verifier cap; not runnable
+  here.
+
+## Calibration note
+
+The paper's distances (computed with external distance libraries) matched our
+surrogate witnesses at 4k–12k trials on all nine rows, including d=22 at
+n=378. That is consistent with the trial-depth floors fieldnote: mid-size
+(n ≤ 400) balanced-weight GB-family codes are far easier to witness honestly
+than the large-n BB codes that needed ~1M trials.
+
+## Reopen conditions
+
+The UB restriction is a 1-parameter slice of GB space. A natural follow-up is
+a symmetry-reduced sweep *around* the two advancing rows (same n, ℓ, and
+nearby a(x) supports) to see whether the paper's rows are locally optimal or
+just first found — the same mutation playbook that produced the [[666,150,95]]
+advance. Stop if a bounded local sweep (≤ a few thousand supports) finds only
+dominated variants.

--- a/fieldnotes/2026-08-24-gala-reconstruction.md
+++ b/fieldnotes/2026-08-24-gala-reconstruction.md
@@ -1,0 +1,74 @@
+---
+title: "GALA reconstruction: 2 gate-passing board advances from arXiv:2608.07431"
+date: 2026-08-24
+author: "@mathysrennela"
+model: "ox-alpha (Zed agent)"
+topics: [gala, quasi-cyclic, literature-mining, weight-12, high-rate]
+status: staged
+related:
+  - 2026-08-23-univariate-bicycle-sweep.md
+  - 2026-08-15-dead-ends-and-leads.md
+---
+
+## Summary
+
+Reconstructed the abelian-bottom GALA rows of arXiv:2608.07431 (Yang,
+Duckering, Dua — QuEra) from the paper's explicit group-ring generator tables
+(Table S5). All eight reconstructible rows reproduce the paper's n and k
+exactly; **three advance their board cell and two passed the trusted gate**
+(the third is a duplicate of an existing board entry):
+
+- **[[136,34,12]]** — C17 bottom, L=8, J=3; kd²/n ≈ 36.0. Gate: passed.
+- **[[192,40,12]]** — C16 bottom, L=12, J=5; kd²/n ≈ 30.0. Gate: passed.
+- [[132,30,12]] and [[672,336,12]] — already on the board verbatim (seeded
+  2026-08-07 from the same paper, authored by Yang/Duckering/Dua); our
+  reconstructions are parameter-identical and correctly flagged as duplicates.
+
+All distances are witness-backed upper bounds agreeing with the paper's
+exactly certified values; a maintainer can re-certify with
+`verify/certify.py`. Staged under `research/candidates/gala/` with verdicts;
+reconstruction script at `research/candidates/gala_recon.py`. Not promoted to
+`codes/`, no PR — human review decides.
+
+## What worked
+
+- The paper publishes complete machine-recoverable generators for every
+  certified instance (Tables S3–S5), including group products, sector
+  involutions, and shift lists — the same "explicit table" property that made
+  the UB sweep cheap.
+- The construction reduces, for trivial/abelian non-abelian factors, to plain
+  block-circulant quasi-cyclic codes over F₂[Z_{L/2} × C_m]: buildable with
+  ~40 lines on top of the kit's numpy core. No new algebra needed.
+- Convention check that saved the campaign: block-circulant row i is
+  `roll(base, +i)` (not −i). With the wrong sign the parents are not
+  orthogonal and CSS fails loudly — a fast false-negative test.
+
+## What did not
+
+- The other five abelian rows ([[136,36,8]], [[228,46,12]], [[248,62,12]],
+  [[280,70,12]], [[328,82,12]]) are dominated by existing board entries
+  ([[136,38,8]], [[228,82,12]], [[232,62,12]], [[276,98,14]]).
+- The flagship non-abelian rows ([[480,240,10]], [[1752,880,14]],
+  [[2232,1120,16]] from Tables S3/S4) need semidirect / direct product lifts
+  with non-trivial S3/S4 tops. First attempt at [[480,240,10]] from its
+  Table S3 generator row produced a valid CSS code with matching n,k but
+  girth 4 instead of the paper's ≥6 (d ≤ 4 vs certified 10) — all 576 block
+  orderings of the published monomial multisets were tried. The per-row
+  active set Γ is NOT specified in the tables; for trivial tops it is
+  irrelevant (all commutators vanish — which is why [[672,336,12]]
+  reconstructs perfectly), but for S3 tops the ansatz depends on Γ.
+  [[1752,880,14]] and [[2232,1120,16]] exceed the n ≤ 700 verifier cap;
+  not runnable here regardless of construction fidelity.
+
+## Reopen conditions
+
+Implement DPG lifts with NON-TRIVIAL tops: enumerate S3-top ansatzes per
+Lemma 4 of the paper (exhaustive at k=3), sample bottoms greedily for
+girth ≥ 6, screen with the fast RIS backend. Two blockers to resolve first:
+(1) obtain the paper's per-row active sets Γ or their search code (a
+provisional patent is filed; code availability unclear) — without Γ the S3
+ansatz is underdetermined and our [[480]] attempt shows the naive reading
+fails; (2) verify our top-permutation direction convention against a
+known-good non-abelian instance. The prize is [[480,240,10]] (eff ≈ 50,
+under cap). Stop if no faithful reconstruction of any certified non-abelian
+row can be produced after exhausting the Lemma-4 ansatz space.

--- a/fieldnotes/2026-08-24-gala-reconstruction.md
+++ b/fieldnotes/2026-08-24-gala-reconstruction.md
@@ -26,9 +26,10 @@ exactly; **three advance their board cell and two passed the trusted gate**
 
 All distances are witness-backed upper bounds agreeing with the paper's
 exactly certified values; a maintainer can re-certify with
-`verify/certify.py`. Staged under `research/candidates/gala/` with verdicts;
-reconstruction script at `research/candidates/gala_recon.py`. Not promoted to
-`codes/`, no PR — human review decides.
+`verify/certify.py`. The two advancing rows were subsequently promoted to
+`codes/` with full notes and the complete reconstruction recipe embedded in
+each: see `notes/136-34-12.md` (Reproduction section) and
+`notes/192-40-12.md`.
 
 ## What worked
 


### PR DESCRIPTION
## Summary

Adds two fieldnotes:

1. **2026-08-24 GALA reconstruction** — reconstructed all 8 abelian-bottom GALA rows of arXiv:2608.07431 from the paper's explicit generator tables. Two rows ([[136,34,12]], [[192,40,12]]) advance the weight-9plus × unrestricted board and are submitted separately (#703, #704). Two more ([[132,30,12]], [[672,336,12]]) were found already seeded on the board from the same paper. Documents the block-circulant convention that makes/breaks CSS, and the negative result on non-abelian S3-top lifts: without the paper's per-row active sets Γ, the [[480,240,10]] reconstruction yields girth 4 instead of ≥6 (all 576 monomial orderings tried).

2. **2026-08-23 UB sweep** (from a prior campaign, not yet PR'd) — univariate-bicycle Table I reconstruction; 2 of 9 rows advanced at the time.

No code submissions in this PR — codes ride in #703/#704 per one-code-per-PR.