### PR TITLE
Add a per-PR concurrency group to the verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,10 +23,8 @@ on:
   push:
     branches: [main]
 
-# Every push to a PR branch re-runs the full suite plus the ~15-minute
-# refutation gate, so without this N pushes cost N parallel full runs (issue
-# #594 pass 1, M1). Only the latest head of a PR matters; push-to-main runs
-# are never cancelled.
+# Only the latest head of a PR matters: cancel superseded runs so repeated
+# pushes cannot multiply CI cost. Push-to-main runs are never cancelled.
 concurrency:
   group: verify-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,14 @@ on:
   push:
     branches: [main]
 
+# Every push to a PR branch re-runs the full suite plus the ~15-minute
+# refutation gate, so without this N pushes cost N parallel full runs (issue
+# #594 pass 1, M1). Only the latest head of a PR matters; push-to-main runs
+# are never cancelled.
+concurrency:
+  group: verify-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Compile-only coverage for the optional CUDA accelerator.  This deliberately
   # does not require a GPU and is advisory until the hosted toolkit install is

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -3,7 +3,7 @@
   "files": {
     ".github/workflows/prose.yml": "c07a2339ee92c5eb7b5297a37ac5be7e9ca3e655ab3f2f199acc31995bef1f18",
     ".github/workflows/refute-weekly.yml": "d3fb677fd381c397f2b1f60474ad8b86cefc512d2d38ce930ece20498470d7a1",
-    ".github/workflows/verify.yml": "98382a5d2a1befa01ad1a991bc9164662cf35cee11b644fd0c7b794e58aa628a",
+    ".github/workflows/verify.yml": "c9bb10e4bbfe56d9c48a113332f63e55f6255e30966d930d92b2060ee088cbe6",
     "Makefile": "30f2d73d7fc62cb05171a603d899bc27cd4f1b4bbdc3bf59bfdf98b8d8b4bc56",
     "pyproject.toml": "80042e2387ce95973d1abdc12435f09c0ebf27faff489195ed19c89f383b3a65",
     "uv.lock": "61ecdbd6e185ccb5a6a06a7cb589c5d144002a3eb281fbbf99c2659b6593bffb",

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -3,7 +3,7 @@
   "files": {
     ".github/workflows/prose.yml": "c07a2339ee92c5eb7b5297a37ac5be7e9ca3e655ab3f2f199acc31995bef1f18",
     ".github/workflows/refute-weekly.yml": "d3fb677fd381c397f2b1f60474ad8b86cefc512d2d38ce930ece20498470d7a1",
-    ".github/workflows/verify.yml": "c9bb10e4bbfe56d9c48a113332f63e55f6255e30966d930d92b2060ee088cbe6",
+    ".github/workflows/verify.yml": "99ab5b2af06a4add38e3661935fe1ccc15a55183043c4b26ac57830ceb15e146",
     "Makefile": "30f2d73d7fc62cb05171a603d899bc27cd4f1b4bbdc3bf59bfdf98b8d8b4bc56",
     "pyproject.toml": "80042e2387ce95973d1abdc12435f09c0ebf27faff489195ed19c89f383b3a65",
     "uv.lock": "61ecdbd6e185ccb5a6a06a7cb589c5d144002a3eb281fbbf99c2659b6593bffb",


### PR DESCRIPTION
## Add a per-PR concurrency group to the verify workflow

Every push to a PR branch re-runs the whole verify workflow — self-tests,
the CUDA compile job, and for code PRs the ~15-minute refutation gate.
There is no concurrency group today, so N pushes to one branch cost N
**parallel** full runs: a scripted PR can multiply CI cost without limit,
and every run but the last is wasted work.

This adds the standard group:

```yaml
concurrency:
  group: verify-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Only the latest head of a PR matters, so superseded PR runs are
cancelled. `push` runs on main are never cancelled: there,
`github.event.pull_request.number` is empty, so the group falls back to
the branch ref and `cancel-in-progress` evaluates false.

Observed verify job durations on the current board are 1.5–6 minutes
(gate included), so cancellation loses nothing.

The `verify.yml` pin in `verify/validator_manifest.json` is re-pinned
(one line), as required for any change to a pinned workflow.