### PR TITLE
Reuse GF(2) bases across repeated distance searches

### DIFF
--- a/research/kit/search.py
+++ b/research/kit/search.py
@@ -28,7 +28,7 @@ import os
 import numpy as np
 
 from css import compute_k, verify_css, rref
-from surrogate import distance_rand
+from surrogate import distance_rand, prepare_distance_search
 from bb import build_bb
 from group_algebra import build_2bga, dihedral, metacyclic
 from products import (hypergraph_product, lifted_product, balanced_product,
@@ -136,16 +136,24 @@ def screen_adaptive(candidates, *, stages=(400, 20_000, 200_000), target=None,
             continue
         seen.add(fp)
         live.append({"spec": spec, "HX": HX, "HZ": HZ, "k": int(k),
-                     "n": int(HX.shape[1]), "fp": fp, "d": None})
+                     "n": int(HX.shape[1]), "fp": fp, "d": None,
+                     "prep": None})
 
     for si, trials in enumerate(stages):
         if not live:
             break
         for c in live:
-            c["d"] = int(distance_rand(
+            if c["prep"] is None and backend == "numpy":
+                c["prep"] = prepare_distance_search(c["HX"], c["HZ"])
+            got = int(distance_rand(
                 c["HX"], c["HZ"], trials=trials,
                 seed=seed + si * 7919 + int(c["fp"], 16),
-                backend=backend, threads=threads))
+                backend=backend, threads=threads, prepared=c["prep"]))
+            # Every stage returns a valid upper bound, and the stages draw
+            # independently, so a later one can come back worse. Keep the best
+            # bound seen rather than the latest, or a deeper stage could report
+            # a weaker result than the shallower one already proved.
+            c["d"] = got if c["d"] is None else min(c["d"], got)
             tally["trials_spent"] += trials
         live = [c for c in live if c["d"] != float("inf") and c["d"] >= min_d]
         if target is not None and si < len(stages) - 1:

--- a/research/kit/surrogate.py
+++ b/research/kit/surrogate.py
@@ -140,7 +140,51 @@ def _rref_perm(M, perm):
     return M[:r]
 
 
-def _search_lightest(Hself, Hopp, trials, seed, pair_depth=10):
+class PreparedSearch:
+    """Reusable GF(2) state for repeated distance searches on one code.
+
+    ``kernel_basis`` and ``logical_basis`` depend only on the check matrices, so
+    a workflow that searches the same code at several budgets (a staged screen,
+    a ladder that widens until it converges) recomputes them every time for no
+    reason. Building this once and passing it to ``distance_rand`` keeps the
+    per-call work to the trials themselves.
+
+    The bases are treated as immutable: each search allocates its own scratch
+    and never writes through them, so one prepared object is safe to reuse
+    across calls and across budgets.
+    """
+
+    __slots__ = ("HX", "HZ", "n", "_sides")
+
+    def __init__(self, HX, HZ):
+        self.HX = np.asarray(HX, dtype=np.int8) % 2
+        self.HZ = np.asarray(HZ, dtype=np.int8) % 2
+        self.n = int(self.HX.shape[1])
+        self._sides = {}
+        for tag, Hself, Hopp in (("X", self.HX, self.HZ),
+                                 ("Z", self.HZ, self.HX)):
+            K = kernel_basis(Hopp)
+            LO = logical_basis(Hself, Hopp)
+            self._sides[tag] = (Hself, Hopp, K, LO)
+
+    def side(self, tag):
+        """Return (Hself, Hopp, kernel basis, opposite-logical basis).
+
+        ``tag`` is 'X' or 'Z'.
+        """
+        return self._sides[tag]
+
+
+def prepare_distance_search(HX, HZ):
+    """Precompute the GF(2) bases ``distance_rand`` would rebuild on every call.
+
+    Pass the result as ``distance_rand(..., prepared=obj)``. Worth it when the
+    same code is searched more than once, which is what a staged screen does.
+    """
+    return PreparedSearch(HX, HZ)
+
+
+def _search_lightest(Hself, Hopp, trials, seed, pair_depth=10, bases=None):
     """Randomized upper-bound search for the lightest nontrivial logical of one
     type: a vector v with v in ker(Hopp) (commutes with the opposite checks) but
     v not in rowspace(Hself) (not a stabilizer product). Returns
@@ -154,8 +198,11 @@ def _search_lightest(Hself, Hopp, trials, seed, pair_depth=10):
     Hself = np.asarray(Hself, dtype=np.int8) % 2
     Hopp = np.asarray(Hopp, dtype=np.int8) % 2
     n = Hself.shape[1]
-    K = kernel_basis(Hopp)            # operators commuting with the opposite checks
-    LO = logical_basis(Hself, Hopp)   # opposite-type logicals -> nontriviality test
+    if bases is None:
+        K = kernel_basis(Hopp)        # operators commuting with the opposite checks
+        LO = logical_basis(Hself, Hopp)   # opposite-type logicals -> nontriviality
+    else:
+        K, LO = bases                 # prepared once; never written through here
     if K.size == 0 or LO.size == 0:
         return float("inf"), []
     rng = np.random.default_rng(seed)
@@ -194,7 +241,8 @@ def lightest_logical(Hself, Hopp, trials=8000, seed=0):
     return _search_lightest(Hself, Hopp, trials, seed)
 
 
-def distance_rand(HX, HZ, trials=2000, seed=0, *, backend="numpy", threads=1):
+def distance_rand(HX=None, HZ=None, trials=2000, seed=0, *,
+                  backend="numpy", threads=1, prepared=None):
     """Return a randomized upper bound on ``d = min(d_X, d_Z)``.
 
     ``backend`` is ``"numpy"`` (portable), ``"fast"`` (requires ``make fast``),
