### PR TITLE
Add qldpc targets, showing which track cells are open

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [`AGENTS.md`](AGENTS.md) for the precedence rule.
 | Submit a code you already have | [`CONTRIBUTING.md`](CONTRIBUTING.md) — one command: `./qldpc submit` |
 | Have an LLM find and submit a code on your behalf | [Contribute with an LLM](CONTRIBUTING.md#contribute-with-an-llm) (a ready-to-paste prompt) |
 | Have an agent search without publishing | [`research/AUTORESEARCH.md`](research/AUTORESEARCH.md) (stage-only research workflow) |
+| See which track cells are open right now | one command: `./qldpc targets` (add `--n 200` for what a code that size needs) |
 | Understand the boards and the targets to beat | [`TRACKS.md`](TRACKS.md) — especially the "Reference bars" section |
 | Point a coding agent at this repo | [`AGENTS.md`](AGENTS.md) |
 

--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -34,6 +34,7 @@ import argparse
 import datetime
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -549,6 +550,69 @@ def open_pr(slug, out, note_out=None, title=None, body_file=None, root=None):
     return 0
 
 
+def cmd_targets(args):
+    """Print per-cell occupancy and frontier, so a newcomer can see what to aim at.
+
+    Reuses the site's own cells() and pareto(), the pair that decides records on
+    the published board, so these are the board's numbers rather than a second
+    opinion about them.
+    """
+    entries = _load_board_entries()
+    if not entries:
+        raise SystemExit("could not load the board; run this from a checkout")
+
+    by_cell = {}
+    for e in entries:
+        for cell in cells(e):
+            by_cell.setdefault(cell, []).append(e)
+
+    def matches(L, W):
+        if not args.cell:
+            return True
+        toks = [x for x in re.split(r"[/, ]+", args.cell.lower()) if x]
+        hay = f"{L} {W} {LOCALITY_LABEL.get(L, L)} {WEIGHT_LABEL.get(W, W)}".lower()
+        return all(tok in hay for tok in toks)
+
+    def eff(e):
+        return e["k"] * e["d"] ** 2 / e["n"]
+
+    rows = [(c, v) for c, v in sorted(by_cell.items()) if matches(*c)]
+    if not rows:
+        raise SystemExit(f"no cell matched {args.cell!r}. Weight classes: "
+                         f"{sorted({c[1] for c in by_cell})}; locality classes: "
+                         f"{sorted({c[0] for c in by_cell})}")
+
+    for (L, W), peers in rows:
+        front = [peers[i] for i in sorted(pareto(peers))]
+        print(f"\n{LOCALITY_LABEL.get(L, L)} / {WEIGHT_LABEL.get(W, W)}")
+        print(f"  {len(peers)} codes, {len(front)} nondominated, "
+              f"best kd2/n {max(eff(e) for e in peers):.2f}")
+        if args.n:
+            near = [e for e in front if e["n"] <= args.n]
+            if not near:
+                print(f"  nothing at n <= {args.n}: any verified code here "
+                      f"lands on the frontier")
+            else:
+                print(f"  at n <= {args.n}, {len(near)} entries to get past; "
+                      f"the ones to beat:")
+                for e in sorted(near, key=eff, reverse=True)[:args.top]:
+                    print(f"    [[{e['n']},{e['k']},{e['d']}]] w={e['w']} "
+                          f"kd2/n={eff(e):.2f}")
+                continue
+        for e in sorted(front, key=eff, reverse=True)[:args.top]:
+            print(f"    [[{e['n']},{e['k']},{e['d']}]] w={e['w']} "
+                  f"kd2/n={eff(e):.2f}")
+        if len(front) > args.top:
+            print(f"    ... {len(front) - args.top} more nondominated")
+
+    print(f"\n{len(entries)} codes across {len(by_cell)} populated cells. "
+          f"A code counts in every cell it qualifies for (the classes nest), "
+          f"so these counts overlap by design.")
+    print("Nondominated means no other code in the cell beats it on all of "
+          "n, k, d and check weight at once, which is what earns a record star.")
+    return 0
+
+
 def cmd_recent(args):
     """What moved on the board recently: codes merged, research notes, and
     fieldnotes, from git history. The 'stay current' step — read this (and
@@ -653,6 +717,17 @@ def main(argv=None):
                                       "search)")
     r.add_argument("--days", type=int, default=14)
     r.set_defaults(func=cmd_recent)
+
+    g = sub.add_parser("targets", help="which track cells are open: occupancy "
+                                       "and frontier per cell (read before you "
+                                       "build)")
+    g.add_argument("--cell", default=None,
+                   help="focus one cell, e.g. 'weight-6/unrestricted'")
+    g.add_argument("--n", type=int, default=None,
+                   help="what a code at this blocklength would need")
+    g.add_argument("--top", type=int, default=6,
+                   help="frontier entries to list per cell (default 6)")
+    g.set_defaults(func=cmd_targets)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/verify/test_cli_targets.py
+++ b/verify/test_cli_targets.py
@@ -1,0 +1,80 @@
+"""Tests for `qldpc targets` (issue #639).
+
+The command exists to tell a newcomer where to aim, so the property that
+matters is that its numbers are the board's own. It reads the same cells() and
+pareto() the site uses to award record stars; if it ever disagrees with them,
+it is worse than not existing, because it would send people at cells that are
+not actually open.
+"""
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_ROOT, "cli"))
+sys.path.insert(0, os.path.join(_ROOT, "site"))
+import qldpc  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cached_board():
+    """Load the board once for the module.
+
+    load_entries() re-verifies every code and costs about 15 s, and these tests
+    call the command four times. Caching it keeps the CI job honest about what
+    it is paying for; the logic under test is cmd_targets, not the loader.
+    """
+    from build import load_entries
+    entries = load_entries()
+    original = qldpc._load_board_entries
+    qldpc._load_board_entries = lambda: entries
+    yield
+    qldpc._load_board_entries = original
+
+
+def _run(*argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        qldpc.main(["targets", *argv])
+    return buf.getvalue()
+
+
+def test_runs_with_no_arguments_and_covers_every_populated_cell():
+    from build import cells
+    out = _run()
+    populated = {c for e in qldpc._load_board_entries() for c in cells(e)}
+    assert f"across {len(populated)} populated cells" in out
+    assert out.count("nondominated") >= len(populated)
+
+
+def test_counts_match_the_site_exactly():
+    """Every cell's count must equal what the site computes, not approximate it."""
+    from build import LOCALITY_LABEL, WEIGHT_LABEL, cells
+    entries = qldpc._load_board_entries()
+    by = {}
+    for e in entries:
+        for c in cells(e):
+            by.setdefault(c, []).append(e)
+    out = _run()
+    for (loc, wt), peers in by.items():
+        header = f"{LOCALITY_LABEL.get(loc, loc)} / {WEIGHT_LABEL.get(wt, wt)}"
+        assert header in out, f"missing cell {header}"
+        line = out.split(header, 1)[1].splitlines()[1]
+        assert f"{len(peers)} codes" in line, (
+            f"{header}: printed {line.strip()!r}, board has {len(peers)}")
+
+
+def test_cell_filter_narrows_and_rejects_nonsense():
+    out = _run("--cell", "weight-6/unrestricted")
+    assert "unrestricted / weight" in out
+    assert "2D-local" not in out.split("populated cells")[0]
+    with pytest.raises(SystemExit):
+        _run("--cell", "not-a-cell")
+
+
+def test_n_option_reports_what_must_be_beaten():
+    out = _run("--cell", "unrestricted", "--n", "100")
+    assert "at n <= 100" in out or "nothing at n <= 100" in out


### PR DESCRIPTION
Closes #639.

## What this adds

`./qldpc targets`, which prints per track cell: how many codes it holds, how
many are nondominated, the best `kd²/n`, and the leading frontier entries.

```
unrestricted / weight ≤ 6
  176 codes, 115 nondominated, best kd2/n 19.20
    [[360,12,24]] w=6 kd2/n=19.20
    [[510,16,24]] w=6 kd2/n=18.07
    ...
```

`--cell weight-6/unrestricted` focuses one cell. `--n 200` switches the
listing to the entries a code of that size would have to get past, which is
the form the question usually arrives in.

## Where the numbers come from

It calls the site's `cells()` and `pareto()`, which `qldpc submit` already
imports to fill in a submission's frontier section, so no membership or
frontier logic is reimplemented and no refactor was needed.

That matters more than convenience. A command like this is worse than absent
if it drifts from the board, because it would send people at cells that are
not actually open, so a test asserts the counts cell by cell against
`load_entries()` rather than sampling one.

Checked by hand against the published board, as the issue asks. All 12
populated cells agree, including the two I verified against the rendered page:
52 codes in 2D-local bilayer / weight ≤ 4, and 176 with best 19.20 in
unrestricted / weight ≤ 6.

## Note on "nondominated"

The counts are high (115 of 176 above) because domination is over four axes at
once, n, k, d and check weight, so most entries win on something. That is the
same rule that awards record stars, so the number is honest, but it is worth
knowing that a large nondominated count does not mean a cell is easy. The
output says so in a closing line rather than leaving it to be inferred.

## Tests and cost

Four tests: runs with no arguments and covers every populated cell; counts
match the site exactly, cell by cell; `--cell` narrows and rejects nonsense;
`--n` reports what must be beaten. The module caches the board once, since
`load_entries()` re-verifies every code at about 15 s a call and four calls
made the file cost 93 s against a CI job of under four minutes. Cached, it
runs in 16 s.

README's "Start here" table gains the row the issue asks for.
