### PR TITLE
Take the accelerator's witness instead of re-finding it in Python

### DIFF
--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -136,6 +136,27 @@ def build_submission(HX, HZ, args):
     if dX is None or dZ is None:
         raise SystemExit("RIS found no logical operator on one side; "
                          "cannot certify a distance")
+    # Let the C++ accelerator tighten the claim when it can. The Python search
+    # slows sharply with n, so on a large code it stops far above the lightest
+    # logical and the entry would claim a distance the submitter can already
+    # disprove. Anything the accelerator returns is checked by gf2 before it is
+    # used, and it is only adopted when it is strictly lighter.
+    if hd._fast is not None and args.fast_trials > 0:
+        print(f"  accelerator pass ({args.fast_trials} trials)...", flush=True)
+        wf, side, sup = hd._fast.distance_rand_witness(
+            HX, HZ, args.fast_trials, args.seed, 8, 8)
+        if wf is not None and side in ("X", "Z"):
+            v = np.zeros(n, dtype=np.int8)
+            v[list(sup)] = 1
+            H_ker, H_row = (HZ, HX) if side == "X" else (HX, HZ)
+            cur = dX if side == "X" else dZ
+            if int(v.sum()) < cur and hd._valid_logical(v, H_ker, H_row):
+                if side == "X":
+                    dX, witX = int(v.sum()), v
+                else:
+                    dZ, witZ = int(v.sum()), v
+                print(f"    accelerator tightened d_{side} to {int(v.sum())}",
+                      flush=True)
     d = min(dX, dZ)
     print(f"  distance (RIS upper bound) d<={d}  (d_X<={dX}, d_Z<={dZ})",
           flush=True)
@@ -638,6 +659,9 @@ def main(argv=None):
                         "(1 = single layer, 2 = bilayer); default 1")
     s.add_argument("--trials", type=int, default=20000,
                    help="RIS trials for the distance witness search")
