### PR TITLE
Filter the board by whether a distance is proved

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1125,6 +1125,11 @@ document.addEventListener('click',e=>{
    switch(m[2]){case'>=':return x>=v;case'<=':return x<=v;
     case'>':return x>v;case'<':return x<v;default:return x===v;}}
   if(t==='record'||t==='frontier')return r.dataset.record==='1';
+  // Distance provenance. 'exact' keeps only entries whose distance is proved
+  // by a committed certificate; 'upper-bound' keeps the rest, which are the
+  // ones a refutation could still move.
+  if(t==='exact'||t==='certified')return r.dataset.tier==='exact';
+  if(t==='upper-bound'||t==='unproven')return r.dataset.tier!=='exact';
   // cell:<locality>~<weight> keeps only the members of one primary-track cell,
   // honoring nesting via the row's precomputed data-cells list.
   if(t.slice(0,5)==='cell:')return (' '+(r.dataset.cells||'')+' ').indexOf(' '+t.slice(5)+' ')>=0;
@@ -3529,7 +3534,9 @@ def board_controls(entries, records):
             '<code>eff&gt;=5</code> <code>g&gt;=0.1</code>; <code>record</code> '
             'keeps only frontier rows; <code>literature</code> / '
             '<code>submitted</code> filter by origin; <code>with-layout</code> '
-            '/ <code>no-layout</code> filter by layout status.</p>'
+            '/ <code>no-layout</code> filter by layout status; '
+            '<code>exact</code> / <code>upper-bound</code> filter by whether '
+            'the distance is proved.</p>'
             '</section>')
 
 
@@ -3665,6 +3672,7 @@ def board_table(entries, records):
             f'data-tracks="{html.escape(search_terms)}" '
             f'data-cells="{html.escape(cell_keys)}" '
             f'data-record="{1 if fr else 0}" '
+            f'data-tier="{e["tier"]}" '
             f'data-origin="{"literature" if e["origin"] == "baseline" else "submitted"}" '
             f'data-model="{html.escape(e["model"].lower())}" '
             f'data-date="{html.escape(e["date"])}" '


### PR DESCRIPTION
Closes #527.

## What this adds

Two search terms on the board: `exact` (alias `certified`) keeps only entries
whose distance is proved by a committed certificate, and `upper-bound` (alias
`unproven`) keeps the rest.

The board already distinguishes the two, showing `d=` where a
`certs/<slug>.json` exists and agrees with the entry, and `d<=` otherwise, but
there was no way to act on that distinction. Asking "which of these distances
are actually proved" meant reading the table.

## How

Rows carry their computed tier as `data-tier`, and the term handler tests it.
It composes with everything already there, so `exact record`, `exact w<=6` and
`upper-bound literature` all work, and the existing chip and count update as
they do for any other term.

## Verified in the rendered page

Driving the real search box in a headless browser against the built board:

| query | rows kept |
|---|---|
| `exact` | 116 |
| `certified` | 116 |
| `upper-bound` | 259 |
| `exact record` | 65 |

116 + 259 = 375, the full listing, and 116 matches the count the build itself
reports for certified-exact entries, so the partition is exactly the one the
site already computes rather than a second opinion about it.

## Scope

`site/build.py` only; `docs/` is rebuilt by CI, following #705. No new lint
findings (the file carries 117 either way).

Worth noting for whoever reviews: this becomes more useful as certificates
accumulate, and #714 adds 16 of them, so the two are complementary but neither
depends on the other.
