### PR TITLE
Correct two claims in notes/457-8-17.md (no code file touched)

### DIFF
--- a/notes/457-8-17.md
+++ b/notes/457-8-17.md
@@ -51,10 +51,19 @@ distances are RIS upper bounds):
 | 15 | [[450,8,≤16]] | [[411,8,≤16]] | 4.983 |
 | **16** | [[512,8,≤17]] | **[[457,8,≤17]]** | **5.059** |
 
-L = 17 and L = 18 were still reducing when this was written ([[558,8,≤18]] and
-[[618,8,≤19]] at that point, 4.65 and 4.67, graft not yet converged and cleanup
-not yet applied); they are not part of this submission. The L = 14 and L = 15
-rows above have had less deep verification than the submitted code.
+L = 17 and L = 18 were still reducing when this was written, and the two figures
+this note gave for them — [[558,8,≤18]] and [[618,8,≤19]], 4.65 and 4.67 — are
+**wrong**. Both were read off mid-run log lines rather than measured on a saved
+code. Re-measuring those runs' saved output with fresh RIS seeds, validating every
+witness against the opposite-type checks, gives [[537,8,≤17]] (4.305) and, after
+the cleanup, [[599,8,≤18]] (4.327): the reduction driver's in-loop screen and
+confirm rungs let a unit of distance through at both sizes. No code was ever saved
+at n = 558; those runs converged to n = 544 and n = 537. The L = 16 line is
+unaffected — its bound of 17 equals the unreduced [[512,8,≤17]]'s own ladder bound
+— and the measured table for the whole family is in the note attached to the
+[[454,8,17]] submission (PR #935). The
+L = 13, L = 14 and L = 15 rows above have had less deep verification than the
+submitted code.
 
 ## Evidence trail
 
@@ -109,8 +118,9 @@ Caveats:
 
 Claude Opus 5 (Claude Code) as the agent. Construction and cleanup come from the
 repository itself (`research/local2d/planar.py`, `boundary_engine._cleanup`);
-the grafting driver is my own, because the repo's `graft_r1` returns only a
-removal count and the layout needs the surviving qubits' original indices — it
+the grafting driver is my own, because `graft_r1` returns `(H_X, H_Z, n_removed)`
+— a count, with no map from surviving columns back to original qubit indices,
+which is what the layout needs — it
 also differs in screening with the compiled `gf2_fast` backend, confirming each
 removal at a deeper rung with a rotating seed, and blacklisting a qubit that
 fails that rung. Every distance search used `gf2_fast` (`make fast`);


### PR DESCRIPTION
## Correction to an existing note (no code file touched)

`notes/457-8-17.md` reports the then-in-progress L = 17 and L = 18 reductions of the same family as
[[558,8,≤18]] and [[618,8,≤19]] (kd²/n 4.65 and 4.67). Both figures are wrong, and I found it while
carrying the same construction further.

- They were read off **mid-run log lines**, not measured on a saved code. No code was ever saved at
  n = 558; those runs converged to n = 544 and n = 537.
- Re-measuring the saved output of those runs with fresh RIS seeds — every witness validated against
  the opposite-type checks with `css.commutes` and `css.in_rowspace` — gives **[[537,8,≤17]]**
  (kd²/n 4.305) and, after the weight-1 cleanup, **[[599,8,≤18]]** (4.327). Weight-17 logicals turn up
  on the L = 17 code in 5 of 6 independent fresh-seed runs at 20k and 200k trials.
- So the reduction driver's in-loop screen and confirm rungs let a unit of distance through at both
  those sizes. They are a filter, not evidence.

**The submitted [[457,8,17]] is not affected.** Its bound of 17 equals the unreduced [[512,8,≤17]]'s own
ladder bound, and it carries its own fresh-seed ladder. `verify/qldpc_verify.py codes/457-8-17.json`
still passes on this branch, and the code file is untouched.

This also fixes a second sentence in the same note: `graft_r1` returns `(H_X, H_Z, n_removed)`, not only
a removal count. What it does not return — and what the single-layer layout needs — is a map from
surviving columns back to original qubit indices.

The measured table for the whole family is in the note attached to PR #935, which submits [[454,8,17]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
