### PR TITLE
Filter the board by whether an entry ships stim circuits (#731)

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1130,6 +1130,12 @@ document.addEventListener('click',e=>{
   // ones a refutation could still move.
   if(t==='exact'||t==='certified')return r.dataset.tier==='exact';
   if(t==='upper-bound'||t==='unproven')return r.dataset.tier!=='exact';
+  // Circuit tier (issue #731). 'with-circuit' keeps the entries that ship
+  // verified syndrome-extraction memory circuits (the gear chip); the plain
+  // 'circuit' alias is what people type. Matched on the row's flag rather
+  // than the search blob so 'no-circuit' cannot substring-match the rest.
+  if(t==='with-circuit'||t==='circuit')return r.dataset.circ==='1';
+  if(t==='no-circuit')return r.dataset.circ!=='1';
   // cell:<locality>~<weight> keeps only the members of one primary-track cell,
   // honoring nesting via the row's precomputed data-cells list.
   if(t.slice(0,5)==='cell:')return (' '+(r.dataset.cells||'')+' ').indexOf(' '+t.slice(5)+' ')>=0;
@@ -3447,6 +3453,13 @@ def board_controls(entries, records):
     if any(e["locality_class"] != "unrestricted" for e in entries):
         tabs += ('<button type=button class=ttab data-q="2d-local" '
                  'title="2D-local codes">2D-local</button>')
+    # circuit tier (issue #731): only worth a tab once an entry ships circuits,
+    # like the 2D-local tab above. The gear matches the row chip.
+    if any(e["d_circ"] is not None for e in entries):
+        tabs += ('<button type=button class=ttab data-q="with-circuit" '
+                 'title="codes shipping verified syndrome-extraction memory '
+                 'circuits with a witnessed circuit-level distance">'
+                 '&#9881; circuit</button>')
     families = sorted({e["family"] for e in entries})
     tabs += "".join(
         f'<button type=button class=ttab data-q="{html.escape(FAMILY_TERM.get(f, f))}" '
@@ -3536,7 +3549,9 @@ def board_controls(entries, records):
             '<code>submitted</code> filter by origin; <code>with-layout</code> '
             '/ <code>no-layout</code> filter by layout status; '
             '<code>exact</code> / <code>upper-bound</code> filter by whether '
-            'the distance is proved.</p>'
+            'the distance is proved; <code>with-circuit</code> (alias '
+            '<code>circuit</code>) / <code>no-circuit</code> filter by whether '
+            'the entry ships verified memory circuits.</p>'
             '</section>')
 
 
@@ -3673,6 +3688,7 @@ def board_table(entries, records):
             f'data-cells="{html.escape(cell_keys)}" '
             f'data-record="{1 if fr else 0}" '
             f'data-tier="{e["tier"]}" '
+            f'data-circ="{1 if e["d_circ"] is not None else 0}" '
             f'data-origin="{"literature" if e["origin"] == "baseline" else "submitted"}" '
             f'data-model="{html.escape(e["model"].lower())}" '
             f'data-date="{html.escape(e["date"])}" '


### PR DESCRIPTION
Closes #731.

The circuit tier went 3 → 7 entries (#707, #722, #723, #724), and the gear chip marked them without any way to select them — "show me the codes with circuits" meant scanning 378 rows.

Both entry points requested in the issue:

- **Search token**: `with-circuit` (alias `circuit`) / `no-circuit`, following the `exact` / `upper-bound` precedent from #527, with the help line extended to document it.
- **Tab/pill**: a `⚙ circuit` tab in the strip next to *2D-local*, rendered only once some entry ships circuits — the same conditional the 2D-local tab uses.

Matching is on a new `data-circ` row flag rather than the search blob, so `no-circuit` can't substring-match the other rows the way a blob token would. The flag is derived from the same `e["d_circ"]` the gear chip already uses, so chip and filter cannot disagree.

### Verified in a browser against the built board
- `⚙ circuit` tab → exactly the 7 circuit entries (16-2-4, 25-1-5, 36-2-6, 49-1-7, 64-2-8, 72-12-6, 81-1-9); tab highlights and the search box syncs to `with-circuit`
- `circuit` alias → 7; `no-circuit` → 371; 7 + 371 = 378 listed
- composes with existing terms and sliders: `with-circuit d>=6` → 5
- `clear filters` resets to 378 and re-activates *All*
- row flag matches the rendered gear chip on all 378 rows; `site/test_security.py` passes (5/5)

`docs/` is left untouched — the site workflow rebuilds and commits it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)