@@ -202,17 +250,33 @@ def distance_rand(HX, HZ, trials=2000, seed=0, *, backend="numpy", threads=1):
     validated by Python; this remains an upper-bound search, not a proof.
     ``trials`` counts different search operations in the two backends, so the
     same value is not a comparable screening budget across backends.
+
+    Pass ``prepared`` (from :func:`prepare_distance_search`) to skip rebuilding
+    the GF(2) bases, which is worth doing when the same code is searched at
+    more than one budget. ``HX``/``HZ`` may then be omitted. The bases do not
+    depend on ``trials`` or ``seed``, so a prepared search returns exactly what
+    the unprepared one would for the same arguments.
     """
     if backend not in ("numpy", "fast", "auto"):
         raise ValueError("backend must be 'numpy', 'fast', or 'auto'")
     if threads < 1:
         raise ValueError("threads must be at least 1")
+    if prepared is not None:
+        HX, HZ = prepared.HX, prepared.HZ
+    elif HX is None or HZ is None:
+        raise TypeError("distance_rand needs HX and HZ, or prepared=")
     if backend in ("fast", "auto") and _fast is not None:
         return _distance_rand_fast(HX, HZ, trials, seed, threads)
     if backend == "fast":
         raise ImportError("gf2_fast is unavailable; run `make fast` to build it")
-    wx, _ = _search_lightest(HX, HZ, trials, seed)
-    wz, _ = _search_lightest(HZ, HX, trials, seed)
+    if prepared is None:
+        wx, _ = _search_lightest(HX, HZ, trials, seed)
+        wz, _ = _search_lightest(HZ, HX, trials, seed)
+    else:
+        hx_self, hx_opp, kx, lx = prepared.side("X")
+        hz_self, hz_opp, kz, lz = prepared.side("Z")
+        wx, _ = _search_lightest(hx_self, hx_opp, trials, seed, bases=(kx, lx))
+        wz, _ = _search_lightest(hz_self, hz_opp, trials, seed, bases=(kz, lz))
     return min(wx, wz)
 
 

--- a/research/test_screen_adaptive.py
+++ b/research/test_screen_adaptive.py
@@ -120,3 +120,53 @@ def test_adaptive_without_a_target_drops_nothing():
                 S.screen_adaptive(_fixed_candidates(), stages=(120, 2_000),
                                   target=None, seed=0)}
     assert flat == adaptive
+
+
+def test_prepared_search_returns_what_the_plain_one_does():
+    """Caching the bases must not change any answer.
+
+    The bases depend only on the check matrices, so a prepared search is the
+    same computation with the setup hoisted; if this ever diverges, the cache
+    is being written through somewhere.
+    """
+    from bb import KNOWN, build_bb
+    from surrogate import distance_rand, prepare_distance_search
+    p = KNOWN["[[72,12,6]]"]
+    HX, HZ = build_bb(p["l"], p["m"], p["A"], p["B"])
+    prep = prepare_distance_search(HX, HZ)
+    for trials in (20, 60):
+        for seed in (1, 2, 3):
+            assert (distance_rand(HX, HZ, trials=trials, seed=seed)
+                    == distance_rand(prepared=prep, trials=trials, seed=seed))
+
+
+def test_prepared_object_survives_repeated_use():
+    """One prepared object, many searches: no state may leak between calls."""
+    from bb import KNOWN, build_bb
+    from surrogate import distance_rand, prepare_distance_search
+    p = KNOWN["[[72,12,6]]"]
+    HX, HZ = build_bb(p["l"], p["m"], p["A"], p["B"])
+    prep = prepare_distance_search(HX, HZ)
+    first = distance_rand(prepared=prep, trials=40, seed=5)
+    for _ in range(4):
+        distance_rand(prepared=prep, trials=40, seed=9)
+    assert distance_rand(prepared=prep, trials=40, seed=5) == first
+
+
+def test_staged_screen_never_reports_a_worse_bound_than_a_stage_found():
+    """A deeper stage must not discard a better bound an earlier one proved.
+
+    Stages draw independently, so a later one can come back higher. Every
+    reading is a valid upper bound, so the reported value must be the best of
+    them; reporting the latest would throw away a proved result.
+    """
+    pool = _fixed_candidates()
+    staged = {r["fingerprint"]: r["d"] for r in
+              S.screen_adaptive(pool, stages=(60, 300), target=None, seed=0)}
+    for st in ((60,), (300,)):
+        single = S.screen_adaptive(pool, stages=st, target=None, seed=0)
+        for r in single:
+            if r["fingerprint"] in staged:
+                assert staged[r["fingerprint"]] <= r["d"], (
+                    f"staged reported {staged[r['fingerprint']]} where a "
+                    f"{st[0]}-trial stage alone found {r['d']}")


### PR DESCRIPTION
Closes #619.

## What this adds

`prepare_distance_search(HX, HZ)` returns a `PreparedSearch` holding the GF(2)
bases a distance search needs, and `distance_rand(..., prepared=obj)` uses them
instead of rebuilding.

`kernel_basis` and `logical_basis` depend only on the check matrices, but
`_search_lightest` rebuilt both on every call, and `distance_rand` calls it
once per side. So anything that searched one code at more than one budget paid
that setup again at every budget.

## Measured

On `[[144,12,12]]` across stages (20, 60, 200), rebuilding the bases was 51% of
the wall time:

| | time |
|---|---|
| rebuild each stage | 2.59 s |
| prepared once | 1.28 s |

2.03x for that pattern. The win shrinks as the trial budget grows, since setup
is a fixed cost: it is 14% of a 50-trial search on `[[72,12,6]]` and 2% of a
500-trial one. This matters for staged screening and ladders, not for a single
deep search, and `screen_adaptive` now prepares once per candidate on the numpy
backend where the reuse actually happens.

The prepared path returns exactly what the plain one does. A test pins that
across several `(trials, seed)` pairs, and another reuses one prepared object
through repeated searches to catch state leaking between calls, since the whole
premise is that the bases are never written through.

## A latent defect fixed on the way

`screen_adaptive` (from #716) overwrote the recorded `d` with each stage's
reading. The stages draw independently, so a later stage returning a *higher*
upper bound would discard a better one an earlier stage had already proved.
Every reading is a valid upper bound, so the minimum is the correct value to
keep.

Worth being precise about the severity: I could not make it fire. The deeper
stage came back worse in 0 of 20 candidates at stages 200/4000, and in none of
15 seeds across the known BB codes; at one trial the search does spread (12 and
14 on `[[144,12,12]]`) but it converges by two trials. So this was latent
rather than an observed wrong answer. The ordering is not guaranteed, which is
reason enough to keep the best reading rather than the last one, and a test now
asserts the staged result is never worse than what a single stage alone finds.

## Scope

`research/` only, no change to validation. The fast backend path is untouched:
`prepared` is accepted and ignored there, since `gf2_fast` builds its own
state, and the numpy path is where the Python-side bases are the cost.
