### PR TITLE
Require a @handle author on new code submissions

### DIFF
--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -273,7 +273,20 @@ def main(argv):
             continue
         hs = handles(doc)
         if not hs:
-            print(f"ok    {f}: no @handle authors (baseline/anonymous), exempt")
+            # Baselines (literature codes) legitimately have no @handle, and
+            # edits to an existing entry keep the refutation/layout binding
+            # paths below. But a NEW submission with no handle binds to
+            # nothing: it is exempt from this check forever, so anyone could
+            # submit it -- and later take it over -- with no authorship
+            # continuity at all (issue #594 pass 5, P3).
+            origin = (doc.get("provenance") or {}).get("origin", "submission")
+            if base_counterpart(f, doc, changes) is None and origin != "baseline":
+                violations.append(
+                    (f, [], "no @handle author (new submissions must bind to "
+                     "a GitHub account; provenance.origin 'baseline' is for "
+                     "literature codes)"))
+                continue
+            print(f"ok    {f}: no @handle authors (baseline), exempt")
             continue
         base_path = base_counterpart(f, doc, changes)
         base_doc = load_base_doc(base, base_path, root) if base_path else None

--- a/verify/check_authorship.py
+++ b/verify/check_authorship.py
@@ -273,12 +273,10 @@ def main(argv):
             continue
         hs = handles(doc)
         if not hs:
-            # Baselines (literature codes) legitimately have no @handle, and
-            # edits to an existing entry keep the refutation/layout binding
-            # paths below. But a NEW submission with no handle binds to
-            # nothing: it is exempt from this check forever, so anyone could
-            # submit it -- and later take it over -- with no authorship
-            # continuity at all (issue #594 pass 5, P3).
+            # A new submission with no @handle binds to no account, so it
+            # would be exempt from this check forever. Baselines keep the
+            # exemption; edits to existing entries keep the binding paths
+            # below.
             origin = (doc.get("provenance") or {}).get("origin", "submission")
             if base_counterpart(f, doc, changes) is None and origin != "baseline":
                 violations.append(

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -401,31 +401,33 @@ def main():
             ["--author", "alice", "--root", td, "--base", "main"])
         check("new code by its author still accepted", rc == 0)
 
-    print("\nnew submissions must bind to a @handle (issue #594 pass 5, P3):")
+    print("\nnew submissions must bind to a @handle:")
 
-    def anonymous_submission():
+    # a genuinely new file (the base code stays, so nothing pairs it with a
+    # base counterpart the way a rename would)
+    def submit_new(td, authors, origin=None):
         doc = copy.deepcopy(BASE_DOC)
-        doc["provenance"]["authors"] = ["Jane Roe"]
-        return doc
+        doc["provenance"]["authors"] = authors
+        if origin:
+            doc["provenance"]["origin"] = origin
+        write_code(td, "60-8-7.json", doc)
+        git(td, "add", "codes")
+        git(td, "commit", "-q", "-m", "new")
+        return check_authorship.main(
+            ["--author", "bob", "--root", td, "--base", "main"])
 
-    run_case("new submission with no @handle rejected",
-             anonymous_submission, False)
-
-    def anonymous_baseline_submission():
-        doc = anonymous_submission()
-        doc["provenance"]["origin"] = "baseline"
-        return doc
-
-    run_case("new baseline submission with no @handle exempt",
-             anonymous_baseline_submission, True)
-
-    def malformed_handle_only():
-        doc = copy.deepcopy(BASE_DOC)
-        doc["provenance"]["authors"] = ["@bad!handle"]
-        return doc
-
-    run_case("new submission with only a malformed handle rejected",
-             malformed_handle_only, False)
+    with tempfile.TemporaryDirectory() as td:
+        make_repo(td)
+        check("new submission with no @handle rejected",
+              submit_new(td, ["Jane Roe"]) == 1)
+    with tempfile.TemporaryDirectory() as td:
+        make_repo(td)
+        check("new baseline submission with no @handle exempt",
+              submit_new(td, ["Jane Roe"], origin="baseline") == 0)
+    with tempfile.TemporaryDirectory() as td:
+        make_repo(td)
+        check("new submission with only a malformed handle rejected",
+              submit_new(td, ["@bad!handle"]) == 1)
 
     print()
     if _fail:

--- a/verify/test_check_authorship.py
+++ b/verify/test_check_authorship.py
@@ -401,6 +401,32 @@ def main():
             ["--author", "alice", "--root", td, "--base", "main"])
         check("new code by its author still accepted", rc == 0)
 
