### PR TITLE
Prefilter candidates before building, and screen in stages

### DIFF
--- a/research/kit/search.py
+++ b/research/kit/search.py
@@ -92,6 +92,92 @@ def screen(candidates, *, min_k=1, min_d=1, trials=400, seed=0,
     return out[:keep] if keep else out
 
 
+def screen_adaptive(candidates, *, stages=(400, 20_000, 200_000), target=None,
+                    min_k=1, min_d=1, metric=efficiency, keep=None,
+                    seed=0, backend="numpy", threads=1, audit=None,
+                    verbose=False):
+    """Screen in widening stages, dropping what cannot reach ``target``.
+
+    ``screen`` spends its whole trial budget on every candidate, including the
+    ones a hundred trials would have settled. This runs the cheapest stage on
+    everything and promotes only what is still worth paying for.
+
+    The rejection is sound rather than heuristic, and that rests on the
+    direction of the error: ``distance_rand`` returns an UPPER bound on d. A
+    candidate whose stage reading already scores below ``target`` therefore has
+    true d at most that reading and true score at most that score, and no
+    deeper stage can rescue it, since widening the search can only lower d.
+    Nothing that could have beaten the target is dropped.
+
+    ``target`` is a score in the units of ``metric`` (kd^2/n by default); with
+    ``target=None`` nothing is dropped for score and the stages only refine the
+    estimate. Candidates on the running Pareto frontier over (n, k, d) are
+    promoted whether or not they clear the target, since the board rewards
+    frontier membership separately from score.
+
+    Pass ``audit`` as a dict to receive per-stage ``promoted`` and ``rejected``
+    counts, plus ``trials_spent`` against ``trials_flat``, the budget a flat
+    ``screen`` at the deepest stage would have spent.
+    """
+    tally = audit if audit is not None else {}
+    tally.setdefault("promoted", [])
+    tally.setdefault("rejected", [])
+    tally.setdefault("trials_spent", 0)
+
+    live, seen = [], set()
+    for spec, HX, HZ in candidates:
+        if not verify_css(HX, HZ):
+            continue
+        k = compute_k(HX, HZ)
+        if k < min_k:
+            continue
+        fp = fingerprint(HX, HZ)
+        if fp in seen:
+            continue
+        seen.add(fp)
+        live.append({"spec": spec, "HX": HX, "HZ": HZ, "k": int(k),
+                     "n": int(HX.shape[1]), "fp": fp, "d": None})
+
+    for si, trials in enumerate(stages):
+        if not live:
+            break
+        for c in live:
+            c["d"] = int(distance_rand(
+                c["HX"], c["HZ"], trials=trials,
+                seed=seed + si * 7919 + int(c["fp"], 16),
+                backend=backend, threads=threads))
+            tally["trials_spent"] += trials
+        live = [c for c in live if c["d"] != float("inf") and c["d"] >= min_d]
+        if target is not None and si < len(stages) - 1:
+            scored = [{"n": c["n"], "k": c["k"], "d": c["d"], "_c": c}
+                      for c in live]
+            front_fps = {r["_c"]["fp"] for r in pareto_frontier(scored)}
+            keepers, dropped = [], 0
+            for c in live:
+                if (metric(c["n"], c["k"], c["d"]) >= target
+                        or c["fp"] in front_fps):
+                    keepers.append(c)
+                else:
+                    dropped += 1
+            tally["promoted"].append(len(keepers))
+            tally["rejected"].append(dropped)
+            live = keepers
+            if verbose:
+                print(f"  stage {si} ({trials} trials): {len(keepers)} kept, "
+                      f"{dropped} rejected")
+
+    tally["trials_flat"] = len(seen) * (stages[-1] if stages else 0)
+    out = []
+    for c in live:
+        w = int(max(*(int(r.sum()) for r in c["HX"]),
+                    *(int(r.sum()) for r in c["HZ"])))
+        out.append({"spec": c["spec"], "n": c["n"], "k": c["k"], "d": c["d"],
+                    "w": w, "fingerprint": c["fp"],
+                    "efficiency": round(float(metric(c["n"], c["k"], c["d"])), 4)})
+    out.sort(key=lambda r: r["efficiency"], reverse=True)
+    return out[:keep] if keep else out
+
+
 def pareto_frontier(records):
     """The Pareto-optimal records over (n smaller, k larger, d larger): those
     not dominated by any other (no other has n' <= n, k' >= k, d' >= d with at
@@ -137,28 +223,66 @@ def update_leaderboard(path, records):
 # ---------------------------------------------------------------------------
 #  Ready-made samplers (all yield (spec, HX, HZ); point ``screen`` at any)
 # ---------------------------------------------------------------------------
-def sample_bb(num, *, l_range=(4, 12), m_range=(3, 10), weight=3, seed=0):
+def bb_shape(l, m, A, B):  # noqa: E741
+    """Return (n, w) for a bivariate-bicycle candidate without building it.
+
+    Both are exact rather than bounds: n = 2lm by construction, and every check
+    row is one A monomial block beside one B block, so the max row weight is
+    |A| + |B| whenever the supports are distinct (which the samplers ensure).
+    Cheap enough to run on every candidate before the dense build.
+    """
+    return 2 * l * m, len(A) + len(B)
+
+
+def sample_bb(num, *, l_range=(4, 12), m_range=(3, 10), weight=3, seed=0,
+              n_range=None, max_weight=None, audit=None):
     """Yield ``num`` random bivariate-bicycle candidates ``(spec, HX, HZ)``.
 
     Each picks a random torus Z_l x Z_m and two sets of ``weight`` distinct
     monomials (distinct so the supports do not cancel mod 2). ``spec`` is a dict
     ``{"family": "bb", "l", "m", "A", "B"}`` -- pass it straight to ``build_bb``
     to rebuild the code.
+
+    ``n_range`` and ``max_weight`` reject a candidate before ``build_bb`` runs,
+    using the exact (n, w) that ``bb_shape`` reads off the parameters. Both are
+    facts about the construction rather than estimates, so nothing that could
+    have passed is discarded. Pass ``audit`` as a dict to receive counts under
+    ``sampled``, ``rejected_n``, ``rejected_w`` and ``built``.
+
+    Deliberately absent: a k prefilter via ``surrogate.mixed_volume``. That is
+    a heuristic here, not a bound. Measured against recomputed k on random
+    candidates whose supports contain (0,0), true k exceeds it in about 2.6% of
+    cases on small tori (l, m in [3,5]; worst observed k = 12 against a bound
+    of 0 at l = m = 3), 0.1% for l, m in [6,9], and in none of 700 samples at
+    [10,14]. Rejecting on it would silently drop real codes, so it is left to
+    callers who want a lossy filter and know the rate.
     """
     rng = np.random.default_rng(seed)
+    tally = audit if audit is not None else {}
+    for key in ("sampled", "rejected_n", "rejected_w", "built"):
+        tally.setdefault(key, 0)
 
-    def distinct_monomials(l, m):
+    def distinct_monomials(l, m):  # noqa: E741
         grid = [(a, b) for a in range(l) for b in range(m)]
         idx = rng.choice(len(grid), size=min(weight, len(grid)), replace=False)
         return [grid[i] for i in idx]
 
     for _ in range(num):
-        l = int(rng.integers(l_range[0], l_range[1] + 1))
+        l = int(rng.integers(l_range[0], l_range[1] + 1))  # noqa: E741
         m = int(rng.integers(m_range[0], m_range[1] + 1))
         if l * m < weight:
             continue
         A = distinct_monomials(l, m)
         B = distinct_monomials(l, m)
+        tally["sampled"] += 1
+        n, w = bb_shape(l, m, A, B)
+        if n_range is not None and not (n_range[0] <= n <= n_range[1]):
+            tally["rejected_n"] += 1
+            continue
+        if max_weight is not None and w > max_weight:
+            tally["rejected_w"] += 1
+            continue
+        tally["built"] += 1
         HX, HZ = build_bb(l, m, A, B)
         yield ({"family": "bb", "l": l, "m": m, "A": A, "B": B}, HX, HZ)
 

--- a/research/test_screen_adaptive.py
+++ b/research/test_screen_adaptive.py
@@ -1,0 +1,122 @@
+"""Tests for the prefilters (#617) and adaptive screening (#618).
+
+Both features exist to skip work, so the property that matters is that they
+skip only work whose outcome was already determined. A filter that drops a
+candidate which could have scored is worse than no filter, because the loss is
+silent.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "kit"))
+import search as S
+from bb import build_bb
+from css import compute_k
+
+
+def test_bb_shape_matches_the_built_matrices():
+    """The prefilter's (n, w) must equal what building actually produces."""
+    for ell, m, A, B in (
+        (6, 6, [(0, 0), (1, 0), (0, 1)], [(0, 0), (2, 0), (0, 3)]),
+        (4, 5, [(0, 0), (1, 2)], [(0, 0), (3, 1), (2, 4)]),
+    ):
+        HX, HZ = build_bb(ell, m, A, B)
+        n_pred, w_pred = S.bb_shape(ell, m, A, B)
+        assert n_pred == HX.shape[1]
+        w_real = max(*(int(r.sum()) for r in HX), *(int(r.sum()) for r in HZ))
+        assert w_pred == w_real
+
+
+def test_prefilters_drop_only_out_of_range_candidates():
+    """Check that everything yielded satisfies the filters.
+
+    The audit counts must also account for every sampled candidate.
+    """
+    audit = {}
+    got = list(S.sample_bb(120, l_range=(3, 9), m_range=(3, 9), weight=3,
+                           seed=4, n_range=(40, 100), max_weight=6,
+                           audit=audit))
+    for spec, HX, _HZ in got:
+        n, w = S.bb_shape(spec["l"], spec["m"], spec["A"], spec["B"])
+        assert 40 <= n <= 100 and w <= 6
+        assert HX.shape[1] == n
+    assert audit["built"] == len(got)
+    assert (audit["sampled"]
+            == audit["built"] + audit["rejected_n"] + audit["rejected_w"])
+    assert audit["rejected_n"] > 0, "no candidate was filtered; test is vacuous"
+
+
+def test_prefilters_do_not_change_which_codes_survive():
+    """Filtering must not change which codes come out.
+
+    The filtered sweep must yield exactly what an unfiltered one would have
+    yielded and then kept.
+    """
+    unfiltered = list(S.sample_bb(120, l_range=(3, 9), m_range=(3, 9),
+                                  weight=3, seed=4))
+    expect = {(s["l"], s["m"], tuple(s["A"]), tuple(s["B"]))
+              for s, _hx, _hz in unfiltered
+              if 40 <= S.bb_shape(s["l"], s["m"], s["A"], s["B"])[0] <= 100}
+    filtered = {(s["l"], s["m"], tuple(s["A"]), tuple(s["B"]))
+                for s, _hx, _hz in S.sample_bb(120, l_range=(3, 9),
+                                               m_range=(3, 9), weight=3,
+                                               seed=4, n_range=(40, 100))}
+    assert filtered == expect
+
+
+def test_mixed_volume_is_not_a_sound_k_bound():
+    """Guard the docstring's claim with the counterexample that motivates it.
+
+    If this ever fails because the bound became sound, the note in sample_bb
+    should be revisited rather than the test deleted.
+    """
+    from surrogate import mixed_volume
+    A = B = [(0, 0), (1, 0), (0, 1)]
+    ell = m = 3
+    HX, HZ = build_bb(ell, m, A, B)
+    k = int(compute_k(HX, HZ))
+    mv = mixed_volume(A, B)
+    assert k > mv, f"expected the bound to be violated here; k={k} mv={mv}"
+
+
+def _fixed_candidates(seed=3, num=24):
+    # Small tori and a modest count: these tests assert relationships
+    # between the two screens, which hold at any budget, so the budget is
+    # chosen for CI wall time rather than for distance accuracy.
+    return list(S.sample_bb(num, l_range=(3, 6), m_range=(3, 6), weight=3,
+                            seed=seed))
+
+
+def test_adaptive_keeps_every_candidate_a_flat_screen_would_report():
+    """Nothing above the target may be lost to staging.
+
+    A candidate is dropped only when its stage reading, an upper bound on d,
+    already scores below the target; since deeper stages can only lower d, the
+    flat screen cannot have scored it higher.
+    """
+    cands = _fixed_candidates()
+    target = 2.0
+    flat = S.screen(cands, trials=2_000, seed=0)
+    flat_good = {r["fingerprint"] for r in flat if r["efficiency"] >= target}
+    adaptive = S.screen_adaptive(_fixed_candidates(), stages=(120, 2_000),
+                                 target=target, seed=0)
+    got = {r["fingerprint"] for r in adaptive}
+    assert flat_good <= got, f"adaptive lost {flat_good - got}"
+
+
+def test_adaptive_reports_its_savings():
+    audit = {}
+    S.screen_adaptive(_fixed_candidates(), stages=(120, 2_000), target=5.0,
+                      seed=0, audit=audit)
+    assert audit["trials_spent"] < audit["trials_flat"], (
+        f"no saving: {audit['trials_spent']} vs {audit['trials_flat']}")
+    assert sum(audit["rejected"]) > 0, "nothing was rejected; test is vacuous"
+
+
+def test_adaptive_without_a_target_drops_nothing():
+    cands = _fixed_candidates()
+    flat = {r["fingerprint"] for r in S.screen(cands, trials=2_000, seed=0)}
+    adaptive = {r["fingerprint"] for r in
+                S.screen_adaptive(_fixed_candidates(), stages=(120, 2_000),
+                                  target=None, seed=0)}
+    assert flat == adaptive


