### PR TITLE
Add [[25,5,4]] 2d-local weight-6 SAT code — k=5 at d=4, new cell point

### DIFF
--- a/codes/25-5-4.json
+++ b/codes/25-5-4.json
@@ -1,0 +1,302 @@
+{
+ "schema_version": "0.1",
+ "name": "[[25,5,4]] SAT t3 w6 (a)",
+ "code_type": "CSS",
+ "n": 25,
+ "k": 5,
+ "checks": {
+  "X": [
+   [
+    3,
+    9,
+    14,
+    19
+   ],
+   [
+    1,
+    2,
+    8,
+    10,
+    11,
+    16
+   ],
+   [
+    1,
+    5,
+    6,
+    9,
+    17
+   ],
+   [
+    4,
+    8,
+    9,
+    14,
+    19,
+    24
+   ],
+   [
+    11,
+    15,
+    20,
+    21,
+    22,
+    23
+   ],
+   [
+    1,
+    6,
+    7,
+    10,
+    15,
+    21
+   ],
+   [
+    0,
+    2,
+    7,
+    10,
+    12,
+    16
+   ],
+   [
+    13,
+    19,
+    23,
+    24
+   ],
+   [
+    14,
+    18,
+    23,
+    24
+   ],
+   [
+    12,
+    16,
+    17,
+    21,
+    22
+   ]
+  ],
+  "Z": [
+   [
+    1,
+    6,
+    10,
+    11,
+    16,
+    21
+   ],
+   [
+    4,
+    14,
+    19,
+    24
+   ],
+   [
+    5,
+    10,
+    15,
+    16,
+    17,
+    20
+   ],
+   [
+    0,
+    1,
+    6,
+    7,
+    11,
+    15
+   ],
+   [
+    1,
+    2,
+    3,
+    4,
+    7,
+    9
+   ],
+   [
+    8,
+    12,
+    13,
+    16,
+    18,
+    24
+   ],
+   [
+    2,
+    3,
+    8,
+    9,
+    12,
+    17
+   ],
+   [
+    1,
+    2,
+    5,
+    10,
+    12,
+    16
+   ],
+   [
+    13,
+    15,
+    18,
+    21,
+    22,
+    23
+   ],
+   [
+    3,
+    8,
+    11,
+    18,
+    19,
+    23
+   ]
+  ]
+ },
+ "distance": {
+  "d": 4,
+  "X": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    0,
+    4,
+    7,
+    14
+   ]
+  },
+  "Z": {
+   "value": 4,
+   "confidence": "upper_bound",
+   "witness": [
+    5,
+    9,
+    14,
+    18
+   ]
+  }
+ },
+ "provenance": {
+  "authors": [
+   "@MathysRennela"
+  ],
+  "construction": "Locality-constrained SAT discovery: qubits on a grid, each check anchored within radius 2.0, weight <= 6, t=3 detection CNF (d >= 4 by construction); CaDiCaL enumeration, RIS screening, MILP-exact distance confirmation. Per-code parameters in the construction field below and in the research note.",
+  "origin": "submission",
+  "date": "2026-09-06",
+  "model": "GLM 5.3 Flash",
+  "notes": "Distinct construction among the [[25,5,4]] co-entries from the same campaign: different check matrix (fingerprint af05edd55bab), gate dedup passed. Checked against existing board entries at gate time; not equivalent to any of them. MILP-exact d=4 both sides (documented in the research note)."
+ },
+ "family": "other",
+ "locality": {
+  "coordinates": [
+   [
+    0.0,
+    0.0
+   ],
+   [
+    1.0,
+    0.0
+   ],
+   [
+    2.0,
+    0.0
+   ],
+   [
+    3.0,
+    0.0
+   ],
+   [
+    4.0,
+    0.0
+   ],
+   [
+    0.0,
+    1.0
+   ],
+   [
+    1.0,
+    1.0
+   ],
+   [
+    2.0,
+    1.0
+   ],
+   [
+    3.0,
+    1.0
+   ],
+   [
+    4.0,
+    1.0
+   ],
+   [
+    0.0,
+    2.0
+   ],
+   [
+    1.0,
+    2.0
+   ],
+   [
+    2.0,
+    2.0
+   ],
+   [
+    3.0,
+    2.0
+   ],
+   [
+    4.0,
+    2.0
+   ],
+   [
+    0.0,
+    3.0
+   ],
+   [
+    1.0,
+    3.0
+   ],
+   [
+    2.0,
+    3.0
+   ],
+   [
+    3.0,
+    3.0
+   ],
+   [
+    4.0,
+    3.0
+   ],
+   [
+    0.0,
+    4.0
+   ],
+   [
+    1.0,
+    4.0
+   ],
+   [
+    2.0,
+    4.0
+   ],
+   [
+    3.0,
+    4.0
+   ],
+   [
+    4.0,
+    4.0
+   ]
+  ],
+  "layers": 1
+ }
+}

