### PR TITLE
Pin contents:read permissions on the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@
 name: lint
 
 # The job only writes a step summary; least-privilege like verify.yml and
-# prose.yml (issue #594 pass 1, L2).
+# prose.yml.
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,12 @@
 # version comes from uv.lock, so lint verdicts cannot drift with upstream
 # releases.
 name: lint
+
+# The job only writes a step summary; least-privilege like verify.yml and
+# prose.yml (issue #594 pass 1, L2).
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## Pin `contents: read` permissions on the lint workflow

`lint.yml` had no `permissions:` block, so on same-repo PRs the job
inherited the repository's default token permissions. The job only runs
ruff and writes a step summary — it needs nothing beyond read.

This pins `permissions: contents: read`, matching what `verify.yml` and
`prose.yml` already declare.

No integrity-manifest re-pin is needed: the manifest pins `prose.yml`,
`refute-weekly.yml`, and `verify.yml` as verdict dependencies;
`lint.yml` (advisory-only) is deliberately outside it.

Found as part of the #594 integrity audit work.