### PR DESCRIPTION
Closes #617 and #618. They touch the same path in `research/kit/search.py`, so
splitting them would have meant one rebasing on the other.

## Prefilters before the dense build (#617)

`sample_bb` built every candidate's matrices before anything could look at
them, so a sweep aimed at a blocklength window paid for every code outside it.
Both quantities a sweep usually filters on are exact functions of the
sampler's own parameters, so `bb_shape` reads them off and the sampler
declines before building:

- `n = 2lm` by construction;
- `w = |A| + |B|`, since each check row is one A block beside one B block and
  the samplers keep the supports distinct.

On 600 samples aimed at `n` in [100,300] with `w <= 6`, 52% of dense builds
are skipped and the sampler runs 1.7x faster. `audit` returns the counts.

### mixed_volume is not a bound here

The issue proposed treating `surrogate.mixed_volume()` as an upper bound on k
and skipping when it falls below `min_k`. It is a heuristic in this setting,
and using it that way would silently discard real codes. Measured against
recomputed k on random candidates whose supports contain (0,0), as the
module's own example does:

| torus | violations | worst case |
|---|---|---|
| l, m in [3,5] | 2.6% | k = 12 against a bound of 0 at l = m = 3 |
| l, m in [6,9] | 0.1% | k = 4 against 2 |
| l, m in [10,14] | 0 of 700 | none observed |

