### PR TITLE
Add [[16,4,4]] 2d-local weight-6 SAT code — new cell point, dominates [[18,4,4]]

### DIFF
--- a/codes/16-4-4.json
+++ b/codes/16-4-4.json
@@ -1,0 +1,212 @@
+{
+ "schema_version": "0.1",
+ "name": "[[16,4,4]] SAT t3 w6 (a)",
+ "code_type": "CSS",
+ "n": 16,
+ "k": 4,
+ "checks": {
+  "X": [
+   [
+    1,
+    4,
+    5,
+    6,
+    11,
+    12
+   ],
+   [
+    1,
+    4,
+    6,
+    8,
+    10,
+    13
+   ],
+   [
+    3,
+    4,
+    6,
+    7,
+    11,
+    14
+   ],
+   [
+    2,
+    5,
+    6,
+    9,
+    13,
+    14
+   ],
+   [
+    3,
+    6,
+    9,
+    10,
+    11,
+    15
+   ],
+   [
+    0,
+    1,
+    2,
+    3,
+    6,
+    10
+   ]
+  ],
+  "Z": [
+   [
+    0,
+    5,
+    8,
+    9,
+    10,
+    12
+   ],
+   [
+    2,
+    4,
+    7,
+    10,
+    11,
+    14
+   ],
+   [
+    1,
+    3,
+    4,
+    7,
+    9,
+    14
+   ],
+   [
+    2,
+    5,
+    6,
+    8,
+    14,
+    15
+   ],
+   [
+    2,
+    6,
+    9,
+    11,
+    13,
+    15
+   ],
+   [
+    0,
+    1,
+    4,
+    5,
+    6,
+    10
+   ]
+  ]
+ },
+ "distance": {
+  "d": 4,
+  "X": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    1,
+    6,
+    8,
+    9
+   ]
+  },
+  "Z": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    8,
+    9,
+    13,
+    15
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@MathysRennela"
+  ],
+  "construction": "Locality-constrained SAT discovery: qubits on a grid, each check anchored within radius 2.0, weight <= 6, t=3 detection CNF (d >= 4 by construction); CaDiCaL enumeration, RIS screening, MILP-exact distance confirmation. Per-code parameters in the construction field below and in the research note.",
+  "origin": "submission",
+  "date": "2026-09-06",
+  "model": "GLM 5.3 Flash",
+  "notes": "Distinct construction among the [[16,4,4]] co-entries from the same campaign: different check matrix (fingerprint 3440fc480e2f), gate dedup passed. Checked against existing board entries at gate time; not equivalent to any of them. MILP-exact d=4 both sides (documented in the research note)."
+ },
+ "family": "other",
+ "locality": {
+  "coordinates": [
+   [
+    0.0,
+    0.0
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    2.0,
+    0.0
+   ],
+   [
+    3.0,
+    0.0
+   ],
+   [
+    0.0,
+    1.0
+   ],
+   [
+    1.0,
+    1.0
+   ],
+   [
+    2.0,
+    1.0
+   ],
+   [
+    3.0,
+    1.0
+   ],
+   [
+    0.0,
+    2.0
+   ],
+   [
+    1.0,
+    2.0
+   ],
+   [
+    2.0,
+    2.0
+   ],
+   [
+    3.0,
+    2.0
+   ],
+   [
+    0.0,
+    3.0
+   ],
+   [
+    1.0,
+    3.0
+   ],
+   [
+    2.0,
+    3.0
+   ],
+   [
+    3.0,
+    3.0
+   ]
+  ],
+  "layers": 1
+ }
+}

