### PR TITLE
Add [[12,2,4]] SAT code discovery

### DIFF
--- a/codes/12-2-4.json
+++ b/codes/12-2-4.json
@@ -1,0 +1,122 @@
+{
+ "schema_version": "0.1",
+ "name": "[[12,2,4]]",
+ "code_type": "CSS",
+ "n": 12,
+ "k": 2,
+ "checks": {
+  "X": [
+   [
+    0,
+    2,
+    3,
+    4,
+    5,
+    7
+   ],
+   [
+    0,
+    2,
+    3,
+    7,
+    9,
+    10
+   ],
+   [
+    3,
+    6,
+    7,
+    11
+   ],
+   [
+    1,
+    4,
+    5,
+    6,
+    8,
+    11
+   ],
+   [
+    0,
+    1,
+    3,
+    4,
+    10,
+    11
+   ]
+  ],
+  "Z": [
+   [
+    2,
+    7,
+    8,
+    9,
+    10,
+    11
+   ],
+   [
+    4,
+    5,
+    9,
+    10
+   ],
+   [
+    0,
+    3,
+    5,
+    7,
+    8,
+    9
+   ],
+   [
+    0,
+    2,
+    4,
+    6,
+    7,
+    9
+   ],
+   [
+    0,
+    1,
+    3,
+    6,
+    9,
+    10
+   ]
+  ]
+ },
+ "distance": {
+  "d": 4,
+  "X": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    0,
+    1,
+    3,
+    6
+   ]
+  },
+  "Z": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    0,
+    3,
+    6,
+    8
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@MathysRennela"
+  ],
+  "construction": "SAT code discovery (arXiv:2608.23460 Sec. VI adapted to CSS): Minisat22 CNF; even-overlap commutation chains, weight<=3 detection clauses (stabilizer-absorbed errors rejected post-hoc), Sinz row-weight bound w<=6; blocking-clause enumeration.",
+  "origin": "submission",
+  "date": "2026-08-25",
+  "model": "Ox Alpha 1.0"
+ },
+ "family": "other"
+}

--- a/notes/12-2-4.md
+++ b/notes/12-2-4.md
@@ -1,0 +1,65 @@
+# [[12,2,4]] — SAT-solver code discovery (weight-6 CSS, t=3 sweep)
+
+## Direction & hypothesis
+
+Weight-6 × unrestricted cell, from the higher-distance push of the SAT
+generator: same encoding as the [[12,2,3]] submission (DalFavero et al.,
+arXiv:2608.23460 Sec. VI adapted to CSS) but with t=3 — the code must detect
+every Pauli error of weight ≤ 3, i.e. d ≥ 4. Hypothesis: the SAT generator's
+hardness cliff sits between w≤6 (cheap) and w≤4 (intractable so far), so
+d≥4 codes should be reachable in the weight-6 cell even though weight-4
+resists.
+
+## What was searched
+
+`research/sat_search.py` (committed with the [[12,2,3]] PR #709): Minisat22
+CNF over X/Z row-incidence variables; even-overlap commutation chains
+(`HX·HZᵀ=0`); per-error detection clauses; Sinz row-weight bound; blocking-
+clause enumeration; stabilizer-absorbed errors rejected post-hoc.
+
+t=3 bisection at n=12, 5 rows/side: dense checks solve instantly (k=2);
+w≤10/8/6 all solve in 0.2–0.7 s; **w≤5 and w≤4 did not finish** — >300 s on
+Minisat22 and >600 s on CaDiCaL (a Kissat-class solver, no better here). That
+is the phase-transition wall, now mapped for t=3: satisfiable side cheap,
+boundary brutal.
+
+This sweep: 40 solutions at w≤6/t=3 (~0.3 s), screened at 2000 RIS trials.
+Four survivors had d upper bound ≥ 4, all [[12,2,4]] with efficiency 2.67;
+the first was packaged.
+
+## Evidence trail
+
+Submitted [[12,2,4]]: witness d_X ≤ 4 and d_Z ≤ 4 found by `qldpc submit`
+(20k RIS trials); local gate passed (`validate_candidate` → passed, weight-6 ×
+unrestricted, board-advancing: dominated by nothing in the cell). Claim is an
+honest **upper bound**, not exact.
+
+## Dead ends
+
+- Weight-4 × d≥4 is out of reach for this encoding: both solvers time out.
+  Fixing it likely needs proper symmetry breaking or the paper's slack-variable
+  group-membership encoding instead of post-hoc rejection of absorbed errors.
+- Earlier session bugs worth restating (full story in the [[12,2,3]] note):
+  CSS detection semantics, stabilizer-absorbed errors, and a CPython `id()`
+  reuse bug that silently disabled the weight bound — caught by the verifier's
+  computed weight class disagreeing with the CNF bound.
+
+## Tools
+
+ox-alpha agent; repo kit (`search.screen`, `submit`,
+`verify/validate_candidate`); python-sat / Minisat22 (CaDiCaL tried on the
+hard instances). Laptop, seconds per sweep.
+
+## Reproduction
+
+```
+uv run --with python-sat python - <<'EOF'
+import sys
+sys.path.insert(0, "research"); sys.path.insert(0, "research/kit")
+from sat_search import enumerate_sat_codes
+spec, HX, HZ = next(iter(enumerate_sat_codes(12, 5, 6, 3, max_codes=1)))
+EOF
+```
+
+Parameters: n=12, 5 rows per side, max row weight 6, detect-all weight-≤3
+errors. The first solution is the submitted code.


### PR DESCRIPTION
## Code submission

- Parameters: [[n, k, d]] = [[12,2,4]]
- Tracks: unrestricted / weight-6 (computed by the verifier from H and the layout)
- Distance confidence: X: upper_bound, Z: upper_bound

Family tag: other (a self-declared filter, never used for ranking).

### Checklist
- [x] One JSON file under `codes/`, conforming to `schema/code.schema.json`
- [x] Distance witness(es) included for each reported side
- [x] `python verify/qldpc_verify.py codes/12-2-4.json` passes locally
- [x] Construction and references filled in under `provenance`
- [x] Checked against existing entries: not equivalent to any current board entry (gate dedup clean; nearest weight-6 neighbors are [[12,4,2]], [[18,4,4]], [[19,1,5]], [[24,6,4]] — all distinct codes)

### What frontier does this advance?
Weight-6 × unrestricted cell. At d=4 this is the smallest n on the board: it strictly extends [[18,4,4]] on n (12 < 18) at equal distance and weight class, and is dominated by nothing ([[16,2,4]] has w=4 but sits in a stricter cell and does not dominate here since 16 > 12 on n; [[12,4,2]] trades distance for k). Score kd²/n = 2.667.

Construction: SAT-solver code discovery (arXiv:2608.23460 Sec. VI adapted to CSS): Minisat22 CNF over X/Z row-incidence variables; even-overlap commutation chains, weight≤3 detection clauses (stabilizer-absorbed errors rejected post-hoc), Sinz row-weight bound w≤6; blocking-clause enumeration. Generator committed with PR #709 as `research/sat_search.py`.

Research note: `notes/12-2-4.md`
