### PR TITLE
Add [[18,4,3]] from a SAT search at an odd weight cap

### DIFF
--- a/codes/18-4-3.json
+++ b/codes/18-4-3.json
@@ -1,0 +1,140 @@
+{
+ "schema_version": "0.1",
+ "name": "[[18,4,3]]",
+ "code_type": "CSS",
+ "n": 18,
+ "k": 4,
+ "checks": {
+  "X": [
+   [
+    0,
+    6,
+    8,
+    13,
+    14
+   ],
+   [
+    0,
+    3,
+    4,
+    6,
+    9
+   ],
+   [
+    10,
+    12,
+    13,
+    16
+   ],
+   [
+    0,
+    2,
+    13,
+    15,
+    17
+   ],
+   [
+    1,
+    2,
+    11,
+    16
+   ],
+   [
+    3,
+    4,
+    7,
+    11,
+    14
+   ],
+   [
+    0,
+    4,
+    5,
+    10,
+    15
+   ]
+  ],
+  "Z": [
+   [
+    6,
+    9,
+    12,
+    13,
+    17
+   ],
+   [
+    5,
+    7,
+    10,
+    11,
+    16
+   ],
+   [
+    2,
+    4,
+    9,
+    11,
+    15
+   ],
+   [
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   [
+    0,
+    3,
+    7,
+    10,
+    13
+   ],
+   [
+    1,
+    8,
+    13,
+    16,
+    17
+   ],
+   [
+    0,
+    7,
+    9,
+    14,
+    15
+   ]
+  ]
+ },
+ "distance": {
+  "d": 3,
+  "X": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    0,
+    3,
+    14
+   ]
+  },
+  "Z": {
+   "value": 3,
+   "confidence": "upper_bound",
+   "witness": [
+    6,
+    8,
+    9
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@vprusso"
+  ],
+  "construction": "SAT-solver code discovery (arXiv:2608.23460 Sec. VI adapted to CSS): CNF over X/Z row-incidence variables, even-overlap commutation clauses for HX HZ^T = 0, per-error detection clauses for every Pauli of weight <= 2, and a Sinz sequential-counter bound of 5 on each row weight; solved with Minisat22 at n=18 with 7 rows per side",
+  "origin": "submission",
+  "date": "2026-08-26",
+  "model": "Claude Fable 5"
+ },
+ "family": "other"
+}

