### PR TITLE
Replace --dry-run JSON prefix with a summary preview (#637)

### DIFF
--- a/cli/qldpc.py
+++ b/cli/qldpc.py
@@ -442,6 +442,49 @@ def validate_authors(authors, anonymous=False):
     return normalized
 
 
+def dry_run_summary(doc, report, out):
+    """Print a screen-sized preview of what submit would write.
+
+    The parameters and score, the distance claim per side, the computed track
+    cells, and the provenance the contributor chose. Replaces the old
+    truncated JSON prefix, which never reached the fields a contributor
+    actually wants to confirm (issue #637).
+    """
+    comp = report.get("computed", {})
+    entry = _entry_for(doc, report)
+    dist = doc["distance"]
+    per_side = []
+    for side in ("X", "Z"):
+        s = dist.get(side, {})
+        witness = "witness found" if s.get("witness") else "no witness"
+        per_side.append(f"{side}: <= {s.get('value')} ({s.get('confidence')}, {witness})")
+    track_cells = ", ".join(
+        f"{LOCALITY_LABEL.get(L, L)} / {WEIGHT_LABEL.get(W, W)}"
+        for L, W in cells(entry)
+    )
+    lines = [
+        f"  code         [[{doc['n']},{doc['k']},{dist['d']}]]",
+        f"  score        kd^2/n = {entry['eff']}",
+        f"  checks       max weight {entry['w']} ({comp.get('weight_class', '?')})",
+        f"  locality     {comp.get('locality_class', 'unrestricted')}",
+        f"  track cells  {track_cells or '(none computed)'}",
+        f"  distance     d <= {dist['d']} (upper_bound)",
+        "               " + "  |  ".join(per_side),
+    ]
+    prov = doc.get("provenance", {})
+    for label, value in (
+        ("authors", ", ".join(prov.get("authors", []))),
+        ("family", doc.get("family")),
+        ("model", prov.get("model")),
+        ("construction", prov.get("construction")),
+        ("notes", prov.get("notes")),
+    ):
+        if value:
+            lines.append(f"  {label:<12} {value}")
+    lines.append("  next         --json prints the full document; drop --dry-run to write")
+    return "\n".join(lines)
+
+
 def cmd_submit(args):
     args.authors = validate_authors(args.authors, args.anonymous)
     HX, HZ, coords, _draft = load_checks(args.code)
@@ -469,7 +512,10 @@ def cmd_submit(args):
     out = os.path.join(args.out, f"{slug}.json")
     if args.dry_run:
         print(f"\n--dry-run: would write {out}")
-        print(json.dumps(doc, indent=1)[:600] + " ...")
+        if args.json:
+            print(json.dumps(doc, indent=1))
+        else:
+            print(dry_run_summary(doc, report, out))
         return 0
     if os.path.exists(out) and not args.force:
         print(f"\n{out} already exists. Use --force to overwrite, or rename.")
@@ -732,6 +778,9 @@ def main(argv=None):
                    help="overwrite an existing codes/<slug>.json")
     s.add_argument("--dry-run", action="store_true",
                    help="build and verify but do not write the file")
+    s.add_argument("--json", action="store_true",
+                   help="with --dry-run, print the full submission JSON "
+                        "instead of the summary")
     s.add_argument("--open-pr", action="store_true",
                    help="create the branch, commit, push, and open the PR")
     s.set_defaults(func=cmd_submit)

