### PR TITLE
Do not report a novelty verdict the gate never reached

### DIFF
--- a/verify/test_validate_candidate.py
+++ b/verify/test_validate_candidate.py
@@ -66,6 +66,27 @@ def main():
     check("computed cell is weight-6 x unrestricted",
           vg["gates"]["novelty"]["cell"] == ["weight-6", "unrestricted"])
 
+    print("1b. a code compared against ITSELF reports no novelty verdict:")
+    # Validating a doc already on the board (issue #728) makes the dedup gate
+    # fire. Reporting that as "does not advance its board cell" with an empty
+    # dominator list describes a rejection on merit that never happened, and it
+    # cost a real submission that was in fact board-advancing.
+    import glob
+    onboard = sorted(glob.glob(os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "codes", "*.json")))
+    if onboard:
+        with open(onboard[0]) as f:
+            dup = json.load(f)
+        vd = V.validate_candidate(dup, seed=SEED)
+        check("dedup fires", vd["gates"]["dedup"]["exact_duplicate_of"] is not None)
+        check("novelty verdict withheld, not falsified",
+              vd["gates"]["novelty"]["board_advancing"] is None)
+        check("label names the duplicate, not a cell failure",
+              any("already on the board" in x for x in vd["labels"])
+              and not any("does not advance" in x for x in vd["labels"]))
+        check("still fails the gate", not vd["passed"])
+
     print("2. an OVER-CLAIM (same checks, inflated witnesses) is rejected:")
     vx = heavy_witness(HX, HZ, n, 20, 1)
     vz = heavy_witness(HZ, HX, n, 20, 2)

--- a/verify/validate_candidate.py
+++ b/verify/validate_candidate.py
@@ -186,12 +186,23 @@ def validate_candidate(doc, *, seed=None, refute=True):
             if (b["n"] <= n and b["k"] >= k and b["d"] >= d and bw <= w
                     and (b["n"] < n or b["k"] > k or b["d"] > d or bw < w)):
                 dominators.append(f"[[{b['n']},{b['k']},{b['d']}]] w={bw} {b['name']}")
-    board_advancing = not dominators and not exact_dup
+    # Novelty against a board that already contains this exact code is not a
+    # well-posed question, so say which condition fired rather than reporting a
+    # verdict that was never reached. Validating a file already sitting in
+    # codes/ compares it with itself, and the old label ("does not advance its
+    # board cell", with an empty dominator list) reads as a rejection on
+    # merit -- which cost a real submission that was in fact board-advancing.
+    board_advancing = None if exact_dup else not dominators
     g["novelty"] = {"cell": [wc, lc], "board_advancing": board_advancing,
                     "dominated_by": dominators, "literature_novelty": "unverified"}
-    verdict["labels"].append(
-        f"advances the {wc} x {lc} board" if board_advancing
-        else "does not advance its board cell")
+    if exact_dup:
+        verdict["labels"].append(
+            "novelty not assessed: this code is already on the board "
+            f"as {exact_dup}")
+    else:
+        verdict["labels"].append(
+            f"advances the {wc} x {lc} board" if board_advancing
+            else "does not advance its board cell")
     verdict["labels"].append("literature novelty UNVERIFIED")
 
     verdict["passed"] = bool(verify_ok and not refuted and not exact_dup)

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Pinned SHA-256 of the trusted autoresearch validation stack. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
-    "validate_candidate.py": "54cc54f6282506baafe1ac8f97c9f479a017a25c66b0426172ca1a4799fa2892",
+    "validate_candidate.py": "e85d28612a9b798e4693c86bbaacc3fd84a674890fe6af4d8253cf07018183b1",
     "qldpc_verify.py": "71308665b86762335d71300e4a8507fff9466986ee68a5fcd1c4df72406f946f",
     "heuristic_distance.py": "57d9e56ce8a409e6cb1a63f48e98878624f0df611b8578c32839b7bfd00989fe",
     "gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",


### PR DESCRIPTION
Closes #728.

## The bug

Validating a code that already sits in `codes/` compares it against itself, so the dedup gate fires. `board_advancing` was then `false` with an empty `dominated_by`, and the label printed was "does not advance its board cell".

That describes a rejection on merit which never happened. No novelty comparison failed; the code simply matched its own fingerprint.

## Why it matters

It cost a real submission. I validated a candidate after `qldpc submit` had written it into `codes/`, read the label as a genuine rejection, withdrew the code, and filed #713 against a weight-rule disagreement between the site and the gate that does not exist. Re-validated from a path outside `codes/`, the same `[[18,4,3]]` returns `board_advancing: true`, and it is now up as #729.

The state is distinguishable rather than ambiguous: an empty `dominated_by` alongside a false verdict is reachable only through self-comparison.

## The change

`board_advancing` is `None` when the candidate is an exact duplicate, and the label names the duplicate instead of asserting a cell failure.

Pass/fail is unchanged. `verdict["passed"]` already keyed off `exact_dup` directly rather than off `board_advancing`, so a duplicate still fails the gate; only the stated reason changes. Nothing in the repo reads `board_advancing` programmatically, the only other references being prose in research notes, so `None` breaks no consumer.

## Test

Added to the existing gate test rather than a new file: dedup fires, the novelty verdict is withheld rather than falsified, the label names the duplicate and does not claim a cell failure, and the candidate still fails.

## Scope

`validate_candidate.py` is in the trusted manifest, so the re-pin is included and the diff wants reviewing alongside the code. No new lint findings (12 either way).