--- a/notes/18-4-3.md
+++ b/notes/18-4-3.md
@@ -1,0 +1,89 @@
+# [[18,4,3]] — SAT-solver code discovery at an odd weight cap
+
+## Direction & hypothesis
+
+Weight-6 x unrestricted cell. The board is 85% even-weight: 56 entries at
+w = 4, 114 at w = 6, 71 at w = 8, against 4 at w = 5 and 6 at w = 7. That is an
+artifact of which constructions have been run rather than a fact about codes.
+Two-block families give `w = wt(a) + wt(b)` and every sweep so far used
+symmetric supports; hypergraph and lifted products sum two degrees. Both land
+on even weights, and nothing had systematically searched an odd cap.
+
+SAT is the tool that can, because an exact weight bound is a native constraint
+rather than something a construction happens to satisfy. The hypothesis was
+simply that the odd caps are unsearched rather than empty.
+
+A caveat worth stating up front, because it nearly sank this submission: the
+board's weight classes are weight-4, weight-6, weight-8 and weight-9plus, so a
+weight-5 code competes in the weight-6 class against all 114 of its members.
+There is no weight-5 cell to fill. The code has to earn its place on (n, k, d)
+against weight-6 entries, with its lower raw weight as a ranking axis inside
+the cell. This one does: nothing on the board with n <= 18 reaches k >= 4 at
+d >= 3 with w <= 5.
+
+## What was searched
+
+`research/sat_search.py` (committed with PR #709): CNF over X/Z row-incidence
+variables, even-overlap commutation chains encoding `HX HZ^T = 0`, per-error
+detection clauses for every Pauli of weight <= 2, and a Sinz sequential-counter
+bound on each row weight; distinct solutions enumerated by blocking clauses.
+
+Sweep over `n` in [18, 38] with `w <= 5` and `t = 2` (so `d >= 3`), taking the
+number of check rows per side as the second dial. The instance that produced
+this code is n = 18 with 7 rows per side, solved in seconds.
+
+## Evidence trail
+
+Submitted claim: `d <= 3`, a witness-backed upper bound, not exact.
+
+- SAT guarantees `d >= 3` by construction, since every weight-2 error is
+  detected.
+- `qldpc submit` at 20k RIS trials: `d_X <= 3`, `d_Z <= 3`.
+- Both bounds meet the encoding's floor, so `d = 3` exactly, though the entry
+  records the honest upper-bound tier rather than claiming exactness through
+  an argument the verifier cannot check.
+
+k = 4 was recomputed from the check matrices rather than taken from the solver.
+Row weights are 4 and 5 on the X side and 5 throughout the Z side, so the
+computed class is weight-6 and the raw weight is 5.
+
+## Dead ends
+
+- **The ordering of the sweep mattered more than the encoding.** Ascending in
+  row count, so that each `n` starts at the fewest checks, puts the hardest
+  instance first: reaching `k >= 3` needs FEWER checks than the sweeps that are
+  known to work, and fewer checks makes detection harder to satisfy. That
+  version burned a 240 s cap on the first instance and would have burned every
+  cap in turn. Descending from the satisfiable boundary outward found this code
+  in seconds. Same solver, same encoding, same budget.
+- **Weight 4 at `k >= 3` looks genuinely hard, not merely unsearched.** At
+  n = 12 every rank split summing to 9 returns UNSAT, so no weight-4 CSS code
+  on 12 qubits with `k >= 3` detects every weight-2 error, at any pair of check
+  counts. n = 14 and n = 16 fall for every unbalanced split but their balanced
+  splits did not resolve; one ran two and a half hours. That is the SAT phase
+  transition sitting where the two check counts are nearly equal.
+- **Sweeping equal check counts proves nothing about a blocklength.** The
+  generator applies one row count to both sides and its solutions come out with
+  `rank(HX) = rank(HZ)`, so a sweep over that parameter walks the diagonal of
+  the `(rX, rZ)` plane. Closing an `n` needs the splits, which needs an
+  asymmetric variant of the generator.
+
+## Tools
+
+Claude Fable 5, matching `provenance.model`. `research/sat_search.py` with
+python-sat / Minisat22; `verify/qldpc_verify.py` and
+`verify/validate_candidate.py` for the gate. Laptop-scale: seconds per
+satisfiable instance, and the unsatisfiable ones are where the time goes.
+
+## Reproduction
+
+```
+uv run --with python-sat python - <<'PY'
+import sys
+sys.path.insert(0, "research")
+from sat_search import enumerate_sat_codes
+spec, HX, HZ = next(iter(enumerate_sat_codes(18, 7, 5, 2, max_codes=1)))
+PY
+```
+
+n = 18, 7 rows per side, max row weight 5, detect every weight-<= 2 error.


### PR DESCRIPTION
## Code submission

- Parameters: `[[18,4,3]]`, check weight 5
- Track: weight-6 / unrestricted (computed by the verifier)
- Distance confidence: X and Z both `upper_bound`
- Score: kd²/n = 2.0

### Checklist
- [x] One JSON file under `codes/`, conforming to `schema/code.schema.json`
- [x] Distance witness included for each side
- [x] `verify/qldpc_verify.py` passes locally
- [x] Construction and references filled in under `provenance`
- [x] Checked against existing entries: `validate_candidate` returns `board_advancing: true` with an empty dominator list

## What frontier does this advance?

Nothing on the board with n ≤ 18 reaches k ≥ 4 at d ≥ 3 with check weight ≤ 5. Its neighbours make the shape clear: the board holds `[[18,4,4]]` at w=6 and `[[16,2,4]]` at w=4, and this reaches k=4 at weight 5.

The score is 2.0, so this is not a headline code. The interest is where it comes from.

## Why the odd weight cap

The board is 85% even-weight: 56 entries at w=4, 114 at w=6, 71 at w=8, against 4 at w=5 and 6 at w=7. That is an artifact of which constructions have been run rather than a fact about codes. Two-block families give `w = wt(a) + wt(b)` and every sweep so far used symmetric supports; hypergraph and lifted products sum two degrees. Both land on even weights. SAT can impose an exact odd bound directly, which is what this uses.

Worth being precise about what that does and does not buy, since I got it wrong first time round: the board's weight classes are weight-4, weight-6, weight-8 and weight-9plus, so there is no weight-5 cell to fill. A weight-5 code competes in the weight-6 class against all 114 of its members and has to earn its place on (n, k, d), with raw weight as a ranking axis inside the cell.

## Distance

The encoding guarantees `d >= 3` by detecting every weight-2 error, and RIS at 20k trials finds weight-3 logicals on both sides, so the bounds meet. The entry still records the upper-bound tier rather than claiming exactness through an argument the verifier cannot check itself.

## Note

`notes/18-4-3.md` carries the failures, which are the more useful half: the sweep only works when it descends from the satisfiable boundary rather than ascending into it (same solver, same budget, the ordering was the whole difference); weight 4 at k ≥ 3 is provably impossible at n = 12 and unresolved at 14 and 16; and sweeping equal check counts cannot close a blocklength at all, since the generator's solutions have equal rank on both sides and only walk the diagonal of the (rX, rZ) plane.

## History

I withdrew this code earlier on a misreading. I had validated it from inside `codes/`, where it matched its own fingerprint, and read the resulting `board_advancing: false` with an empty dominator list as a novelty rejection rather than as self-comparison. Re-validated from outside the corpus it passes. That trap is filed separately as #728.