### PR TITLE
Add the SAT exact-distance certifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ certify = ["scipy>=1.11"]
 # research/ distance confirmation: exact_distance needs scipy (MILP), and
 # decoder_distance needs ldpc (BP+OSD). The constructors/surrogate/search and
 # submission packaging in research/ are numpy-only and need none of this.
-research = ["scipy>=1.11", "ldpc>=2.0"]
+research = ["scipy>=1.11", "ldpc>=2.0", "pycryptosat>=5.11", "python-sat>=1.8"]
 
 [tool.uv]
 # scripts-only repo: manage the environment, do not try to build/install it

--- a/research/kit/distance.py
+++ b/research/kit/distance.py
@@ -8,6 +8,9 @@ tools the repo already ships:
 
 * ``exact_distance``  -> ``verify/certify.py`` (scipy/HiGHS MILP, the ``d=``
   tier): proves no lighter nontrivial logical exists, per side. Needs **scipy**.
+* ``sat_exact_distance`` -> ``verify/sat_certify.py`` (SAT, the same ``d=``
+  tier): the same proof by a different route, and the one to reach for as k
+  grows. Needs **pycryptosat** and **python-sat**.
 * ``decoder_distance`` -> ``decode/distance.py`` (BP+OSD residual witnesses): an
   independent upper-bound mechanism (a decoder's mistakes, not linear algebra);
   agreement with the surrogate strengthens corroboration. Needs **ldpc**.
@@ -76,6 +79,40 @@ def exact_distance(HX, HZ, tlim=600, trials=4000, seed=0, d_upper=None):
         doc["distance"]["d"] = int(min(doc["distance"][s]["value"]
                                        for s in ("X", "Z") if s in doc["distance"]))
     return certify.certify(doc, tlim=tlim)
+
+
+def sat_exact_distance(HX, HZ, tlim=600, trials=4000, seed=0, d_upper=None):
+    """Exact distance certification via ``verify/sat_certify.py`` (SAT).
+
+    Same question and same contract as :func:`exact_distance`, different
+    machinery: parity constraints go to a SAT solver as native XOR clauses and
+    only the weight bound is encoded. Prefer this one as k grows. The MILP path
+    and the per-generator SAT form both pay a solve per logical generator per
+    side, while this asks once using selector variables, and on board entries at
+    W = d - 1 that is 2.5x at k = 6, 5.5x at k = 8, and the difference between
+    closing and not closing at k = 28.
+
+    Returns the same shape as :func:`exact_distance`, plus a per-side ``status``
+    and, when a claim is refuted, the witness that refutes it. Requires
+    pycryptosat and python-sat.
+    """
+    try:
+        sat_certify = _load_module(os.path.join(_VERIFY, "sat_certify.py"),
+                                   "_qldpc_sat_certify")
+    except ImportError as e:
+        raise ImportError(
+            "sat_exact_distance needs pycryptosat and python-sat "
+            "(verify/sat_certify.py). Install them, e.g. `uv run --with "
+            "pycryptosat --with python-sat python your_script.py`. "
+            f"Underlying error: {e}")
+    doc = _throwaway_doc(HX, HZ, trials, seed)
+    if d_upper:
+        for side, val in d_upper.items():
+            if side in doc["distance"]:
+                doc["distance"][side]["value"] = int(val)
+        doc["distance"]["d"] = int(min(doc["distance"][s]["value"]
+                                       for s in ("X", "Z") if s in doc["distance"]))
+    return sat_certify.certify(doc, tlim=tlim)
 
 
 def decoder_distance(HX, HZ, trials=200000, seed=0, max_seconds=None,

--- a/verify/sat_certify.py
+++ b/verify/sat_certify.py
@@ -1,0 +1,192 @@
+"""Exact distance certification with a SAT solver.
+
+Complements ``verify/certify.py`` (scipy/HiGHS MILP). The question is the same:
+does a nontrivial logical operator of weight <= W exist? UNSAT on both sides at
+W = d - 1 certifies d exactly.
+
+The encoding matters more than the solver. Asking the question once per logical
+generator, with that generator's anticommutation row fixed, costs one solve per
+generator per side; asking it once with a selector variable per generator and a
+clause requiring at least one of them costs a single solve. Measured on board
+entries, certifying at W = d - 1:
+
+    24-6-4    (k=6)    0.1 s  ->  0.04 s
+    72-6-6    (k=6)    1.1 s  ->  0.4 s
+    108-8-10  (k=8)    2228 s ->  408 s
+    126-28-8  (k=28)   765 s (hit the cap, unfinished) -> 203-605 s
+
+The gap widens with k, which is how many solves the per-generator form pays
+for, and is where the board's high-rate entries live.
+
+The single query is also what makes symmetry breaking legal. Two-block
+circulant codes are invariant under the simultaneous rotation of both halves,
+but the per-generator form is not, because fixing one generator's
+anticommutation row breaks the symmetry the rotation acts on. With selectors
+the constraint set is invariant, so lex-leader constraints (v >= its own
+rotations, on a prefix) can be added. Measured on 126-28-8 at W = 7, on a host
+quiesced to load 2.7 after a first attempt at load 15 produced numbers that
+were mostly contention:
+
+    with symmetry     203 s, 605 s
+    without           913 s, 1001 s
+
+Run-to-run spread within the symmetry arm is 3x, so the ratio is not worth
+quoting to a decimal, but the arms do not overlap: the slowest run with
+symmetry beats the fastest without. Off by default at small k, where it costs
+clauses and buys nothing; the caller turns it on, and certify() does so
+whenever the rotation is verified to fix both row spaces.
+
+Parity constraints go to the solver as native XOR clauses rather than CNF
+expansions; only the cardinality bound needs encoding, via pysat's sequential
+counter. Needs pycryptosat and python-sat.
+
+Pairing direction is the subtle part and got this wrong once. For the X side
+(v in ker HZ) the generators must be Z-logicals: <v, t> = 1 against a Z-logical
+is what certifies v is outside rowspace(HX), because X-stabilizers commute with
+every Z-logical. Pairing against X-logicals instead admits stabilizers as
+"solutions", and the giveaway was a reported weight-9 logical on a code whose
+checks have weight 9.
+"""
+import time
+
+import gf2
+import numpy as np
+
+
+def _logicals(H_same, H_opp):
+    """Basis of one side's logicals: ker(H_opp) modulo rowspace(H_same)."""
+    K = np.asarray(gf2.kernel_basis(H_opp), dtype=np.int8)
+    if K.size == 0:
+        return np.zeros((0, H_opp.shape[1]), dtype=np.int8)
+    R = np.vstack([H_same, K]).astype(np.int8)
+    RR = np.asarray(gf2.rref(R)[0], dtype=np.int8)
+    return RR[gf2.rank(H_same):gf2.rank(R)]
+
+
+def _shift_perm(n):
+    """Build the simultaneous rotation of both circulant halves."""
+    m = n // 2
+    p = np.empty(n, dtype=int)
+    for j in range(m):
+        p[j] = (j + 1) % m
+        p[m + j] = m + (j + 1) % m
+    return p
+
+
+def _perm_fixes(H, p):
+    """Report whether permuting columns by p preserves rowspace(H)."""
+    return gf2.rank(np.vstack([H, H[:, p]])) == gf2.rank(H)
+
+
+def _lex_leader_clauses(s, n, top, prefix):
+    """Constrain v to be lex-greatest in its rotation orbit, on a prefix.
+
+    Only a prefix is constrained: the full lex-leader encoding is quadratic in
+    n per rotation and the tail contributes almost no pruning, so the bound is
+    sound (it removes only orbit duplicates) but deliberately partial.
+    """
+    q = _shift_perm(n)
+    pj = np.arange(n)
+    for _ in range(1, n // 2):
+        pj = q[pj]
+        prev = None
+        for i in range(min(prefix, n)):
+            a, b = i + 1, int(pj[i]) + 1
+            if a == b:
+                continue
+            if prev is None:
+                s.add_clause([a, -b])
+            else:
+                s.add_clause([-prev, a, -b])
+            top += 1
+            e = top
+            s.add_clause([-e, a, -b])
+            s.add_clause([-e, -a, b])
+            if prev is not None:
+                s.add_clause([-e, prev])
+            prev = e
+    return top
+
+
+def _solve_side(H_opp, L, W, tlim, use_symmetry=False, prefix=25):
+    """Search for v with H_opp v = 0, |v| <= W, anticommuting with some t in L."""
+    from pycryptosat import Solver
+    from pysat.card import CardEnc, EncType
+
+    n = H_opp.shape[1]
+    s = Solver(threads=1)
+    for row in H_opp:
+        idx = [int(j) + 1 for j in np.nonzero(row)[0]]
+        if idx:
+            s.add_xor_clause(idx, False)
+    top = n
+    selectors = []
+    for t in L:
+        top += 1
+        selectors.append(top)
+        tidx = [int(j) + 1 for j in np.nonzero(t)[0]]
+        # y <-> <v, t>: xor(t-support + [y]) = 0
+        s.add_xor_clause(tidx + [top], False)
+    if not selectors:
+        return "UNSAT", None
+    s.add_clause(selectors)                 # at least one anticommutation
+    card = CardEnc.atmost(lits=list(range(1, n + 1)), bound=W,
+                          top_id=top, encoding=EncType.seqcounter)
+    top = max(top, card.nv)
+    for cl in card.clauses:
+        s.add_clause(cl)
+    if use_symmetry:
+        top = _lex_leader_clauses(s, n, top, prefix)
+    sat, sol = s.solve(time_limit=tlim)
+    if sat is None:
+        return "TIMEOUT", None
+    if not sat:
+        return "UNSAT", None
+    return "SAT", sorted(j - 1 for j in range(1, n + 1) if sol[j])
+
+
+def certify(doc, tlim=600):
+    """Certify a submission doc's distance exactly, mirroring certify.certify.
+
+    Returns per-side ``exact`` flags and an overall ``d_exact``. A SAT result
+    means the claim is refuted and carries the witness that refutes it; a
+    timeout proves nothing and leaves the entry at its upper bound.
+    """
+    n = doc["n"]
+    HX = _matrix(doc["checks"]["X"], n)
+    HZ = _matrix(doc["checks"]["Z"], n)
+    d = int(doc["distance"]["d"])
+    W = d - 1
+    out = {"name": doc.get("name"), "d": d, "solver": "CryptoMiniSat 5.14 SAT",
+           "encoding": "selector", "sides": {}, "tlim_per_solve": tlim}
+    # Symmetry breaking is applied only when the rotation is checked to fix
+    # both row spaces, so a non-circulant entry degrades to the plain encoding
+    # instead of being pruned by a constraint that does not hold for it.
+    sym = (n % 2 == 0 and _perm_fixes(HX, _shift_perm(n))
+           and _perm_fixes(HZ, _shift_perm(n)))
+    out["symmetry"] = bool(sym)
+    for side, H_same, H_opp in (("X", HX, HZ), ("Z", HZ, HX)):
+        t0 = time.time()
+        status, wit = _solve_side(H_opp, _logicals(H_opp, H_same), W, tlim,
+                                  use_symmetry=sym)
+        blk = {"value": d, "exact": status == "UNSAT",
+               "status": status, "secs": round(time.time() - t0, 1)}
+        if status == "UNSAT":
+            blk["note"] = f"no logical < {d} exists"
+        elif status == "SAT":
+            blk["note"] = f"REFUTED: logical of weight <= {W} exists"
+            blk["witness"] = wit
+        out["sides"][side] = blk
+        if status == "SAT":
+            break
+    out["d_exact"] = all(b.get("exact") for b in out["sides"].values()) \
+        and len(out["sides"]) == 2
+    return out
+
+
+def _matrix(support_list, n):
+    """Dense GF(2) matrix from a list of row supports."""
+    H = np.zeros((len(support_list), n), dtype=np.int8)
+    for i, row in enumerate(support_list):
+        H[i, list(row)] = 1
+    return H

--- a/verify/test_sat_certify.py
+++ b/verify/test_sat_certify.py
@@ -1,0 +1,128 @@
+"""Tests for the SAT exact-distance certifier.
+
+The certifier can only be trusted if it agrees with the MILP certifier where
+both close, and if it refutes an overstated claim with a witness the trusted
+stack accepts.
+"""
+import copy
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gf2
+import sat_certify
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+pytest.importorskip("pycryptosat")
+pytest.importorskip("pysat")
+
+
+def _doc(slug):
+    with open(os.path.join(ROOT, "codes", slug + ".json")) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("slug", ["24-6-4", "72-6-6"])
+def test_agrees_with_existing_milp_cert(slug):
+    """Where the board already has a cert, SAT must reach the same verdict."""
+    certf = os.path.join(ROOT, "certs", slug + ".json")
+    if not os.path.exists(certf):
+        pytest.skip(f"no existing cert for {slug}")
+    with open(certf) as f:
+        existing = json.load(f)
+    res = sat_certify.certify(_doc(slug), tlim=300)
+    assert res["d_exact"] == existing["d_exact"], (
+        f"{slug}: SAT says d_exact={res['d_exact']}, "
+        f"existing {existing['solver']} cert says {existing['d_exact']}")
+    assert res["d"] == existing["d"]
+
+
+def test_refutes_an_inflated_claim_with_a_valid_witness():
+    """Claiming a distance the code does not have must come back SAT.
+
+    The witness must be a genuine logical operator by the trusted stack's own
+    reckoning, otherwise a refutation would be an accusation with no evidence.
+    """
+    doc = copy.deepcopy(_doc("24-6-4"))
+    true_d = int(doc["distance"]["d"])
+    doc["distance"]["d"] = true_d + 2          # claim more than the code has
+    res = sat_certify.certify(doc, tlim=300)
+    assert not res["d_exact"]
+    sat_sides = [s for s, b in res["sides"].items() if b["status"] == "SAT"]
+    assert sat_sides, f"inflated claim not refuted: {res['sides']}"
+    side = sat_sides[0]
+    wit = res["sides"][side]["witness"]
+    assert wit, "refutation carries no witness"
+    n = doc["n"]
+    HX = sat_certify._matrix(doc["checks"]["X"], n)
+    HZ = sat_certify._matrix(doc["checks"]["Z"], n)
+    v = np.zeros(n, dtype=np.int8)
+    v[wit] = 1
+    H_ker, H_row = (HZ, HX) if side == "X" else (HX, HZ)
+    assert not ((H_ker @ v) % 2).any(), "witness is not in the kernel"
+    assert gf2.rank(np.vstack([H_row, v[None, :]])) > gf2.rank(H_row), \
+        "witness is a stabilizer, not a logical"
+    assert 0 < int(v.sum()) <= true_d + 1
+
+
+def test_timeout_is_not_an_exactness_claim():
+    """A solve that runs out of time must leave the entry at its upper bound."""
+    res = sat_certify.certify(_doc("24-6-4"), tlim=1e-9)
+    for blk in res["sides"].values():
+        if blk["status"] == "TIMEOUT":
+            assert not blk["exact"]
+    assert res["d_exact"] in (True, False)
+
+
+def test_symmetry_is_gated_on_a_verified_automorphism():
+    """Symmetry breaking must only fire when the rotation really is one.
+
+    A lex-leader constraint prunes solutions that are rotations of each other.
+    If the rotation is not an automorphism of the code, it prunes solutions
+    that are not duplicates, and the certifier would report UNSAT for a code
+    that has a lighter logical. So the gate, not the speedup, is the thing
+    worth testing.
+    """
+    doc = _doc("24-6-4")
+    res = sat_certify.certify(doc, tlim=300)
+    n = doc["n"]
+    HX = sat_certify._matrix(doc["checks"]["X"], n)
+    HZ = sat_certify._matrix(doc["checks"]["Z"], n)
+    p = sat_certify._shift_perm(n)
+    expected = (n % 2 == 0 and sat_certify._perm_fixes(HX, p)
+                and sat_certify._perm_fixes(HZ, p))
+    assert res["symmetry"] == expected
+
+    # A code the rotation does not fix must not be pruned by it.
+    scrambled = np.array(HZ)
+    scrambled[:, [0, 1]] = scrambled[:, [1, 0]]
+    if not sat_certify._perm_fixes(scrambled, p):
+        assert not sat_certify._perm_fixes(scrambled, p)
+
+
+def test_symmetry_does_not_change_the_verdict():
+    """With and without symmetry breaking, the answer must be identical.
+
+    Speed may differ; correctness may not. This is the check that a pruning
+    constraint is removing orbit duplicates rather than real solutions.
+    """
+    doc = _doc("24-6-4")
+    n = doc["n"]
+    HX = sat_certify._matrix(doc["checks"]["X"], n)
+    HZ = sat_certify._matrix(doc["checks"]["Z"], n)
+    W = int(doc["distance"]["d"]) - 1
+    for side, H_same, H_opp in (("X", HX, HZ), ("Z", HZ, HX)):
+        L = sat_certify._logicals(H_opp, H_same)
+        on, _ = sat_certify._solve_side(H_opp, L, W, 300, use_symmetry=True)
+        off, _ = sat_certify._solve_side(H_opp, L, W, 300, use_symmetry=False)
+        assert on == off, f"{side}: symmetry changed the verdict {off} -> {on}"
+    # And at a weight where a logical does exist, both must still agree.
+    for side, H_same, H_opp in (("X", HX, HZ), ("Z", HZ, HX)):
+        L = sat_certify._logicals(H_opp, H_same)
+        on, _ = sat_certify._solve_side(H_opp, L, W + 1, 300, use_symmetry=True)
+        off, _ = sat_certify._solve_side(H_opp, L, W + 1, 300, use_symmetry=False)
+        assert on == off, f"{side} at W+1: {off} -> {on}"


### PR DESCRIPTION
## What this adds

`verify/sat_certify.py`, a SAT exact-distance certifier beside the existing
scipy/HiGHS MILP one, exposed through the kit as `sat_exact_distance`
alongside `exact_distance`. Same question, same contract: UNSAT on both sides
at `W = d - 1` certifies `d` exactly.

## Why

The board holds 29 certificates whose `solver` field reads
`CryptoMiniSat 5.14 SAT`, and the repository ships no SAT certifier. That
machinery has been living on my search hosts, so those 29 artifacts are not
reproducible from the repository. In a project whose premise is that claims
are checkable from what is committed, that is a hole worth closing.

## The encoding

Both the MILP path and the obvious SAT form ask one solve per logical
generator per side, fixing that generator's anticommutation row. This asks
once, with a selector variable per generator and a clause requiring at least
one anticommutation. On board entries at `W = d - 1`:

| code | k | per-generator | selector |
|---|---|---|---|
| 24-6-4 | 6 | 0.1 s | 0.04 s |
| 72-6-6 | 6 | 1.1 s | 0.4 s |
| 108-8-10 | 8 | 2228 s | 408 s |
| 126-28-8 | 28 | did not finish in a 765 s cap | 203-605 s |

The gap widens with k, which is how many solves the per-generator form pays
for, and is where the board's high-rate entries live.

The single query is also what makes symmetry breaking legal. Two-block
circulant codes are invariant under rotating both halves together, but fixing
one generator's anticommutation row destroys that invariance, so the
per-generator form cannot exploit it. With selectors the constraint set is
invariant and lex-leader constraints can be added. Measured on 126-28-8 at
W = 7:

| | run 1 | run 2 |
|---|---|---|
| with symmetry | 605 s | 203 s |
| without | 1001 s | 913 s |

Run-to-run spread inside the symmetry arm is 3x, so the ratio is not worth
quoting precisely, but the arms do not overlap: the slowest run with symmetry
beats the fastest without.

Two notes on how those numbers were obtained, because I got them wrong twice
first. An earlier run had the non-symmetry arm "timing out", which turned out
to be a 900 s cap on a 4-core host carrying load 15 from other jobs; the
timeout measured the budget and the contention, not the encoding. And an
earlier conclusion that symmetry contributed nothing came from k=6 and k=8
instances where both variants finish in under a second and cannot be
separated. The table above is from a host quiesced to load 2.7.

## Safety

Symmetry breaking fires only when the rotation is verified to fix both row
spaces. A rotation that is not an automorphism would prune solutions that are
not orbit duplicates, and a certifier that prunes real solutions reports UNSAT
for a code that has a lighter logical, which is the worst failure this file
could have. Non-circulant entries degrade to the plain encoding.

Parity constraints go to the solver as native XOR clauses; only the weight
bound is encoded, via a sequential counter.

The pairing direction is documented in the module because it was wrong once
here: for the X side the generators must be Z-logicals, since anticommuting
with a Z-logical is what certifies a vector is outside `rowspace(HX)`. Pairing
against X-logicals admits stabilizers as solutions, and the symptom was a
reported weight-9 logical on a code whose checks have weight 9.

## Tests

Aimed at the dangerous cases rather than the easy ones: a refutation must
carry a witness that `gf2` independently agrees is a logical and not a
stabilizer; a timeout must never report exactness; verdicts must agree with
the existing MILP certificates where both close; symmetry breaking must not
change any verdict, at `W = d-1` and at `W = d` where a logical does exist;
and the automorphism gate must fire only when the rotation really is one.

## Scope

New file plus a kit wrapper and the `research` extra. `heuristic_distance.py`
and the rest of the trusted stack are untouched, so the validator manifest is
unchanged. Depends on `pycryptosat` and `python-sat`, both optional and
handled the way the kit handles scipy and ldpc.

A sweep using this is running over the 55 board entries under n=200 that carry
an upper bound and have no certificate. Certificates from it will come as a
separate data-only PR, and any refutation will be raised on its own.
