### PR TITLE
fix: correct GPT 5.6 Sol spelling in [[140,6,10]] attribution

### DIFF
--- a/codes/140-6-10.json
+++ b/codes/140-6-10.json
@@ -1034,8 +1034,8 @@
       "an internal weight-5 bivariate-bicycle evolutionary campaign in github.com/qiskit-community/qcode-discovery (branch weight5-campaigns, not part of a public branch at the time of this submission -- this submission's own distance/CSS claims are independently re-derived and re-verified using only this repository's tools and do not rely on that source being externally checkable)"
     ],
     "date": "2026-09-07",
-    "notes": "Independently corroborated with this repo's own tools before submission: research/kit/surrogate.py distance_rand at 5,000 and 50,000 trials both returned d=10; research/kit/distance.py decoder_distance (BP+OSD, 200,000 injected-error trials) returned d_heuristic=10, verdict=corroborated; research/kit/distance.py exact_distance (scipy/HiGHS MILP) proved d_X=d_Z=10 exact. Discovered by GPT-5.6-sol (per the source campaign's own per-candidate model-attribution log, alias azure/gpt-5.6-sol); this submission's re-verification and packaging was done by Claude Sonnet 5.",
-    "model": "GPT-5.6-sol",
+    "notes": "Independently corroborated with this repo's own tools before submission: research/kit/surrogate.py distance_rand at 5,000 and 50,000 trials both returned d=10; research/kit/distance.py decoder_distance (BP+OSD, 200,000 injected-error trials) returned d_heuristic=10, verdict=corroborated; research/kit/distance.py exact_distance (scipy/HiGHS MILP) proved d_X=d_Z=10 exact. Discovered by GPT 5.6 Sol (per the source campaign's own per-candidate model-attribution log, alias azure/gpt-5.6-sol); this submission's re-verification and packaging was done by Claude Sonnet 5.",
+    "model": "GPT 5.6 Sol",
     "origin": "submission",
     "novelty": "unknown"
   },

--- a/notes/140-6-10.md
+++ b/notes/140-6-10.md
@@ -62,7 +62,7 @@ result rather than running a new search in this repository.
 ## Tools
 
 Discovering model, per the source campaign's own per-candidate
-model-attribution log: GPT-5.6-sol (`azure/gpt-5.6-sol`), matching
+model-attribution log: GPT 5.6 Sol (`azure/gpt-5.6-sol`), matching
 `provenance.model`. This submission's independent re-verification and
 packaging in this repository was done separately by Claude Sonnet 5, via
 Claude Code, operating on this repository's `research/kit` and `verify/`


### PR DESCRIPTION
provenance.model and notes in #915 used "GPT-5.6-sol", which does not match the spelling the existing board entries use for this model. 

Per @FarLab's review comment on PR #918 (https://github.com/unitaryfoundation/qldpc-challenge/pull/918#issuecomment-5572247608), the correct spelling is "GPT 5.6 Sol". The sibling submissions in PR #914 ([[96,4,10]]) and PR #916 ([[180,4,14]]) attribute discovery to Claude Opus 5 only and don't mention GPT anywhere, so they need no change.

