### PR TITLE
Add pre-push prose gate (worktree-based CI simulation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,19 @@ Two more, same reason:
   comments, unticked checklist boxes, session URLs. If a checklist box is not true, make it
   true or say why.
 
+**Before pushing: run the worktree gate.** A passing local run of `check_prose.py` is not
+sufficient — it validates paths against your working tree, where uncommitted files exist.
+CI validates against the PR tree only, so citations to uncommitted files pass locally and
+fail remotely. Before every `git push` of a submission branch, run:
+
+```
+verify/prepush_prose_check.sh <pr-body.md>
+```
+
+It re-runs the check inside a clean worktree of HEAD (committed content only), which fails
+exactly when CI would. It must exit 0 before the push. Treat this as part of pushing, not
+as an optional review step — the working-tree check proves nothing about what CI sees.
+
 A note named `<n>-<k>-<d>.md` must state its own `[[n,k,d]]` first. Follow
 `notes/TEMPLATE.md`; its sections are what a later searcher reads.
 

--- a/verify/prepush_prose_check.sh
+++ b/verify/prepush_prose_check.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Pre-push prose gate: reproduce CI's view of a submission branch before pushing.
+#
+# CI checks the PR body and changed notes against a tree containing ONLY
+# committed files. A local working-tree run of check_prose.py cannot catch
+# citations to uncommitted files, because those files exist locally. This
+# script runs the check inside a clean worktree of HEAD (staged + committed
+# content only), so it fails exactly when CI would.
+#
+# Usage: verify/prepush_prose_check.sh <pr-body-file>
+#   The PR body must be given as a file; pass /dev/null if you have none yet.
+#
+# Exit 0 = safe to push. Anything else = fix the reported paths first.
+
+set -e
+
+BODY=${1:?usage: verify/prepush_prose_check.sh <pr-body-file>}
+ROOT=$(git rev-parse --show-toplevel)
+WT=$(mktemp -d "${TMPDIR:-/tmp}/prose-check.XXXXXX")
+
+trap 'git worktree remove --force "$WT" 2>/dev/null' EXIT
+
+# Clean checkout of everything COMMITTED at HEAD. Uncommitted or untracked
+# files are invisible here -- which is the entire point.
+git worktree add --detach "$WT" HEAD >/dev/null 2>&1
+
+CHANGED=$(git diff --name-only --diff-filter=AMR origin/main...HEAD \
+          -- notes/ fieldnotes/ || true)
+
+if [ -z "$CHANGED" ]; then
+    echo "no changed notes/fieldnotes vs origin/main; checking PR body only"
+    exec python3 "$ROOT/verify/check_prose.py" \
+        --root "$WT" --base origin/main --body-file "$BODY"
+fi
+
+# Pass the file list via xargs-style splitting; check_prose.py takes --files
+# as nargs="*", so word splitting is what we want here (paths have no spaces).
+# shellcheck disable=SC2086
+python3 "$ROOT/verify/check_prose.py" \
+    --root "$WT" \
+    --base origin/main \
+    --body-file "$BODY" \
+    --files $CHANGED

--- a/verify/prepush_prose_check.sh
+++ b/verify/prepush_prose_check.sh
@@ -2,12 +2,10 @@
 # Pre-push prose gate: reproduce CI's view of a submission branch before pushing.
 #
 # CI checks the PR body and changed notes against a tree containing ONLY
-# committed files. A local working-tree run of check_prose.py cannot catch
-# citations to uncommitted files, because those files exist locally. This
-# script runs the check inside a clean worktree of HEAD (staged + committed
-# content only), so it fails exactly when CI would.
+# committed files. This script runs the check inside a clean worktree of
+# HEAD, so it fails exactly when CI would.
 #
-# Usage: verify/prepush_prose_check.sh <pr-body-file>
+# Usage: BASE=origin/main verify/prepush_prose_check.sh <pr-body-file>
 #   The PR body must be given as a file; pass /dev/null if you have none yet.
 #
 # Exit 0 = safe to push. Anything else = fix the reported paths first.
@@ -15,29 +13,40 @@
 set -e
 
 BODY=${1:?usage: verify/prepush_prose_check.sh <pr-body-file>}
+BASE=${BASE:-origin/main}
 ROOT=$(git rev-parse --show-toplevel)
 WT=$(mktemp -d "${TMPDIR:-/tmp}/prose-check.XXXXXX")
 
-trap 'git worktree remove --force "$WT" 2>/dev/null' EXIT
+cleanup() { git worktree remove --force "$WT" >/dev/null 2>&1 || rm -rf "$WT"; }
+trap cleanup EXIT
 
-# Clean checkout of everything COMMITTED at HEAD. Uncommitted or untracked
-# files are invisible here -- which is the entire point.
-git worktree add --detach "$WT" HEAD >/dev/null 2>&1
-
-CHANGED=$(git diff --name-only --diff-filter=AMR origin/main...HEAD \
-          -- notes/ fieldnotes/ || true)
-
-if [ -z "$CHANGED" ]; then
-    echo "no changed notes/fieldnotes vs origin/main; checking PR body only"
-    exec python3 "$ROOT/verify/check_prose.py" \
-        --root "$WT" --base origin/main --body-file "$BODY"
+# Fail loudly on uncommitted work: the worktree shows committed content only,
+# so a dirty tree means the gate would not see what you might push.
+if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: working tree is dirty; commit (or stash) before running the gate." >&2
+    exit 2
 fi
 
-# Pass the file list via xargs-style splitting; check_prose.py takes --files
-# as nargs="*", so word splitting is what we want here (paths have no spaces).
-# shellcheck disable=SC2086
-python3 "$ROOT/verify/check_prose.py" \
-    --root "$WT" \
-    --base origin/main \
-    --body-file "$BODY" \
-    --files $CHANGED
+# Verify the base ref exists BEFORE degrading behavior on it.
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+    echo "ERROR: base ref '$BASE' not found; fetch or set BASE=<ref>." >&2
+    exit 2
+fi
+
+git worktree add --detach "$WT" HEAD >/dev/null
+
+CHANGED=$(git diff --name-only --diff-filter=AMR "$BASE...HEAD" \
+          -- notes/ fieldnotes/ || true)
+
+PY=${QLDPC_PYTHON:-python3}
+
+# No exec here: exec would skip the EXIT trap and leak the worktree.
+if [ -z "$CHANGED" ]; then
+    echo "no changed notes/fieldnotes vs $BASE; checking PR body only"
+    "$PY" "$ROOT/verify/check_prose.py" \
+        --root "$WT" --base "$BASE" --body-file "$BODY"
+else
+    # shellcheck disable=SC2086
+    "$PY" "$ROOT/verify/check_prose.py" \
+        --root "$WT" --base "$BASE" --body-file "$BODY" --files $CHANGED
+fi


### PR DESCRIPTION
## What

A local run of `verify/check_prose.py` validates cited paths against the working tree — where uncommitted files exist. CI validates against the PR tree only. Citations to uncommitted files therefore pass locally and fail remotely (observed on PR #725: the note cited a fieldnote that existed locally but was not committed).

## Fix

`verify/prepush_prose_check.sh <pr-body.md>` re-runs the prose check inside a clean git worktree of HEAD (committed content only), so it fails exactly when CI would. AGENTS.md documents it as a mandatory step before every push of a submission branch.

## Validation

- Reintroduced the exact bad citation that broke #725 in a scratch commit: gate fails with the same message CI produced.
- Reverted: gate passes.
- Note: this PR touches verify/, so per the submission-scope rule it must be reviewed/merged independently of any code-submission PR.