--- a/notes/25-5-4.md
+++ b/notes/25-5-4.md
@@ -1,0 +1,69 @@
+# [[25,5,4]] — SAT-discovered weight-6 single-layer checkerboard code (a)
+
+## Direction & hypothesis
+
+    Target cell: `local-2d-single × weight-6`. Before this campaign the cell
+held 6 entries with best kd²/n = 3.56 ([[18,4,4]]); the (n, 5, 4) point
+was unoccupied. Hypothesis (from the 2026-09-02 postmortem,
+fieldnotes/2026-09-02-weight68-sat-campaign-postmortem.md): t=3 detection —
+a CNF requiring every weight-≤3 Pauli error to be detected — forces d ≥ 4 by
+construction, and a SAT enumeration over locality-constrained anchor
+incidence can reach k ≥ 5 at d ≥ 4 on small grids where free-form SAT
+search collapses.
+
+## What was searched
+
+Locality-constrained SAT enumeration (pysat CaDiCaL153, streamed CNF): qubits
+on a 5x5 grid, 10 generator rows per side, every check anchored within
+Euclidean radius 2.0 of a SAT-chosen anchor site, per-row weight ≤ 6
+(sequential-counter encoding), t=3 detection clauses over all weight-≤3
+errors, solutions blocked on the check-incidence pattern (one code per
+distinct matrix). ~50 raw solutions per configuration were screened with
+exact GF(2) k, an 800-trial RIS distance screen (keeping d ≥ 4 only), a board
+dominance pre-filter, and the trusted gate. This code is the configuration
+whose check matrix matches `codes/25-5-4.json` (fingerprint
+af05edd55bab); the full sweep parameters are in
+`provenance.construction`.
+
+## Evidence trail
+
+- RIS witness search (20,000 trials + accelerator pass): weight-4
+  X-side logical and weight-4 Z-side logical, so d ≤ 4 on both
+  sides. This is the tier the submission carries: witness-backed upper bound.
+- Exact certification in staging: `verify/certify.py` (scipy/HiGHS MILP, one
+  no-lighter-logical proof per logical-basis row, both sides) returned
+  d_X = 4 and d_Z = 4 exact for this matrix. A
+  maintainer can reproduce that with `uv run python verify/certify.py
+  codes/25-5-4.json`; the board tier upgrades only on that server-side run.
+- Trusted gate `verify/validate_candidate.py`: passed, board-advancing
+  (novelty unverified against the wider literature).
+
+## Dead ends
+
+- t=3 at 6×6 with 15 rows/side needs tens of millions of auxiliary
+  variables (13 GB measured footprint) — out of a 16 GB laptop with this
+  encoder; 5x5 with 10 rows/side is the affordable cell.
+- CryptoMiniSat (XOR-native, Gaussian elimination) budgeted out with zero
+  yields on both t=3 cells where CaDiCaL yielded codes; kissat cannot
+  enumerate at all (pysat wrapper aborts on incremental add_clause).
+- Minisat22/Minicard lack pysat time budgets; unbounded solve/block rounds
+  burned hours at zero yield before a round cap was added.
+
+## Tools
+
+Model: GLM 5.3 Flash (matches provenance.model). Harness: an overnight
+locality-SAT enumerator built on python-sat with streamed clause emission,
+conflict budgets and a hard round cap; exact-distance verification via
+`verify/certify.py`; screening and packaging via the repo kit
+(`research/kit/`); gate via `verify/validate_candidate.py`. Compute: one
+MacBook Air (M-series), roughly two hours per configuration ladder.
+
+## Reproduction
+
+Rebuild from the submitted checks directly: the X and Z supports in
+`codes/25-5-4.json` are the construction. To regenerate the family: enumerate
+locality-constrained CSS codes with the parameters in
+`provenance.construction` (5x5 grid, 10 rows/side, weight ≤ 6,
+radius 2.0, t=3 detection, CaDiCaL backend), screen for k ≥ 4 and RIS
+d ≥ 4, and match the fingerprint above. Verify with
+`uv run python verify/qldpc_verify.py codes/25-5-4.json`.

