### PR TITLE
Add [[12,2,3]] SAT-solver code discovery

### DIFF
--- a/codes/12-2-3.json
+++ b/codes/12-2-3.json
@@ -1,0 +1,103 @@
+{
+ "schema_version": "0.1",
+ "name": "[[12,2,3]]",
+ "code_type": "CSS",
+ "n": 12,
+ "k": 2,
+ "checks": {
+  "X": [
+   [
+    0,
+    2,
+    4,
+    9
+   ],
+   [
+    0,
+    6,
+    7,
+    8
+   ],
+   [
+    1,
+    2,
+    3,
+    10
+   ],
+   [
+    1,
+    7,
+    8,
+    11
+   ],
+   [
+    3,
+    5,
+    7,
+    9
+   ]
+  ],
+  "Z": [
+   [
+    4,
+    7,
+    8,
+    9
+   ],
+   [
+    2,
+    5,
+    9,
+    10
+   ],
+   [
+    0,
+    5,
+    6,
+    9
+   ],
+   [
+    1,
+    3,
+    6,
+    7
+   ],
+   [
+    1,
+    2,
+    4,
+    11
+   ]
+  ]
+ },
+ "distance": {
+  "d": 3,
+  "X": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    0,
+    3,
+    6
+   ]
+  },
+  "Z": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    5,
+    7,
+    8
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@MathysRennela"
+  ],
+  "construction": "SAT-solver code discovery (arXiv:2608.23460 Sec. VI adapted to CSS): Minisat22 CNF over X/Z row-incidence variables; even-overlap commutation chains, weight<=2 detection clauses, Sinz row-weight bound w<=4; solution enumeration via blocking clauses.",
+  "origin": "submission",
+  "date": "2026-08-25"
+ },
+ "family": "other"
+}

--- a/notes/12-2-3.md
+++ b/notes/12-2-3.md
@@ -1,0 +1,67 @@
+# [[12,2,3]] — SAT-solver code discovery (weight-4 CSS)
+
+## Direction & hypothesis
+
+Weight-4 × unrestricted cell, approached by *satisfiability* rather than by a
+parametrized family: following DalFavero et al. (arXiv:2608.23460, Sec. VI),
+formulate "find an [[n,k]] CSS code with all check weights ≤ w that detects
+every Pauli error of weight ≤ t" directly as CNF and let a complete solver
+enumerate solutions. Hypothesis: a SAT generator explores a different region
+of code space than polynomial/group-algebra families and might land on
+non-dominated small codes the algebraic sweeps miss.
+
+## What was searched
+
+`research/sat_search.py` (committed in this PR): Minisat22 over X/Z row
+incidence variables; even-overlap commutation chains encoding `HX·HZᵀ = 0`;
+per-error detection clauses requiring some row with odd symplectic overlap;
+Sinz sequential-counter bound w ≤ 4 per row; distinct solutions enumerated via
+blocking clauses. Errors that would be stabilizer elements (zero syndrome) are
+rejected post-hoc rather than via slack variables.
+
+Sweeps at t=2 (d ≥ 3 target): (n, rows) ∈ {(12,5), (14,6), (16,7), (18,8)},
+60 solutions each (~2–4 s per sweep). Survivors screened with the kit funnel
+(`search.screen`, 400 RIS trials).
+
+## Evidence trail
+
+Submitted [[12,2,3]]: witness d_X ≤ 3 and d_Z ≤ 3 found by `qldpc submit`
+(20k RIS trials); local gate passed (`validate_candidate` → passed, weight-4 ×
+unrestricted, board-advancing per its Pareto check). Claim is an honest
+**upper bound**, not exact. Companion [[14,2,3]] from the same generator is
+submitted separately.
+
+## Dead ends
+
+- First encoding modeled generators as general Paulis split into CSS rows —
+  wrong detection semantics (it rejected the Steane code). Fixed by giving
+  X-rows and Z-rows separate variable families.
+- Requiring nonzero syndrome for *all* weight-≤t errors is unsound: stabilizer
+  elements legitimately have zero syndrome. Every t=2 instance came back
+  spuriously UNSAT until absorbed errors were handled.
+- CPython `id()` reuse silently shared one weight counter across rows (codes
+  came out weight-8 despite w≤4); caught because the verifier's computed
+  weight class disagreed with the CNF bound.
+- Dense-check instances solve instantly but always give k=0; bounding weight
+  is precisely what makes the search hard. Instances right at the
+  satisfiability boundary ran past 90 s while neighbors solved in 0.1 s —
+  the paper's phase transition, observed live.
+
+## Tools
+
+ox-alpha agent; repo kit (`search.screen`, `submit`, `verify/validate_candidate`);
+python-sat / Minisat22. All runs on a laptop, seconds per sweep.
+
+## Reproduction
+
+```
+uv run --with python-sat python - <<'EOF'
+import sys
+sys.path.insert(0, "research"); sys.path.insert(0, "research/kit")
+from sat_search import enumerate_sat_codes
+spec, HX, HZ = next(iter(enumerate_sat_codes(12, 5, 4, 2, max_codes=1)))
+EOF
+```
+
+Parameters: n=12, 5 rows per side, max row weight 4, detect-all weight-≤2
+errors. The first solution is the submitted code.

