### PR TITLE
Certify 16 board entries exactly with SAT

### DIFF
--- a/certs/112-2-10.json
+++ b/certs/112-2-10.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[112,2,10]] trivariate bicycle (arXiv:2406.19151), 2D-local bilayer layout",
+ "d": 10,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  },
+  "Z": {
+   "value": 10,
+   "exact": true,
+   "note": "no logical < 10 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/144-2-12.json
+++ b/certs/144-2-12.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[144,2,12]] trivariate bicycle (arXiv:2406.19151), 2D-local bilayer layout",
+ "d": 12,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists"
+  },
+  "Z": {
+   "value": 12,
+   "exact": true,
+   "note": "no logical < 12 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/34-2-7.json
+++ b/certs/34-2-7.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[34,2,7]], 2D-local bilayer layout",
+ "d": 7,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/40-12-4.json
+++ b/certs/40-12-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[40,12,4]], 2D-local bilayer layout",
+ "d": 4,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/40-2-8.json
+++ b/certs/40-2-8.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[40,2,8]], 2D-local bilayer layout",
+ "d": 8,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  },
+  "Z": {
+   "value": 8,
+   "exact": true,
+   "note": "no logical < 8 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/42-10-4.json
+++ b/certs/42-10-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,10,4]]",
+ "d": 4,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/42-12-4.json
+++ b/certs/42-12-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,12,4]]",
+ "d": 4,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/42-6-6.json
+++ b/certs/42-6-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,6,6]]",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/50-10-4.json
+++ b/certs/50-10-4.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[50,10,4]], 2D-local bilayer layout",
+ "d": 4,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  },
+  "Z": {
+   "value": 4,
+   "exact": true,
+   "note": "no logical < 4 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/50-2-9.json
+++ b/certs/50-2-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[50,2,9]], 2D-local bilayer layout",
+ "d": 9,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/54-2-9.json
+++ b/certs/54-2-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[54,2,9]]",
+ "d": 9,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/54-6-7.json
+++ b/certs/54-6-7.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[54,6,7]], 2D-local bilayer layout",
+ "d": 7,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  },
+  "Z": {
+   "value": 7,
+   "exact": true,
+   "note": "no logical < 7 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/54-8-6.json
+++ b/certs/54-8-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[54,8,6]]",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/78-6-5.json
+++ b/certs/78-6-5.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[78,6,5]], 2D-local bilayer layout",
+ "d": 5,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  },
+  "Z": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/84-2-9.json
+++ b/certs/84-2-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[84,2,?]] weight-4 multivariate-bicycle finalist 5, 2D-local bilayer layout",
+ "d": 9,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/90-6-5.json
+++ b/certs/90-6-5.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[90,6,5]], 2D-local bilayer layout",
+ "d": 5,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  },
+  "Z": {
+   "value": 5,
+   "exact": true,
+   "note": "no logical < 5 exists"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
## What this adds

16 certificate files under `certs/`, each proving a board entry's distance
exactly. These entries carried witness-backed upper bounds and no
certificate, so the board displayed `d<=` for distances that turned out to be
provable.

| code | d | solve time |
|---|---|---|
| 144-2-12 | 12 | 5292 s |
| 112-2-10 | 10 | 172 s |
| 50-2-9 | 9 | 86 s |
| 54-2-9 | 9 | 82 s |
| 84-2-9 | 9 | 49 s |
| 54-6-7 | 7 | 6 s |
| 40-2-8 | 8 | 4 s |
| 34-2-7 | 7 | 1 s |
| 42-6-6, 54-8-6, 78-6-5, 90-6-5, 40-12-4, 42-10-4, 42-12-4, 50-10-4 | 4-6 | under 1 s each |

## Method

UNSAT at `W = d - 1` on both sides certifies `d`. Produced by the certifier in
#711, which asks the question once per side using selector variables rather
than once per logical generator.

Verdicts were cross-checked against the existing `verify/certify.py`
(scipy/HiGHS MILP) on the four cheapest instances, which agreed on all four.
The two certifiers share no solver and no encoding, so agreement is worth
more than either alone.

## What is not here

`114-4-14` did not close inside a 900 s per-solve cap and keeps its upper
bound. A timeout proves nothing and does not become a certificate.

Certificates that already existed were left untouched. An earlier pass of the
conversion script would have rewritten three of them to read
`CryptoMiniSat 5.14 SAT` in place of `scipy/HiGHS MILP`, which would restate
someone else's certification as this one's. Those are reverted and the script
now refuses to overwrite.

## Scope

Data only, no code. The sweep that produced these is still running over the
remaining uncertified bicycle entries under n = 200, and further certificates
will follow separately rather than by force-pushing this branch. No refutation
has appeared so far; if one does, it means a board entry overstates its
distance and I will raise it on its own rather than bury it in a certificate
batch.