+    s.add_argument("--fast-trials", type=int, default=2_000_000,
+                   help="gf2_fast trials used to tighten the claim "
+                        "(0 disables the accelerator)")
     s.add_argument("--seed", type=int, default=0)
     s.add_argument("--out", default=os.path.join(_ROOT, "codes"))
     s.add_argument("--force", action="store_true",

--- a/verify/heuristic_distance.py
+++ b/verify/heuristic_distance.py
@@ -92,6 +92,18 @@ def ris_min_logical(HX, HZ, trials, seed, pair_depth=8, max_seconds=None):
     return best, wit
 
 
+def _valid_logical(v, H_ker, H_row):
+    """Report whether v is a nontrivial logical operator.
+
+    True when v lies in ker(H_ker) and outside rowspace(H_row). Used to check
+    anything the C++ accelerator hands back before it is recorded, so an
+    accelerator bug cannot put an unbacked witness into a verdict.
+    """
+    if v.sum() == 0 or ((H_ker @ v) % 2).any():
+        return False
+    return gf2.rank(np.vstack([H_row, v[None, :]])) > gf2.rank(H_row)
+
+
 def estimate(doc, trials=20000, seed=0, fast_trials=400000, max_seconds=None):
     """Heuristic distance verdict for a submission `doc`.
 
@@ -129,16 +141,28 @@ def estimate(doc, trials=20000, seed=0, fast_trials=400000, max_seconds=None):
               f"(fast_trials=0 disables it deliberately)", file=sys.stderr)
     # Optional C++ accelerator: a larger overall search (min over both sides).
     if _fast is not None and fast_trials > trials:
-        d_fast = int(_fast.distance_rand_parallel(HX, HZ, fast_trials, seed, 8, 8))
-        if d_heur is None or d_fast < d_heur:
-            d_heur = d_fast                # a lighter logical exists; python re-finds
-            # extract a witness at the tighter weight via a focused python pass
-            for H_a, H_b, key in ((HX, HZ, "X"), (HZ, HX, "Z")):
-                w, wit = ris_min_logical(H_a, H_b, trials * 4, seed + 7)
-                if w is not None and w <= d_fast:
-                    sides.setdefault(key, {})
-                    sides[key].update(lightest_found=w,
-                                      witness=sorted(int(j) for j in np.nonzero(wit)[0]))
+        # Take the witness straight from the accelerator rather than asking the
+        # Python pass to re-find it. The re-find never worked at large n: the
+        # accelerator is orders of magnitude faster per trial, so a budget that
+        # lets it reach weight w leaves the Python pass far short of w, and the
+        # tighter weight was recorded with no witness to back it.
+        d_fast, side, sup = _fast.distance_rand_witness(HX, HZ, fast_trials,
+                                                        seed, 8, 8)
+        d_fast = int(d_fast) if d_fast is not None else None
+        if d_fast is not None and (d_heur is None or d_fast < d_heur):
+            d_heur = d_fast
+            if side in ("X", "Z"):
+                wit = np.zeros(n, dtype=np.int8)
+                wit[list(sup)] = 1
+                # Validate before recording: the accelerator is not the trusted
+                # stack, so a witness only counts once gf2 agrees it is in the
+                # right kernel and outside the opposite rowspace.
+                H_ker, H_row = (HZ, HX) if side == "X" else (HX, HZ)
+                if _valid_logical(wit, H_ker, H_row):
+                    sides.setdefault(side, {})
+                    sides[side].update(
+                        lightest_found=int(wit.sum()),
+                        witness=sorted(int(j) for j in np.nonzero(wit)[0]))
         method = "ris+gf2_fast"
         trials = max(trials, fast_trials)
 

--- a/verify/test_heuristic_distance.py
+++ b/verify/test_heuristic_distance.py
@@ -19,6 +19,8 @@ import glob
 import json
 import os
 import sys
+import numpy as np
+
 import heuristic_distance as H
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -141,3 +143,45 @@ def test_main():
 
 if __name__ == "__main__":
     main(sys.argv[1:])
+
+
+def test_accelerator_witness_is_recorded_and_valid():
+    """Check that an accelerator find is recorded with a valid witness.
+
+    When the accelerator finds a lighter logical, the verdict must carry a
+    witness at that weight, and the witness must survive gf2 validation.
+    """
+    doc = json.load(open(os.path.join(ROOT, "codes", "144-12-12.json")))
+    if H._fast is None:
+        print("  gf2_fast unavailable; skipping")
+        return
+    res = H.estimate(doc, trials=200, seed=0, fast_trials=200_000)
+    assert res["method"] == "ris+gf2_fast"
+    d = res["d_heuristic"]
+    assert d is not None
+    backed = [s for s, blk in res["sides"].items()
+              if blk.get("witness") and blk.get("lightest_found") == d]
+    assert backed, f"no witness recorded at the reported weight {d}: {res['sides']}"
+    n = doc["n"]
+    HX = H._matrix(doc["checks"]["X"], n)
+    HZ = H._matrix(doc["checks"]["Z"], n)
+    for side in backed:
+        v = np.zeros(n, dtype=np.int8)
+        v[res["sides"][side]["witness"]] = 1
+        H_ker, H_row = (HZ, HX) if side == "X" else (HX, HZ)
+        assert H._valid_logical(v, H_ker, H_row), f"{side} witness invalid"
+    print(f"  accelerator witness ok: d={d}, sides backed={backed}")
+
+
+def test_valid_logical_rejects_stabilizer_and_nonkernel():
+    """Reject a stabilizer row and a vector outside the kernel."""
+    doc = json.load(open(os.path.join(ROOT, "codes", "144-12-12.json")))
+    n = doc["n"]
+    HX = H._matrix(doc["checks"]["X"], n)
+    HZ = H._matrix(doc["checks"]["Z"], n)
+    assert not H._valid_logical(HX[0].astype(np.int8), HZ, HX), "stabilizer accepted"
+    bad = np.zeros(n, dtype=np.int8)
+    bad[0] = 1
+    if ((HZ @ bad) % 2).any():
+        assert not H._valid_logical(bad, HZ, HX), "non-kernel vector accepted"
+    assert not H._valid_logical(np.zeros(n, dtype=np.int8), HZ, HX), "zero accepted"

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -3,7 +3,7 @@
   "files": {
     "validate_candidate.py": "54cc54f6282506baafe1ac8f97c9f479a017a25c66b0426172ca1a4799fa2892",
     "qldpc_verify.py": "71308665b86762335d71300e4a8507fff9466986ee68a5fcd1c4df72406f946f",
-    "heuristic_distance.py": "ec313b3aa64327de717a333182f5d3d7eae4e7a2c6ab2448fca86f2770f8a9c7",
+    "heuristic_distance.py": "57d9e56ce8a409e6cb1a63f48e98878624f0df611b8578c32839b7bfd00989fe",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",
     "check_validator_integrity.py": "36c248ca70d0a64fdad5548a36b15e326ee4b24e60a20e08d37499428882a195"
   }


### PR DESCRIPTION
## What this changes

In `heuristic_distance.estimate`, the optional `gf2_fast` branch now takes
its witness directly from `distance_rand_witness` rather than calling
`distance_rand_parallel` for a weight and then asking a focused pure-Python
RIS pass to re-find a witness at that weight.

## Why the old path could not work

The re-find is attempted at `trials * 4` pure-Python trials. That pass is
orders of magnitude slower per trial than the accelerator, so any budget
large enough for the accelerator to reach weight `w` leaves the Python pass
far short of `w`. Measured on a 674-qubit generalized-bicycle code:

- pure-Python `ris_min_logical`: 77 ms/trial, reaching `d <= 91` after 300
  trials on the X side and `d <= 95` on the Z side;
- `gf2_fast` witness search: `d <= 76`, with the witness validated against
  `gf2` (in the correct kernel, raises the opposite check matrix rank from
  252 to 253).

So on codes where the accelerator earns its keep, `d_heuristic` was being
set to the tighter weight while `sides` kept a witness from the earlier,
weaker pass, or no witness at all. The verdict was still sound, since it
turns on the weight, but nothing recorded backed the number.

## Safety

Anything the accelerator returns is checked by `gf2` before it is recorded:
nonzero, in `ker(H_ker)`, and outside `rowspace(H_row)`. The compiled
extension is not part of the trusted stack, and a witness only counts once
the trusted stack agrees it is one. That guard is exported as
`_valid_logical` and tested directly against a stabilizer row, a
non-kernel vector, and the zero vector.

## Scope

`refute_check` calls `estimate` with `fast_trials=0`, so the accelerator
branch is skipped and the CI gate remains pure Python with a fixed seed and
unchanged behaviour. The warning path for `0 < fast_trials <= trials` is
also unchanged.

## Follow-up, not included here

Generalized-bicycle codes have a reversal symmetry that maps a logical on
one side to a logical of equal weight on the other: swap the two circulant
blocks and reverse each, since conjugating a circulant by the reversal
permutation transposes it. Since the accelerator reports the best logical
across both sectors and only says which sector won, that symmetry gives the
opposite side's witness with no additional search on this family. Worth a
separate PR once it has been checked against more of the board's 2BGA
entries than the one code it was derived on.