--- a/research/sat_search.py
+++ b/research/sat_search.py
@@ -1,0 +1,280 @@
+"""SAT-based CSS code discovery (DalFavero et al., arXiv:2608.23460, Sec. VI),
+with the group-membership slack handled the CSS way.
+
+Formulates "find an [[n, k]] CSS code whose checks all have weight <= w and
+which detects every Pauli error of weight <= t" as CNF:
+
+  variables
+    xr[g][q] -- X-check row g acts with X on qubit q
+    zr[g][q] -- Z-check row g acts with Z on qubit q
+
+  commutation: HX HZ^T = 0, i.e. every (X-row, Z-row) pair overlaps on an even
+    number of qubits (per-pair XOR parity chains).
+
+  detection of error e=(xe|ze): e must have nonzero syndrome OR lie in the
+    stabilizer group. For CSS codes "in the stabilizer" means xe in rowspace(HZ)
+    ... more precisely e is undetected iff xe is in rowspace(HZ) AND ze in
+    rowspace(HX). Encoding rowspace membership directly needs slack variables
+    over GF(2) products; instead we use the equivalent *distance* form:
+    e is detected iff (HX ze != 0) or (HZ xe != 0), where HX ze != 0 means some
+    X-row has odd overlap with ze. We encode "odd overlap" per row with XOR
+    parity chains and require at least one odd row overall -- but we do NOT
+    require it for errors that are stabilizer elements. Since enumerating
+    stabilizer membership is complex, we take the paper's route: require
+    detection for all errors EXCEPT allow each error an "absorbed" escape hatch
+    via slack literals s[g] marking that error as a product of rows. To keep
+    the encoding sound and simple, we instead only enumerate errors up to
+    weight t and require nonzero syndrome for all of them; this is exactly
+    right whenever the resulting code has no weight-<=t stabilizers, which we
+    CHECK after decoding (rejecting any assignment where some weight-<=t error
+    has zero syndrome -- those are precisely the absorbed ones).
+
+  weight bound: Sinz sequential counter over active qubits per row.
+
+Any satisfying assignment decodes to CSS (HX, HZ); assignments where a
+weight-<=t error lands in the stabilizer group are rejected post-hoc (they
+would be valid codes too, just not certified by this clause set). Distinct
+solutions are enumerated with blocking clauses.
+
+Distance is NOT decided here -- yielded codes go through the normal witness +
+validation-gate pipeline like everything else in this repo.
+
+Usage:
+
+    from sat_search import enumerate_sat_codes, search_sat_codes
+
+    recs = search_sat_codes(n=10, n_generators=5, max_weight=4, t=2,
+                            count=200, seed=7, min_k=4, min_d=4)
+
+Requires ``python-sat`` (``uv run --with python-sat python ...``).
+"""
+import itertools
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "kit"))
+
+try:
+    from pysat.solvers import Minisat22
+    _HAS_PYSAT = True
+except ImportError:
+    _HAS_PYSAT = False
+
+
+def _seq_counter(lits, bound, A, tag):
+    """Sinz sequential counter: at most ``bound`` of ``lits`` may be true.
+    ``tag`` must be unique per call (aux-variable namespace)."""
+    n = len(lits)
+    if bound >= n:
+        return []
+    s = [[A(("s", tag, i, j)) for j in range(bound)] for i in range(n)]
+    cls = []
+    cls.append([-lits[0], s[0][0]])
+    cls.append([-s[0][0], lits[0]])
+    for j in range(1, bound):
+        cls.append([-s[0][j]])
+    for i in range(1, n):
+        cls.append([s[i][0], -lits[i]])
+        cls.append([s[i][0], -s[i - 1][0]])
+        cls.append([-s[i][0], lits[i], s[i - 1][0]])
+        for j in range(1, bound):
+            cls.append([s[i][j], -lits[i], -s[i - 1][j - 1]])
+            cls.append([s[i][j], -s[i - 1][j]])
+            cls.append([-s[i][j], s[i - 1][j], lits[i]])
+            cls.append([-s[i][j], s[i - 1][j], s[i - 1][j - 1]])
+        cls.append([-lits[i], -s[i - 1][bound - 1]])
+    return cls
+
+
+def _xor_chain(lits, A, tag):
+    """CNF for a literal equal to the XOR of ``lits``; returns (clauses, out)."""
+    cls = []
+    prev = None
+    for i, lit in enumerate(lits):
+        cur = A((tag, i))
+        if prev is None:
+            cls.append([-cur, lit])
+            cls.append([cur, -lit])
+        else:
+            cls.append([-cur, prev, lit])
+            cls.append([-cur, -prev, -lit])
+            cls.append([cur, -prev, lit])
+            cls.append([cur, prev, -lit])
+        prev = cur
+    return cls, prev
+
+
+def enumerate_sat_codes(n, n_generators, max_weight, t, *, seed=0,
+                        max_codes=None):
+    """Yield ``(spec, HX, HZ)`` for distinct CSS codes found by SAT.
+
+    Parameters
+    ----------
+    n            : number of physical qubits
+    n_generators : rows sought in EACH of HX and HZ
+    max_weight   : per-row weight bound (active qubits <= max_weight)
+    t            : code must detect every Pauli error of weight <= t
+                   (errors that would be stabilizer elements cause rejection)
+    seed         : reserved for reproducibility bookkeeping in spec
+    max_codes    : stop after this many codes
+
+    Each spec is rebuildable:
+    {"family": "sat-css", "n", "n_generators", "max_weight", "t", "seed",
+     "index"}.
+    """
+    if not _HAS_PYSAT:
+        raise ImportError("sat_search needs python-sat")
+
+    aux = {}
+
+    def A(name):
+        return aux.setdefault(name, len(aux) + 1)
+
+    # --- errors: all nontrivial Paulis of weight 1..t as (xe_bits, ze_bits)
+    def iter_errors():
+        for w in range(1, t + 1):
+            for support in itertools.combinations(range(n), w):
+                for comps in itertools.product((1, 2, 3), repeat=w):
+                    xe = np.zeros(n, dtype=np.int8)
+                    ze = np.zeros(n, dtype=np.int8)
+                    for q, c in zip(support, comps):
+                        if c in (1, 3):
+                            xe[q] = 1
+                        if c in (2, 3):
+                            ze[q] = 1
+                    yield tuple(xe), tuple(ze)
+
+    G = n_generators
+    xr = {(g, q): A(("xr", g, q)) for g in range(G) for q in range(n)}
+    zr = {(g, q): A(("zr", g, q)) for g in range(G) for q in range(n)}
+
+    clauses = []
+
+    # --- commutation: even overlap between every X-row g1 and Z-row g2
+    for g1 in range(G):
+        for g2 in range(G):
+            pair_lits = []
+            for q in range(n):
+                p = A(("ov", g1, g2, q))          # p <-> xr[g1,q] & zr[g2,q]
+                clauses.append([-p, xr[(g1, q)]])
+                clauses.append([-p, zr[(g2, q)]])
+                clauses.append([p, -xr[(g1, q)], -zr[(g2, q)]])
+                pair_lits.append(p)
+            ch, out = _xor_chain(pair_lits, A, ("par", g1, g2))
+            clauses.extend(ch)
+            if out is not None:
+                clauses.append([-out])             # final parity must be 0
+
+    # --- detection: for each error, SOME X-row has odd overlap with ze OR
+    #     SOME Z-row has odd overlap with xe.
+    #     Per X-row g: odd overlap with ze <=> XOR_q (xr[g,q] & ze[q]) = 1.
+    #     Conjoin the fixed ze bits into per-(g,q) literals, then XOR-chain.
+    for e_idx, (xe, ze) in enumerate(iter_errors()):
+        lits = []
+        for g in range(G):
+            row_lits = []
+            for q in range(n):
+                if ze[q]:
+                    row_lits.append(xr[(g, q)])
+            if row_lits:
+                if len(row_lits) == 1:
+                    lits.append(row_lits[0])
+                else:
+                    ch, out = _xor_chain(row_lits, A, ("dx", g, e_idx))
+                    clauses.extend(ch)
+                    lits.append(out)
+        for g in range(G):
+            row_lits = []
+            for q in range(n):
+                if xe[q]:
+                    row_lits.append(zr[(g, q)])
+            if row_lits:
+                if len(row_lits) == 1:
+                    lits.append(row_lits[0])
+                else:
+                    ch, out = _xor_chain(row_lits, A, ("dz", g, e_idx))
+                    clauses.extend(ch)
+                    lits.append(out)
+        if lits:
+            clauses.append(list(lits))
+
+    # --- weight bound per row
+    for side, varmap in enumerate((xr, zr)):
+        for g in range(G):
+            act = []
+            for q in range(n):
+                a = A(("act", side, g, q))
+                v = varmap[(g, q)]
+                clauses.append([-a, v])          # a -> v
+                clauses.append([-v, a])          # v -> a
+                act.append(a)
+            clauses.extend(_seq_counter(act, max_weight, A,
+                                        tag=("w", side, g)))
+
+    # --- symmetry breaking: first X-row starts with an X on qubit 0
+    clauses.append([xr[(0, 0)]])
+
+    own_vars = set(aux.values())
+    solver = Minisat22(bootstrap_with=clauses)
+    try:
+        count = 0
+        while max_codes is None or count < max_codes:
+            if not solver.solve():
+                break
+            model = {abs(m) for m in solver.get_model() if m > 0}
+            HX = np.zeros((G, n), dtype=np.int8)
+            HZ = np.zeros((G, n), dtype=np.int8)
+            for g in range(G):
+                for q in range(n):
+                    HX[g, q] = 1 if xr[(g, q)] in model else 0
+                    HZ[g, q] = 1 if zr[(g, q)] in model else 0
+            block = [-v for v in own_vars if v in model]
+
+            # reject degenerate rows (schema requires non-empty checks)
+            if (HX.sum(axis=1) == 0).any() or (HZ.sum(axis=1) == 0).any():
+                solver.add_clause(block)
+                continue
+
+            # reject assignments where some weight-<=t error has zero syndrome
+            # (that error would be a stabilizer element, not "detected")
+            ok = True
+            for xe, ze in iter_errors():
+                xev = np.array(xe, dtype=np.int8)
+                zev = np.array(ze, dtype=np.int8)
+                if not ((HX @ zev) % 2).any() and not ((HZ @ xev) % 2).any():
+                    ok = False
+                    break
+            if not ok:
+                solver.add_clause(block)
+                continue
+
+            spec = {"family": "sat-css", "n": n, "n_generators": G,
+                    "max_weight": max_weight, "t": t, "seed": seed,
+                    "index": count}
+            yield (spec, HX, HZ)
+            count += 1
+            solver.add_clause(block)
+    finally:
+        solver.delete()
+
+
+def search_sat_codes(n, n_generators, max_weight, t, *, count=100, seed=0,
+                     min_k=4, min_d=4, trials=400, keep=25, verbose=True):
+    """Generate up to ``count`` SAT-found codes and screen them with the kit's
+    standard funnel (``search.screen``). Returns ranked records."""
+    from search import screen
+    gen = enumerate_sat_codes(n, n_generators, max_weight, t, seed=seed,
+                              max_codes=count)
+    recs = screen(gen, min_k=min_k, min_d=min_d, trials=trials)
+    if verbose:
+        print(f"SAT-CSS sweep n={n} gens={n_generators} w<={max_weight} t={t}: "
+              f"{len(recs)} survivors (k>={min_k}, d_ub>={min_d})")
+        for r in recs[:keep]:
+            print(f"  [[{r['n']},{r['k']},{r['d']}]] eff={r['efficiency']} {r['spec']}")
+    return recs[:keep]
+
+
+if __name__ == "__main__":
+    search_sat_codes(n=8, n_generators=4, max_weight=3, t=1, count=30, seed=11)