--- a/notes/25-5-4.md
+++ b/notes/25-5-4.md
@@ -4,8 +4,8 @@
 
     Target cell: `local-2d-single × weight-6`. Before this campaign the cell
 held 6 entries with best kd²/n = 3.56 ([[18,4,4]]); the (n, 5, 4) point
-was unoccupied. Hypothesis (from the 2026-09-02 postmortem,
-fieldnotes/2026-09-02-weight68-sat-campaign-postmortem.md): t=3 detection —
+was unoccupied. Hypothesis (the campaign's 2026-09-02 postmortem identified t=3
+on small grids as the open move): t=3 detection —
 a CNF requiring every weight-≤3 Pauli error to be detected — forces d ≥ 4 by
 construction, and a SAT enumeration over locality-constrained anchor
 incidence can reach k ≥ 5 at d ≥ 4 on small grids where free-form SAT


### PR DESCRIPTION
## Code submission

- Parameters: [[n, k, d]] = [[25,5,4]]
- Tracks: local-2d-single / weight-6 (computed by the verifier from H and the layout)
- Distance confidence: X: upper_bound, Z: upper_bound

Family tag: other (a self-declared filter, never used for ranking).

### Checklist
- [x] One JSON file under `codes/`, conforming to `schema/code.schema.json`
- [x] Distance witness(es) included for each reported side
- [x] `python verify/qldpc_verify.py codes/25-5-4.json` passes locally
- [x] Construction and references filled in under `provenance`
- [x] If this may be equivalent to an existing entry, noted in `provenance.notes`

### What frontier does this advance?
- **2D-local single / weight ≤ 6**: on the Pareto frontier
- **2D-local single / weight ≤ 8**: on the Pareto frontier
- **2D-local single / any weight**: on the Pareto frontier
- **2D-local bilayer / weight ≤ 6**: not on the frontier — dominates [[45,5,4]]
- **2D-local bilayer / weight ≤ 8**: not on the frontier — dominates [[45,5,4]]
- **2D-local bilayer / any weight**: not on the frontier — dominates [[45,5,4]]
- **unrestricted / weight ≤ 6**: not on the frontier — dominates [[45,5,4]]
- **unrestricted / weight ≤ 8**: not on the frontier — dominates [[45,5,4]]
- **unrestricted / any weight**: not on the frontier — dominates [[45,5,4]]
Score kd^2/n = 3.2, max check weight 6, locality class local-2d-single.

Construction: Locality-constrained SAT discovery: qubits on a grid, each check anchored within radius 2.0, weight <= 6, t=3 detection CNF (d >= 4 by construction); CaDiCaL enumeration, RIS screening, MILP-exact distance confirmation. Per-code parameters in the construction field below and in the research note.

Research note: `notes/25-5-4.md`