--- a/notes/16-4-4.md
+++ b/notes/16-4-4.md
@@ -1,0 +1,69 @@
+# [[16,4,4]] — SAT-discovered weight-6 single-layer checkerboard code (a)
+
+## Direction & hypothesis
+
+    Target cell: `local-2d-single × weight-6`. Before this campaign the cell
+held 6 entries with best kd²/n = 3.56 ([[18,4,4]]); the (n, 4, 4) point
+was unoccupied. Hypothesis (from the 2026-09-02 postmortem,
+fieldnotes/2026-09-02-weight68-sat-campaign-postmortem.md): t=3 detection —
+a CNF requiring every weight-≤3 Pauli error to be detected — forces d ≥ 4 by
+construction, and a SAT enumeration over locality-constrained anchor
+incidence can reach k ≥ 4 at d ≥ 4 on small grids where free-form SAT
+search collapses.
+
+## What was searched
+
+Locality-constrained SAT enumeration (pysat CaDiCaL153, streamed CNF): qubits
+on a 4x4 grid, 6 generator rows per side, every check anchored within
+Euclidean radius 2.0 of a SAT-chosen anchor site, per-row weight ≤ 6
+(sequential-counter encoding), t=3 detection clauses over all weight-≤3
+errors, solutions blocked on the check-incidence pattern (one code per
+distinct matrix). ~50 raw solutions per configuration were screened with
+exact GF(2) k, an 800-trial RIS distance screen (keeping d ≥ 4 only), a board
+dominance pre-filter, and the trusted gate. This code is the configuration
+whose check matrix matches `codes/16-4-4.json` (fingerprint
+3440fc480e2f); the full sweep parameters are in
+`provenance.construction`.
+
+## Evidence trail
+
+- RIS witness search (20,000 trials + accelerator pass): weight-4
+  X-side logical and weight-4 Z-side logical, so d ≤ 4 on both
+  sides. This is the tier the submission carries: witness-backed upper bound.
+- Exact certification in staging: `verify/certify.py` (scipy/HiGHS MILP, one
+  no-lighter-logical proof per logical-basis row, both sides) returned
+  d_X = 4 and d_Z = 4 exact for this matrix. A
+  maintainer can reproduce that with `uv run python verify/certify.py
+  codes/16-4-4.json`; the board tier upgrades only on that server-side run.
+- Trusted gate `verify/validate_candidate.py`: passed, board-advancing
+  (novelty unverified against the wider literature).
+
+## Dead ends
+
+- t=3 at 6×6 with 15 rows/side needs tens of millions of auxiliary
+  variables (13 GB measured footprint) — out of a 16 GB laptop with this
+  encoder; 4x4 with 6 rows/side is the affordable cell.
+- CryptoMiniSat (XOR-native, Gaussian elimination) budgeted out with zero
+  yields on both t=3 cells where CaDiCaL yielded codes; kissat cannot
+  enumerate at all (pysat wrapper aborts on incremental add_clause).
+- Minisat22/Minicard lack pysat time budgets; unbounded solve/block rounds
+  burned hours at zero yield before a round cap was added.
+
+## Tools
+
+Model: GLM 5.3 Flash (matches provenance.model). Harness: an overnight
+locality-SAT enumerator built on python-sat with streamed clause emission,
+conflict budgets and a hard round cap; exact-distance verification via
+`verify/certify.py`; screening and packaging via the repo kit
+(`research/kit/`); gate via `verify/validate_candidate.py`. Compute: one
+MacBook Air (M-series), roughly two hours per configuration ladder.
+
+## Reproduction
+
+Rebuild from the submitted checks directly: the X and Z supports in
+`codes/16-4-4.json` are the construction. To regenerate the family: enumerate
+locality-constrained CSS codes with the parameters in
+`provenance.construction` (4x4 grid, 6 rows/side, weight ≤ 6,
+radius 2.0, t=3 detection, CaDiCaL backend), screen for k ≥ 4 and RIS
+d ≥ 4, and match the fingerprint above. Verify with
+`uv run python verify/qldpc_verify.py codes/16-4-4.json`.

--- a/notes/16-4-4.md
+++ b/notes/16-4-4.md
@@ -4,8 +4,8 @@
 
     Target cell: `local-2d-single × weight-6`. Before this campaign the cell
 held 6 entries with best kd²/n = 3.56 ([[18,4,4]]); the (n, 4, 4) point
-was unoccupied. Hypothesis (from the 2026-09-02 postmortem,
-fieldnotes/2026-09-02-weight68-sat-campaign-postmortem.md): t=3 detection —
+was unoccupied. Hypothesis (the campaign's 2026-09-02 postmortem identified t=3
+on small grids as the open move): t=3 detection —
 a CNF requiring every weight-≤3 Pauli error to be detected — forces d ≥ 4 by
 construction, and a SAT enumeration over locality-constrained anchor
 incidence can reach k ≥ 4 at d ≥ 4 on small grids where free-form SAT


### PR DESCRIPTION
## Code submission

- Parameters: [[n, k, d]] = [[16,4,4]]
- Tracks: local-2d-single / weight-6 (computed by the verifier from H and the layout)
- Distance confidence: X: upper_bound, Z: upper_bound

Family tag: other (a self-declared filter, never used for ranking).

### Checklist
- [x] One JSON file under `codes/`, conforming to `schema/code.schema.json`
- [x] Distance witness(es) included for each reported side
- [x] `python verify/qldpc_verify.py codes/16-4-4.json` passes locally
- [x] Construction and references filled in under `provenance`
- [x] If this may be equivalent to an existing entry, noted in `provenance.notes`

### What frontier does this advance?
- **2D-local single / weight ≤ 6**: on the Pareto frontier — dominates [[18,4,4]]
- **2D-local single / weight ≤ 8**: on the Pareto frontier — dominates [[18,4,4]]
- **2D-local single / any weight**: on the Pareto frontier — dominates [[18,4,4]]
- **2D-local bilayer / weight ≤ 6**: on the Pareto frontier — dominates [[18,4,4]]
- **2D-local bilayer / weight ≤ 8**: on the Pareto frontier — dominates [[18,4,4]]
- **2D-local bilayer / any weight**: on the Pareto frontier — dominates [[18,4,4]]
- **unrestricted / weight ≤ 6**: on the Pareto frontier — dominates [[18,4,4]]
- **unrestricted / weight ≤ 8**: on the Pareto frontier — dominates [[18,4,4]]
- **unrestricted / any weight**: on the Pareto frontier — dominates [[18,4,4]]
Score kd^2/n = 4.0, max check weight 6, locality class local-2d-single.

Construction: Locality-constrained SAT discovery: qubits on a grid, each check anchored within radius 2.0, weight <= 6, t=3 detection CNF (d >= 4 by construction); CaDiCaL enumeration, RIS screening, MILP-exact distance confirmation. Per-code parameters in the construction field below and in the research note.

Research note: `notes/16-4-4.md`