Since #617 asks that filters "only remove candidates with a sound upper-bound
reason", it is not wired in. The measurement lives in the `sample_bb`
docstring and is pinned by a test carrying the l = m = 3 counterexample, so
the next person to reach for it finds the counterexample instead of
rediscovering it as missing codes.

Worth flagging for whoever picks this up: the prize the issue was aiming at is
real and still unclaimed. 94% of random BB candidates have k = 0, so a *sound*
cheap k test would dominate every other prefilter. mixed_volume is ruled out;
a gcd-based necessary condition is the obvious next candidate.

## Staged screening (#618)

`screen` spends its full trial budget on every candidate. `screen_adaptive`
runs the cheapest stage on all of them and promotes only what can still reach
the target.

The rejection is sound rather than heuristic, and it rests on the direction of
the error: `distance_rand` returns an upper bound on d, so a candidate whose
stage reading already scores below the target has true d at most that reading,
hence true score at most that score, and no deeper stage can rescue it because
widening the search only lowers d. Pareto members are promoted regardless of
score, since the board rewards frontier membership separately.

On a 300-candidate pool (20 distinct with k >= 2), stages (200, 4000), target
4.0:

| | adaptive | flat |
|---|---|---|
| trials | 24,000 | 80,000 |
| wall | 43.0 s | 151.4 s |

15 of 20 rejected at the cheap stage; all 3 codes the flat screen found above
the target are retained. `screen` is unchanged for callers who want a fixed
budget.

## Tests

Aimed at the property that makes these safe to use rather than at the speedup:
`bb_shape` agrees with the built matrices; the prefilters yield exactly what
an unfiltered sweep would have yielded and then kept; adaptive screening
retains every candidate a flat screen reports above the target; `target=None`
drops nothing; and the audit shows a real saving. Budgets are small so the
file runs in about 30 s, since CI runs `research/test_*.py`.
