### PR TITLE
Rerun the prose check when a PR body is edited

### DIFF
--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -8,6 +8,22 @@ permissions:
 
 on:
   pull_request:
+    # `edited` is not in the default set (opened, synchronize, reopened) and it is
+    # the one that matters here: the checker reads the body from
+    # `github.event.pull_request.body`, which is the body as of the triggering
+    # event. Without it, editing a PR body to fix a cited path reruns nothing, and
+    # re-running from the PR page replays the same stale payload -- so a body-only
+    # failure could not be cleared except by an unrelated push (issue #897).
+    # `edited` also fires on title and base changes; the job is stdlib-only and
+    # takes about ten seconds, so that is a fair price.
+    types: [opened, synchronize, reopened, edited]
+
+# A burst of body edits should settle on the last one rather than race: the newest
+# run for a PR wins and any older one still in flight is cancelled, so the check
+# status always reflects the current body.
+concurrency:
+  group: prose-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   prose:

--- a/verify/check_prose.py
+++ b/verify/check_prose.py
@@ -39,6 +39,11 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Label for problems that came from the PR description rather than a committed
+# file. Named once because the reporter prints it and the closing hint tests for
+# it: a body problem is fixed by editing the PR, not by touching the tree.
+BODY_LABEL = "PR body"
+
 # Directories the repo deliberately does not commit. Citing one as evidence is
 # unfalsifiable by construction -- AGENTS.md defines research/candidates/ as
 # gitignored working output.
@@ -222,7 +227,7 @@ def main(argv):
 
     if args.body_file and os.path.exists(args.body_file):
         with open(args.body_file, encoding="utf-8") as f:
-            check_text(f.read(), "PR body", root, problems)
+            check_text(f.read(), BODY_LABEL, root, problems)
 
     if not problems:
         print(f"prose check ok ({len(files)} file(s) checked)")
@@ -231,6 +236,11 @@ def main(argv):
     print("Prose check failed: the text points at things a reviewer cannot open.\n")
     for label, why, detail in problems:
         print(f"  {label}: {why}\n    {detail}")
+    if any(label == BODY_LABEL for label, _, _ in problems):
+        print(f"\nAnything labelled '{BODY_LABEL}' above is in the PR description, "
+              "not in a\ncommitted file: fix it by editing the PR body. Nothing in "
+              "the tree has to\nchange for it.")
+
     print("\nFix by pointing at something that exists in this PR, or by naming the")
     print("external source and pinning it (e.g. 'github.com/org/repo @ abc1234,")
     print("`path/in/that/repo.py`'). research/candidates/ is gitignored working")

--- a/verify/test_check_prose.py
+++ b/verify/test_check_prose.py
@@ -96,6 +96,30 @@ def main():
               problems_for("# [[270,54,10]] code", tmp, slug=("270", "54", "10"))
               == [])
 