--- a/verify/test_cli_dry_run.py
+++ b/verify/test_cli_dry_run.py
@@ -1,0 +1,131 @@
+"""Regression tests for the --dry-run preview (issue #637).
+
+The old preview printed a raw 600-character prefix of the JSON, which
+truncated mid-field and never reached the distance block on a board-sized
+code. The preview must now be a summary naming the output path, and the full
+document must remain available behind --json.
+"""
+
+import json
+
+import qldpc
+
+
+def _doc():
+    return {
+        "schema_version": "0.1",
+        "name": "[[7,1,3]]",
+        "code_type": "CSS",
+        "n": 7,
+        "k": 1,
+        "checks": {"X": [[0, 1, 2]], "Z": [[0, 3, 4]]},
+        "distance": {
+            "d": 3,
+            "X": {"value": 3, "confidence": "upper_bound", "witness": [0, 1, 2]},
+            "Z": {"value": 3, "confidence": "upper_bound", "witness": [0, 3, 4]},
+        },
+        "provenance": {
+            "authors": ["@me"],
+            "construction": "steane construction",
+            "origin": "submission",
+            "date": "2026-09-02",
+        },
+        "family": "topological",
+    }
+
+
+def _report():
+    return {
+        "ok": True,
+        "checks": [],
+        "computed": {
+            "n": 7,
+            "k": 1,
+            "max_check_weight": 3,
+            "weight_class": "weight-4",
+            "locality_class": "unrestricted",
+        },
+        "earned_distance": {"d": {"value": 3, "tier": "upper_bound"}},
+    }
+
+
+def test_dry_run_prints_summary_naming_output_path(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(qldpc, "load_checks", lambda _path: (None, None, None, None))
+    monkeypatch.setattr(qldpc, "build_submission", lambda _hx, _hz, args: _doc())
+    monkeypatch.setattr(qldpc, "verify", lambda _doc, refute: _report())
+    out = str(tmp_path / "codes")
+
+    rc = qldpc.main(["submit", "x.npz", "--authors", "@me", "--dry-run", "--out", out])
+
+    assert rc == 0
+    text = capsys.readouterr().out
+    assert f"--dry-run: would write {out}/7-1-3.json" in text
+    # the fields a contributor is deciding on
+    assert "[[7,1,3]]" in text
+    assert "kd^2/n" in text
+    assert "max weight 3" in text
+    assert "unrestricted" in text
+    assert "upper_bound" in text
+    assert "witness found" in text
+    assert "authors" in text and "@me" in text
+    assert "topological" in text
+    # no truncated field names: the old prefix printed a bare " ..." marker
+    assert " ..." not in text
+    # nothing is written
+    import os
+
+    assert not os.path.exists(out)
+
+
+def test_dry_run_track_cells_are_labeled(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(qldpc, "load_checks", lambda _path: (None, None, None, None))
+    monkeypatch.setattr(qldpc, "build_submission", lambda _hx, _hz, args: _doc())
+    monkeypatch.setattr(qldpc, "verify", lambda _doc, refute: _report())
+    out = str(tmp_path / "codes")
+
+    qldpc.main(["submit", "x.npz", "--authors", "@me", "--dry-run", "--out", out])
+
+    text = capsys.readouterr().out
+    # weight-4 / unrestricted belongs to the nested grid: every weight class
+    # cell (<=4, <=6, <=8, any) and the unrestricted locality cell
+    assert "weight ≤ 4" in text
+    assert "unrestricted" in text
+
+
+def test_dry_run_json_flag_prints_full_document(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(qldpc, "load_checks", lambda _path: (None, None, None, None))
+    monkeypatch.setattr(qldpc, "build_submission", lambda _hx, _hz, args: _doc())
+    monkeypatch.setattr(qldpc, "verify", lambda _doc, refute: _report())
+    out = str(tmp_path / "codes")
+
+    qldpc.main(["submit", "x.npz", "--authors", "@me", "--dry-run", "--json", "--out", out])
+
+    text = capsys.readouterr().out
+    # the full document, parseable and complete (the old prefix cut mid-key)
+    start = text.index("{")
+    doc = json.loads(text[start:])
+    assert doc["distance"]["Z"]["witness"] == [0, 3, 4]
+
+
+def test_summary_is_screen_sized_for_a_board_scale_code():
+    doc = _doc()
+    doc["name"] = "[[684,12,81]]"
+    doc["n"], doc["k"] = 684, 12
+    doc["distance"]["d"] = 81
+    doc["checks"] = {"X": [[0, 1]] * 342, "Z": [[0, 1]] * 342}
+    doc["distance"]["X"] = {
+        "value": 81,
+        "confidence": "upper_bound",
+        "witness": list(range(81)),
+    }
+    report = _report()
+    report["computed"].update(n=684, k=12, max_check_weight=8)
+    report["earned_distance"]["d"] = {"value": 81, "tier": "upper_bound"}
+
+    text = qldpc.dry_run_summary(doc, report, "codes/684-12-81.json")
+
+    lines = text.splitlines()
+    assert len(lines) <= 12
+    # the distance block must survive on a board-sized code
+    assert "d <= 81" in text
+    assert "[[684,12,81]]" in text


### PR DESCRIPTION
## `--dry-run` preview: summary instead of truncated JSON

Fixes #637.

`--dry-run` is the main preview surface for a submission, but it printed a raw
600-character prefix of the JSON (`json.dumps(doc, indent=1)[:600] + " ..."`).
With `indent=1` that prefix is almost entirely the per-check support arrays,
cut mid-key, and on a board-sized code the distance block never appears at all.

The preview is now a screen-sized summary built from values the submit command
has already computed by that point — no new verification logic:

- `[[n,k,d]]` and `kd^2/n`;
- max check weight with its weight class, and the computed locality class;
- the track cells the code lands in, labeled with the same strings the board
  uses (reusing `cells`, `LOCALITY_LABEL`, `WEIGHT_LABEL` from the site
  builder, so the CLI cannot drift from the board);
- the distance claim per side: value, confidence, and whether a witness was
  found;
- provenance fields the contributor chose (authors, family, model,
  construction, notes) when present;
- the exact path that would be written.

The full document remains available: `--dry-run --json` prints the complete
submission JSON instead of the summary.

### Example output (Steane code)

```
--dry-run: would write codes/7-1-3.json
  code         [[7,1,3]]
  score        kd^2/n = 1.286
  checks       max weight 4 (weight-4)
  locality     unrestricted
  track cells  unrestricted / weight ≤ 4, unrestricted / weight ≤ 6, ...
  distance     d <= 3 (upper_bound)
               X: <= 3 (upper_bound, witness found)  |  Z: <= 3 (upper_bound, witness found)
  authors      @me
  next         --json prints the full document; drop --dry-run to write
```

### Acceptance from the issue

- `qldpc submit <code>.npz --authors @me --dry-run` prints a summary that fits
  on a screen and names the output path: covered by
  `verify/test_cli_dry_run.py`.
- No truncated field names in the output: asserted in
  `verify/test_cli_dry_run.py` (the old `" ..."` prefix marker must not
  appear).
- The board-scale regression test builds a `[[684,12,81]]`-shaped document and
  asserts the summary stays under 12 lines with the distance block intact.

### Notes

- This PR touches only `cli/qldpc.py` and the new
  `verify/test_cli_dry_run.py`; it changes no verification or certification
  code.
- Neighbor suites (`verify/test_cli_authors.py`,
  `verify/test_cli_targets.py`, `verify/test_frontier_summary.py`) pass, and
  the change adds no new ruff findings to `cli/qldpc.py`.