### PR DESCRIPTION
## Code submission

- Parameters: [[n, k, d]] = [[12,2,3]]
- Tracks: unrestricted / weight-4 (computed by the verifier from H and the layout)
- Distance confidence: X: upper_bound, Z: upper_bound

Family tag: other (a self-declared filter, never used for ranking).

### Checklist
- [x] One JSON file under `codes/`, conforming to `schema/code.schema.json`
- [x] Distance witness(es) included for each reported side
- [x] `python verify/qldpc_verify.py codes/12-2-3.json` passes locally
- [x] Construction and references filled in under `provenance`
- [x] Checked against existing entries: not equivalent to any current board entry (gate dedup clean; nearest weight-4 neighbors are [[7,1,3]] and [[16,2,4]], both distinct codes)

### What frontier does this advance?
Weight-4 × unrestricted cell. The only weight-4 entries at comparable size are [[7,1,3]] and [[16,2,4]]. This code sits on the d=3 frontier with k=2: it strictly extends [[7,1,3]] on k (2 > 1) at equal distance, and is not dominated by any entry ([[16,2,4]] has higher n; nothing weight-4 offers k ≥ 2 at n ≤ 12). Score kd²/n = 1.5.

Construction: SAT-solver code discovery (arXiv:2608.23460 Sec. VI adapted to CSS): Minisat22 CNF over X/Z row-incidence variables; even-overlap commutation chains, weight≤2 detection clauses, Sinz row-weight bound w≤4; solution enumeration via blocking clauses. Generator committed in this PR as `research/sat_search.py`.

Research note: `notes/12-2-3.md`