+    # A body-sourced problem must say so and point the reader at the PR
+    # description; a file-only failure must not mention the body (issue #897).
+    with tempfile.TemporaryDirectory() as tmp:
+        body = os.path.join(tmp, "body.md")
+        with open(body, "w") as f:
+            f.write("Research note: `notes/700-206-74.md`\n")
+        r = subprocess.run([sys.executable, os.path.join(_HERE, "check_prose.py"),
+                            "--root", tmp, "--files", "--body-file", body],
+                           cwd=ROOT, capture_output=True, text=True)
+        check("body-only problem fails", r.returncode == 1)
+        check("body problem is labelled as such", "PR body:" in r.stdout)
+        check("body problem points at the PR description",
+              "editing the PR body" in r.stdout, r.stdout.strip()[-80:])
+
+        note = os.path.join(tmp, "n.md")
+        with open(note, "w") as f:
+            f.write("Built with `evaluation/distance_milp.py`\n")
+        r = subprocess.run([sys.executable, os.path.join(_HERE, "check_prose.py"),
+                            "--root", tmp, "--files", note],
+                           cwd=ROOT, capture_output=True, text=True)
+        check("file-only problem fails", r.returncode == 1)
+        check("file-only problem does not blame the PR body",
+              "editing the PR body" not in r.stdout)
+
     # Against the real tree: the two behaviours the check exists to distinguish.
     real = os.path.join(ROOT, "notes", "300-60-14.md")
     if os.path.exists(real):

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Pinned SHA-256 of the repo-local production validation and policy-gate execution closure. CI (check_validator_integrity.py) fails if any of these files drifts from this pin. Re-pin deliberately with `python verify/check_validator_integrity.py --update` and get the diff reviewed.",
   "files": {
-    ".github/workflows/prose.yml": "19e41ce543fa45bde186afa4ea833d5660cbb91b0c2d2ed549238e28feeeebbb",
+    ".github/workflows/prose.yml": "371b8311ddc77dfb836e02ee0ef483eb08231a12258f4a187313f09d366a7f41",
     ".github/workflows/refute-weekly.yml": "5a3d9b6d6b0563f3b0259eb918ccfcf4f0a419d6b3fc74cdd321ce5dc3e95ff6",
     ".github/workflows/verify.yml": "b8294de4a8c1ccf38533dfe7c632812b91493f4b81d7c0f41434e28207483834",
     "Makefile": "30f2d73d7fc62cb05171a603d899bc27cd4f1b4bbdc3bf59bfdf98b8d8b4bc56",
@@ -13,7 +13,7 @@
     "schema/code.schema.json": "b1badf0ae7c83e6217db21266e6977e40689f6d114cb135e16c0f272d3eb174d",
     "verify/build_receipt.py": "e748231cd0bd9a9a96023a1349763ed214b7ea894336834e76afb0c065a80afd",
     "verify/check_authorship.py": "adb22156e802b6b876a030b1d27fb1804733bf8dcf3f5a16a88f1873543794f2",
-    "verify/check_prose.py": "af9fc3b72c7723cd0aa6309a5a0162acbf1e4ac0bd18722179633802c30df9d0",
+    "verify/check_prose.py": "59d0188146f81285b06016d9a942f67349e72e72bfe06085eb8831f3d49d8fbc",
     "verify/check_submission_scope.py": "04945a2ef6b0cabd7b8c3998aa33aa8c66cac158dd4955272742dbaa8c850bf1",
     "verify/check_validator_integrity.py": "d739db6680bd4c4b481e811234ed6abf470cbf09449825e1dbdb08261234ebd3",
     "verify/circuit_tools.py": "37a3082aabc26d908bcf2612a6a2f5fb35788a5aa7e93249692f976aaa148106",


### PR DESCRIPTION
Fixes #897.

## The bug

`.github/workflows/prose.yml` triggered on a bare `pull_request`, which defaults to `opened, synchronize, reopened`. Editing a PR body is an `edited` event, so it fired nothing. The body reaches the checker from `github.event.pull_request.body`, frozen at the triggering event, so after an edit the job kept replaying the body from the contributor's last push.

Re-running does not clear it, which is what makes this worse than a stale pass: a re-run replays the original event payload, stale body included. The failing run on #873 was attempt 3.

This is not historical. PR #937 is stuck on it right now, red on its current head over `notes/690-168-90.md`, a path that appears nowhere in its present body. Checking that PR's tree out and running the checker against the body it has today gives `prose check ok (5 file(s) checked)`, so the only thing between it and a green check is a rerun with the fresh body.

## The fix

`types: [opened, synchronize, reopened, edited]` on the trigger. `edited` also fires on title and base changes; the job is stdlib-only and takes about ten seconds, so that is a fair price.

A `concurrency` group comes with it, keyed on the PR number with `cancel-in-progress: true`. A burst of body edits should settle on the last one rather than race, so the reported status always reflects the current body.

Widening the trigger exposes nothing. The workflow is `pull_request`, not `pull_request_target`, holds only `contents: read`, and passes the body to the checker as a file through the environment rather than into a shell.

## Failure message

The issue also suggested the message does not say where an unresolvable path came from. It already does, via the `PR body` label, which is how both currently-failing PRs were diagnosed. What was missing is the remedy: the closing advice talked only about pointing at files that exist and never said to edit the body. `verify/check_prose.py` now adds a line when any problem carries that label, and names the label once as a constant so the reporter and the hint cannot drift apart.

The message #873 would have received:

```
  PR body: path does not exist in this tree
    notes/700-206-74.md

Anything labelled 'PR body' above is in the PR description, not in a
committed file: fix it by editing the PR body. Nothing in the tree has to
change for it.
```

## Checks

Five cases added to `verify/test_check_prose.py`: a body-sourced problem fails, is labelled, and points at the description; a file-only problem fails without blaming the body. Full suite is green at 163 passed, 6 skipped. `ruff check` reports no new findings on either changed file.

`verify/validator_manifest.json` is re-pinned, since both `.github/workflows/prose.yml` and `verify/check_prose.py` are in the trusted closure. Exactly those two hashes move.

## Not included

PR #872's prose failure is genuine rather than stale, but arguably a false positive of a different kind: its body passes `--out` a file under the system temp directory while describing the reproduction for the very flag it fixes, and the checker reads that as an absolute local path. Writing this section is what proved the point: quoting that path verbatim here failed the gate on this very PR. Left alone here; it deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demonstrated on this PR

Editing this body after the checks first went green triggered a fresh prose run, which is the behaviour the issue reports as missing. On main the edit would have been silent.
