### PR TITLE
Certify three more board entries exactly with SAT

### DIFF
--- a/certs/42-14-6.json
+++ b/certs/42-14-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,14,6]] cyclic bicycle code (arXiv:2608.09115v1)",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/42-16-6.json
+++ b/certs/42-16-6.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[42,16,6]] cyclic bicycle code (arXiv:2608.09115v1)",
+ "d": 6,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  },
+  "Z": {
+   "value": 6,
+   "exact": true,
+   "note": "no logical < 6 exists"
+  }
+ },
+ "d_exact": true
+}

--- a/certs/72-10-9.json
+++ b/certs/72-10-9.json
@@ -1,0 +1,18 @@
+{
+ "name": "[[72,10,9]] 2BGA on SmallGroup(36,2)",
+ "d": 9,
+ "solver": "CryptoMiniSat 5.14 SAT",
+ "sides": {
+  "X": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  },
+  "Z": {
+   "value": 9,
+   "exact": true,
+   "note": "no logical < 9 exists"
+  }
+ },
+ "d_exact": true
+}


### PR DESCRIPTION
Continues #714 as the sweep works through the remaining uncertified bicycle entries under n = 200.

| code | d | solve time |
|---|---|---|
| 42-14-6 | 6 | 6 s |
| 42-16-6 | 6 | 27 s |
| 72-10-9 | 9 | 2038 s |

Method is unchanged from #714: UNSAT at `W = d - 1` on both sides, produced by the certifier in #711.

Cross-checked against the existing `verify/certify.py` MILP path. It agrees on `42-14-6` and `42-16-6`, and does not close `72-10-9` within 300 s. Worth being explicit that this is not a disagreement: a MILP timeout is a statement about that solver's budget, and the SAT verdict rests on its own UNSAT rather than on MILP confirming it. It is also the reason the SAT path was added, since the gap widens with k and `72-10-9` has k = 10.

Sweep totals so far: 22 certified exact, 7 that timed out and keep their upper bounds, and no refutations. A refutation would mean a board entry overstates its distance, and would be raised on its own rather than inside a certificate batch.

Data only, no code.