+    print("\nnew submissions must bind to a @handle (issue #594 pass 5, P3):")
+
+    def anonymous_submission():
+        doc = copy.deepcopy(BASE_DOC)
+        doc["provenance"]["authors"] = ["Jane Roe"]
+        return doc
+
+    run_case("new submission with no @handle rejected",
+             anonymous_submission, False)
+
+    def anonymous_baseline_submission():
+        doc = anonymous_submission()
+        doc["provenance"]["origin"] = "baseline"
+        return doc
+
+    run_case("new baseline submission with no @handle exempt",
+             anonymous_baseline_submission, True)
+
+    def malformed_handle_only():
+        doc = copy.deepcopy(BASE_DOC)
+        doc["provenance"]["authors"] = ["@bad!handle"]
+        return doc
+
+    run_case("new submission with only a malformed handle rejected",
+             malformed_handle_only, False)
+
     print()
     if _fail:
         print(f"FAILED: {_fail}")

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -12,7 +12,7 @@
     "decode/distance.py": "7e266f8ad50d55fa44e34a5e0bf0005e91de19f24c35c27bf8f9bad796f56076",
     "schema/code.schema.json": "b1badf0ae7c83e6217db21266e6977e40689f6d114cb135e16c0f272d3eb174d",
     "verify/build_receipt.py": "e748231cd0bd9a9a96023a1349763ed214b7ea894336834e76afb0c065a80afd",
-    "verify/check_authorship.py": "5c504a2d70b2d6dd1d3dd074e32a2a3664752a0984dca09d56ef50b492fe73b9",
+    "verify/check_authorship.py": "1fafa07d67cfe32f215f23ce331e1c6f05236f6aa79a528756cda77d0887f22d",
     "verify/check_prose.py": "af9fc3b72c7723cd0aa6309a5a0162acbf1e4ac0bd18722179633802c30df9d0",
     "verify/check_submission_scope.py": "04945a2ef6b0cabd7b8c3998aa33aa8c66cac158dd4955272742dbaa8c850bf1",
     "verify/check_validator_integrity.py": "d739db6680bd4c4b481e811234ed6abf470cbf09449825e1dbdb08261234ebd3",

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -12,7 +12,7 @@
     "decode/distance.py": "7e266f8ad50d55fa44e34a5e0bf0005e91de19f24c35c27bf8f9bad796f56076",
     "schema/code.schema.json": "b1badf0ae7c83e6217db21266e6977e40689f6d114cb135e16c0f272d3eb174d",
     "verify/build_receipt.py": "e748231cd0bd9a9a96023a1349763ed214b7ea894336834e76afb0c065a80afd",
-    "verify/check_authorship.py": "1fafa07d67cfe32f215f23ce331e1c6f05236f6aa79a528756cda77d0887f22d",
+    "verify/check_authorship.py": "61f63f43a3f692b516f392eba973a73b09dfdcdf67e7e8b907ea332d930b4216",
     "verify/check_prose.py": "af9fc3b72c7723cd0aa6309a5a0162acbf1e4ac0bd18722179633802c30df9d0",
     "verify/check_submission_scope.py": "04945a2ef6b0cabd7b8c3998aa33aa8c66cac158dd4955272742dbaa8c850bf1",
     "verify/check_validator_integrity.py": "d739db6680bd4c4b481e811234ed6abf470cbf09449825e1dbdb08261234ebd3",


### PR DESCRIPTION
## Require a `@handle` author on new code submissions

Today, a new submission whose authors contain no valid `@handle` (plain
names only, a malformed handle like `@bad!handle`, or an empty author
list) is exempt from the authorship check entirely: `check_authorship.py`
prints "no @handle authors (baseline/anonymous), exempt" and accepts it.
Such an entry binds to no GitHub account, so anyone can open the PR for
it — and, because the exemption is computed per-diff, later take it over
by adding a handle, with no authorship continuity ever applying.

This change makes the authorship check reject a **new** submission (a
code file with no base-revision counterpart) that has no valid
`@handle` author. Two cases keep working exactly as before:

- **Baselines** (`provenance.origin: "baseline"`): literature codes
  legitimately have no handle; their exemption stays.
- **Edits to existing entries**: unchanged — the refutation-binding
  (`witness_provenance.found_by`) and layout-binding
  (`locality.contributed_by.by`) paths still govern who may modify a
  merged code, including handle-less ones.

The entry point for contributors is unchanged: `./qldpc submit
--authors @yourhandle` already requires a handle (or an explicit
`--anonymous`, which now fails CI rather than landing an unbound entry).

New tests cover the rejected anonymous submission, the exempt baseline
submission, and the malformed-handle case; existing baseline-edit and
binding tests pass unchanged. The `check_authorship.py` pin in
`verify/validator_manifest.json` is re-pinned (one line).

Found as part of the #594 integrity audit work.