### PR TITLE
Add help text to five bare flags, reject a .json --out path

### DIFF
--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -443,6 +443,13 @@ def validate_authors(authors, anonymous=False):
 
 
 def cmd_submit(args):
+    if args.out.endswith(".json"):
+        raise SystemExit(
+            f"--out expects a directory, not a filename: {args.out!r}\n"
+            "The output filename is always <n>-<k>-<d>.json, computed after "
+            "verification, so it is not yours to choose. Pass the directory "
+            f"it should go in instead, e.g. --out {os.path.dirname(args.out) or '.'}"
+        )
     args.authors = validate_authors(args.authors, args.anonymous)
     HX, HZ, coords, _draft = load_checks(args.code)
     if args.coords:                      # explicit coords file overrides
@@ -700,7 +707,9 @@ def main(argv=None):
                         "version, e.g. 'Claude Opus 4.8' (not a bare 'Claude'), or "
                         "'human' (claimed, not verified; the verifier requires a "
                         "version if a model is named)")
-    s.add_argument("--notes", default="")
+    s.add_argument("--notes", default="",
+                   help="short free-text notes recorded on the submission "
+                        "(not the research note; see --note-file)")
     s.add_argument("--note-file", default="",
                    help="markdown research note staged as notes/<slug>.md and "
                         "rendered publicly beside the code: the search story "
@@ -708,7 +717,9 @@ def main(argv=None):
                         "ends (see notes/TEMPLATE.md; 10 KiB cap)")
     s.add_argument("--date", default="",
                    help="submission date (YYYY-MM-DD); defaults to today")
-    s.add_argument("--name", default="")
+    s.add_argument("--name", default="",
+                   help="display name for the construction; defaults to the "
+                        "auto-generated [[n,k,d]] name")
     s.add_argument("--family", choices=[
                        "bivariate-bicycle", "generalized-bicycle", "2bga-coset",
                        "hypergraph-product", "lifted-product", "balanced-product",
@@ -726,8 +737,13 @@ def main(argv=None):
     s.add_argument("--fast-trials", type=int, default=2_000_000,
                    help="gf2_fast trials used to tighten the claim "
                         "(0 disables the accelerator)")
-    s.add_argument("--seed", type=int, default=0)
-    s.add_argument("--out", default=os.path.join(_ROOT, "codes"))
+    s.add_argument("--seed", type=int, default=0,
+                   help="seed for the RIS distance-witness search "
+                        "(default 0; pass a different value to search a "
+                        "fresh set of trials)")
+    s.add_argument("--out", default=os.path.join(_ROOT, "codes"),
+                   help="output DIRECTORY (default: codes/); the filename is "
+                        "always <n>-<k>-<d>.json and is not yours to choose")
     s.add_argument("--force", action="store_true",
                    help="overwrite an existing codes/<slug>.json")
     s.add_argument("--dry-run", action="store_true",
@@ -739,7 +755,8 @@ def main(argv=None):
     r = sub.add_parser("recent", help="what landed recently: codes, research "
                                       "notes, fieldnotes (read before you "
                                       "search)")
-    r.add_argument("--days", type=int, default=14)
+    r.add_argument("--days", type=int, default=14,
+                   help="look back this many days (default 14)")
     r.set_defaults(func=cmd_recent)
 
     g = sub.add_parser("targets", help="which track cells are open: occupancy "

--- a/verify/test_cli_out_flag.py
+++ b/verify/test_cli_out_flag.py
@@ -1,0 +1,37 @@
+"""Regression tests for --out validation (issue #638)."""
+
+import pytest
+
+import qldpc
+
+
+def _fail_if_code_is_loaded(_path):
+    raise AssertionError("--out must be checked before loading the code")
+
+
+def test_submit_rejects_json_path_before_loading_code(monkeypatch):
+    monkeypatch.setattr(qldpc, "load_checks", _fail_if_code_is_loaded)
+
+    with pytest.raises(SystemExit, match=r"--out expects a directory"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "--out", "/tmp/probe.json",
+        ])
+
+
+def test_submit_accepts_directory_out_and_reaches_code_loading(monkeypatch):
+    reached = []
+
+    def record_load(path):
+        reached.append(path)
+        raise RuntimeError("load reached")
+
+    monkeypatch.setattr(qldpc, "load_checks", record_load)
+
+    with pytest.raises(RuntimeError, match="load reached"):
+        qldpc.main([
+            "submit", "must-not-be-loaded.npz",
+            "--authors", "@vprusso", "--out", "/tmp/some-output-dir",
+        ])
+
+    assert reached == ["must-not-be-loaded.npz"]


### PR DESCRIPTION
Fixes #638.

`--notes`, `--name`, `--seed`, `--out`, and `--days` had no `help=`, so they rendered bare in `--help`. Added a one-line `help=` to each.

`--out` was the confusing one: it's always treated as a directory (the filename is auto-generated as `<n>-<k>-<d>.json` after verification), so passing something that looks like a filename, e.g. `--out /tmp/probe.json`, surfaced as a raw traceback from deep in `makedirs`/`open` instead of a clear message. I reproduced it locally — the actual exception is `FileExistsError` when the path already exists as a file (not `IsADirectoryError` as in the issue body, but same root cause: the flag never checks whether the value looks like a filename).

Added an early check in `cmd_submit` that rejects a `.json` `--out` path before any verification work happens, and a regression test (`verify/test_cli_out_flag.py`) following the existing `test_cli_authors.py` pattern — asserts the check fires before the code is even loaded, and that a normal directory path still reaches loading.

Full suite (`run_tests.py --skip-slow`) passes: 137 passed, 8 skipped.