### PR TITLE
Downloadable codes addressed by ID (#556)

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -1462,6 +1462,58 @@ def load_entries():
     return entries
 
 
+INDEX_MANIFEST = "_index.json"
+
+
+def codes_index(entries):
+    """Return the download manifest for the board (issue #556).
+
+    Every code's ID with its parameters, so the JSON served at
+    codes/<id>.json can be found and fetched programmatically. The ID is the
+    slug: the codes/ filename stem, unique on the board and validated against
+    _SAFE_SLUG.
+    """
+    return {
+        "codes": [
+            {
+                "id": e["slug"],
+                "n": e["n"],
+                "k": e["k"],
+                "d": e["d"],
+                "tier": e["tier"],
+            }
+            for e in sorted(entries, key=lambda e: (e["n"], e["k"], e["d"], e["slug"]))
+        ]
+    }
+
+
+def write_code_artifacts(entries):
+    """Write the per-code detail pages and the download artifacts (#556).
+
+    Each code's verified submission JSON is served at codes/<id>.json,
+    addressed by its ID, plus the _index manifest. Orphan files left behind
+    when a code is removed are pruned. The manifest stem starts with an
+    underscore so _SAFE_SLUG can never match it: a code can never collide
+    with the manifest, and "index" stays available as a code ID.
+    """
+    os.makedirs(os.path.join(DOCS, "codes"), exist_ok=True)
+    slugs = {e["slug"] for e in entries}
+    for e in entries:
+        with open(os.path.join(DOCS, "codes", e["slug"] + ".html"), "w") as f:
+            f.write(detail_page(e))
+        with open(os.path.join(DOCS, "codes", e["slug"] + ".json"), "w") as f:
+            json.dump(e["doc"], f, indent=1)
+            f.write("\n")
+    with open(os.path.join(DOCS, "codes", INDEX_MANIFEST), "w") as f:
+        json.dump(codes_index(entries), f, indent=2)
+    for f in glob.glob(os.path.join(DOCS, "codes", "*")):
+        stem, ext = os.path.splitext(os.path.basename(f))
+        if ext not in (".html", ".json") or stem == INDEX_MANIFEST[:-len(".json")]:
+            continue
+        if stem not in slugs:
+            os.remove(f)
+
+
 def pareto(te):
     """Pareto frontier over (n, k, d, w): a code is on it when no other code
     beats it on all four axes (n and w lower-is-better, k and d higher-is-
@@ -2158,8 +2210,11 @@ def detail_page(e):
         body = "\n".join(str(s) for s in H)
         P.append(f'<details><summary>{nm} ({len(H)} checks, sparse supports)'
                  f'</summary><div class=wit>{body}</div></details>')
-    P.append(f'<div class=kv style="margin-top:10px"><a href="{REPO}/codes/'
-             f'{e["slug"]}.json">raw submission JSON</a></div>')
+    P.append(f'<div class=kv style="margin-top:10px">'
+             f'<b>Code ID</b> <code>{e["slug"]}</code> &middot; '
+             f'<a href="{e["slug"]}.json" download '
+             f'title="the verified submission, served by this site">download JSON</a>'
+             f' &middot; <a href="{REPO}/codes/{e["slug"]}.json">raw on GitHub</a></div>')
     P.append('</section>')
 
     P.append("<script>document.querySelectorAll('[data-copy]').forEach("
@@ -3929,14 +3984,7 @@ def build():
             'embed{width:100%;height:100%}</style></head><body>'
             '<embed src="qec_challenge.pdf" type="application/pdf">'
             '</body></html>')
-    slugs = {e["slug"] for e in entries}
-    for e in entries:
-        with open(os.path.join(DOCS, "codes", e["slug"] + ".html"), "w") as f:
-            f.write(detail_page(e))
-    # prune orphan detail pages left behind when a code is removed
-    for f in glob.glob(os.path.join(DOCS, "codes", "*.html")):
-        if os.path.splitext(os.path.basename(f))[0] not in slugs:
-            os.remove(f)
+    write_code_artifacts(entries)
     check_analytics_coverage()
 
     # machine-readable stats; the README badges (shields.io dynamic JSON) read

--- a/site/test_downloads.py
+++ b/site/test_downloads.py
@@ -1,0 +1,82 @@
+"""Download artifacts addressed by code ID (issue #556)."""
+
+import importlib.util
+import json
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def load_site_build():
+    spec = importlib.util.spec_from_file_location(
+        "site_build_downloads", os.path.join(ROOT, "site", "build.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_with_one_code(tmp_path):
+    """Run the full build against a one-code board.
+
+    Stale artifacts are pre-planted in docs/codes to exercise pruning.
+    """
+    build = load_site_build()
+    with open(os.path.join(ROOT, "verify", "fixtures", "72-6-6.json")) as f:
+        doc = json.load(f)
+    codes = tmp_path / "codes"
+    codes.mkdir()
+    with open(codes / "72-6-6.json", "w") as f:
+        json.dump(doc, f)
+
+    build.ROOT = str(tmp_path)
+    build.DOCS = str(tmp_path / "docs")
+    build.CERTS = str(tmp_path / "certs")
+    os.makedirs(os.path.join(build.DOCS, "codes"), exist_ok=True)
+    for stale in ("12-2-3.html", "12-2-3.json"):
+        with open(os.path.join(build.DOCS, "codes", stale), "w") as f:
+            f.write("stale")
+    build.build()
+    return build
+
+
+def test_every_code_is_served_by_id(tmp_path):
+    build = _build_with_one_code(tmp_path)
+    with open(os.path.join(build.DOCS, "codes", "72-6-6.json")) as f:
+        served = json.load(f)
+    with open(os.path.join(ROOT, "verify", "fixtures", "72-6-6.json")) as f:
+        assert served == json.load(f)
+
+    with open(os.path.join(build.DOCS, "codes", "72-6-6.html")) as f:
+        page = f.read()
+    # the page lives in docs/codes/, so the artifact link is same-directory
+    assert '<a href="72-6-6.json" download' in page
+    assert "Code ID</b> <code>72-6-6</code>" in page
+
+
+def test_index_manifest_lists_every_id(tmp_path):
+    build = _build_with_one_code(tmp_path)
+    with open(os.path.join(build.DOCS, "codes", build.INDEX_MANIFEST)) as f:
+        index = json.load(f)
+    assert index["codes"] == [
+        {"id": "72-6-6", "n": 72, "k": 6, "d": 6, "tier": index["codes"][0]["tier"]}
+    ]
+    # tiers are the board's short labels: "ub" (upper bound) or "exact"
+    assert index["codes"][0]["tier"] in ("ub", "exact")
+
+
+def test_manifest_filename_cannot_be_a_code_id(tmp_path):
+    # the manifest stem must fail _SAFE_SLUG, so a code named "index" (or any
+    # other slug) can never have its submission artifact overwritten by the
+    # manifest
+    build = load_site_build()
+    assert build._SAFE_SLUG.fullmatch(build.INDEX_MANIFEST[: -len(".json")]) is None
+
+
+def test_stale_artifacts_are_pruned_but_manifest_kept(tmp_path):
+    build = _build_with_one_code(tmp_path)
+    leftovers = os.listdir(os.path.join(build.DOCS, "codes"))
+    assert "12-2-3.html" not in leftovers
+    assert "12-2-3.json" not in leftovers
+    assert build.INDEX_MANIFEST in leftovers
+    assert set(leftovers) == {"72-6-6.html", "72-6-6.json", build.INDEX_MANIFEST}


### PR DESCRIPTION
## Downloadable codes, addressed by ID

Implements #556 (suggestion from @perlinm): give each code an ID so it can be
downloaded more easily from the website.

### What an ID is

Every code's ID is its **slug** — the stem of its JSON filename in `codes/`.
It is already the board's identity: unique per entry (filesystem uniqueness in
`codes/`) and validated against `_SAFE_SLUG` (`site/build.py`, checked in
`load_entries`). Making that explicit costs nothing and requires no schema or
verifier change, so the trust anchor stays untouched. The qLDPC library
reference in the issue (`qldpc.codes.common.from_qecdb_id`) fetches a code by
opaque ID; here the ID is human-readable and self-describing.

### What the site gains

- **Per-code download artifact**: the build now writes each verified
  submission JSON as `.json` in the generated `codes/` site directory,
  next to the detail page. The code is downloadable straight from the website
  at a stable URL, not only through a GitHub blob link. CI's existing
  `git add docs/codes` publishes the artifacts with no workflow change.
- **Download manifest**: the build also writes an `_index.json` manifest into
  that generated directory, listing every code's `id`, `n`, `k`, `d`, and
  tier, so all codes can be discovered and fetched programmatically (e.g.
  `jq -r '.codes[].id'` to enumerate IDs). The manifest stem starts with an
  underscore, which `_SAFE_SLUG` rejects, so no code ID can ever collide with
  the manifest file — a code named `index` serves its own submission JSON
  untouched.
- **Detail-page links**: each code page now shows its ID and a
  `download`-attributed link to the site-served JSON, next to the existing
  GitHub link. The href is same-directory relative (`.json`), consistent
  with the page's `../`-relative asset scheme.
- **Pruning**: orphan JSON artifacts are pruned alongside orphan detail pages
  when a code is removed; the manifest (stem `_index`) is never pruned.

The writing, manifest, and pruning live in one new `write_code_artifacts()`
helper (with `codes_index()` for the manifest) that replaced the inline
detail-page loop at the end of `build()`.

### Tests

`site/test_downloads.py` runs the full build against a one-code board (the
`verify/fixtures/72-6-6.json` fixture, same pattern as `site/test_security.py`)
and asserts:

- the served JSON is byte-equivalent (as parsed JSON) to the submission;
- the detail page links `72-6-6.json` with `download` and shows the ID;
- the manifest lists the ID with its parameters and tier;
- the manifest stem fails `_SAFE_SLUG`, so it can never be a code ID;
- stale `12-2-3.html`/`12-2-3.json` artifacts are pruned and the manifest
  survives.

A real board build (504 codes) was verified locally: 504 artifacts plus the
manifest, every detail page carrying the link.

### Notes

- No change to `verify/`, `schema/`, or the submission format: IDs are
  derived at build time, so all existing entries get one automatically with no
  backfill commit.
- `site/build.py` and `site/test_downloads.py` are the only files touched.
- The dry-run preview change that briefly rode along in this PR was moved out
  (it will be submitted separately against #637).