### PR TITLE
Bound syndrome decoder cross-check in refutation gate

### DIFF
--- a/verify/gate_changed.py
+++ b/verify/gate_changed.py
@@ -55,7 +55,9 @@ Usage:
 """
 import glob
 import json
+import multiprocessing as mp
 import os
+import queue
 import secrets
 import subprocess
 import sys
@@ -66,13 +68,13 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import circuit_tools as CT
 import gf2
 import heuristic_distance as H
+from build_receipt import make_receipt, write_receipt
 from circuit_verify import MAX_DEM_MECHANISMS, SIDE_FILES
 from qldpc_verify import file_size_error
 from validate_candidate import validate_candidate
-from build_receipt import make_receipt, write_receipt
 
 try:
-    import gf2_fast as GF          # optional C++ accelerator (make fast); the
+    import gf2_fast as GF  # optional C++ accelerator (make fast); the
 except ImportError:                # gate degrades to the python passes without it
     GF = None
 
@@ -81,6 +83,8 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Fixed thread count for the fast pass so its verdict is reproducible from the
 # printed seed alone (the per-thread RNG streams depend on the split).
 FAST_THREADS = 4
+SYNDROME_SECONDS = 10.0
+SYNDROME_GRACE_SECONDS = 5.0
 
 
 def _load_syndrome():
@@ -92,6 +96,57 @@ def _load_syndrome():
         return sd
     except Exception:
         return None
+
+
+def _syndrome_worker(doc, seed, max_seconds, out):
+    """Run the optional syndrome-decoder check in a killable child process."""
+    try:
+        sd = _load_syndrome()
+        if sd is None:
+            out.put({"kind": "missing"})
+            return
+        out.put({
+            "kind": "ok",
+            "result": sd.refute_check(
+                doc, seed=seed, max_seconds=max_seconds),
+        })
+    except BaseException as e:
+        out.put({"kind": "error", "error": f"{type(e).__name__}: {e}"})
+
+
+def _syndrome_refute_bounded(
+    doc, seed, max_seconds=SYNDROME_SECONDS,
+    grace_seconds=SYNDROME_GRACE_SECONDS, worker=_syndrome_worker,
+):
+    """Bound the optional BP+OSD cross-check even if one decode call stalls."""
+    ctx = mp.get_context("fork" if hasattr(os, "fork") else "spawn")
+    out = ctx.Queue()
+    proc = ctx.Process(target=worker, args=(doc, seed, max_seconds, out))
+    proc.start()
+    proc.join(max_seconds + grace_seconds)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(2)
+        print(
+            "note: syndrome-decoder cross-check timed out "
+            f"(budget {max_seconds:g}s + grace {grace_seconds:g}s); "
+            "continuing with RIS gates")
+        return False, None, None, 0
+    if proc.exitcode:
+        raise RuntimeError(
+            "syndrome-decoder cross-check exited with status "
+            f"{proc.exitcode}")
+    try:
+        msg = out.get_nowait()
+    except queue.Empty as e:
+        raise RuntimeError("syndrome-decoder cross-check produced no result") from e
+    if msg.get("kind") == "missing":
+        return False, None, None, 0
+    if msg.get("kind") == "error":
+        raise RuntimeError(
+            "syndrome-decoder cross-check failed: "
+            f"{msg.get('error')}")
+    return tuple(msg["result"])
 
 
 def map_changed(paths):
@@ -696,7 +751,8 @@ def main(argv):
             results[f"RIS#{si}"] = H.refute_check(doc, seed=s, max_seconds=budget,
                                                   trials=trials)
         if SD is not None:
-            results["syndrome-decoder"] = SD.refute_check(doc, seed=seed + 1)
+            results["syndrome-decoder"] = _syndrome_refute_bounded(
+                doc, seed=seed + 1)
         # Frontier claims additionally face the accelerated deep search when the
         # extension is built (CI builds it; see Makefile `fast`): ~150x the
         # python trial target in the wall-clock freed by dropping 2 of the 3

--- a/verify/test_refute_gate.py
+++ b/verify/test_refute_gate.py
@@ -19,10 +19,12 @@ import copy
 import json
 import os
 import sys
-import numpy as np
+import time
+
 import gf2
-import qldpc_verify
 import heuristic_distance
+import numpy as np
+import qldpc_verify
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _fail = []
@@ -120,7 +122,9 @@ def main():
     # count as a record (and so face the deep refutation tier). Regression for
     # the locality-blind global frontier the gate used before.
     import tempfile
+
     import gate_changed
+
     with tempfile.TemporaryDirectory() as td:
         cd = os.path.join(td, "codes")
         os.makedirs(cd)
@@ -162,6 +166,36 @@ def test_refute_gate():
 def test_main():
     """pytest entry point; the suite body lives in main()."""
     assert main() == 0
+
+
+def _fake_syndrome_ok(doc, seed, max_seconds, out):
+    out.put({"kind": "ok", "result": (True, 3, [1, 2, 3], 99)})
+
+
+def _fake_syndrome_hangs(doc, seed, max_seconds, out):
+    time.sleep(60)
+
+
+def test_bounded_syndrome_decoder_returns_child_result():
+    import gate_changed
+
+    got = gate_changed._syndrome_refute_bounded(
+        {}, seed=7, max_seconds=0.1, grace_seconds=0.1,
+        worker=_fake_syndrome_ok,
+    )
+    assert got == (True, 3, [1, 2, 3], 99)
+
+
+def test_bounded_syndrome_decoder_times_out():
+    import gate_changed
+
+    t0 = time.monotonic()
+    got = gate_changed._syndrome_refute_bounded(
+        {}, seed=7, max_seconds=0.05, grace_seconds=0.05,
+        worker=_fake_syndrome_hangs,
+    )
+    assert got == (False, None, None, 0)
+    assert time.monotonic() - t0 < 5
 
 
 if __name__ == "__main__":

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -19,7 +19,7 @@
     "verify/circuit_tools.py": "37a3082aabc26d908bcf2612a6a2f5fb35788a5aa7e93249692f976aaa148106",
     "verify/circuit_verify.py": "b55f03ebbc82c83b19abcbad2798b789c4aa1b9543cea47d6dba5199d124bbca",
     "verify/fixtures/72-6-6.json": "5660f9b429f507276fade0aa1a4dbed5a7ecd384f4a333c28daaa83255ccad4b",
-    "verify/gate_changed.py": "e3c46ee834dff02d50224c06dd94fd26d33149081df0cdd95666405aab2dc26a",
+    "verify/gate_changed.py": "0eb1dd2cdaeca71cbdb0474f0d646ff668f4c5fb996e4f80e25ed0b6a7cb3692",
     "verify/gf2.py": "47e8999a4e22a12a852d81ce0f5a9e0248cd04a9d8940b9cb3edba7e85ad5508",
     "verify/heuristic_distance.py": "57d9e56ce8a409e6cb1a63f48e98878624f0df611b8578c32839b7bfd00989fe",
     "verify/ler_tools.py": "908d7e63ea6ed6e855e35768e51a269ce20ebeb5757c12e08e91a641cf353de2",


### PR DESCRIPTION
## Summary

This bounds the optional BP+OSD syndrome-decoder cross-check in `verify/gate_changed.py` by running it in a child process with a hard wall-clock budget. If one decoder call stalls past the intended `max_seconds` window, the gate logs a note and continues with the existing RIS gates instead of letting the whole verify job run until GitHub cancels it.

The syndrome decoder remains fail-closed for real errors: missing output, child failures, and decoder exceptions still raise. The timeout case is treated like the optional decoder being unavailable after its budget is exhausted.

## Context

This is the verify-side companion to the merged prose rerun fix in #945. That PR fixes stale PR-body payloads for prose checks, but PR #937 also exposed a separate verify failure mode: the gate can enter `decode/distance.py` and then sit inside a single `BpOsdDecoder.decode(...)` call, so the decoder's internal `max_seconds` check is not reached.

Local probes against the #937 GB candidate reproduced that behavior: claims 86, 84, 82, 80, 78, and 76 each timed out after 90 seconds inside the syndrome-decoder path. Lowering the claimed distance alone therefore does not prevent the hosted verify job from being cancelled.

## Checks

- `UV_PYTHON=/opt/homebrew/bin/python3 /opt/homebrew/bin/uv run --offline --frozen python run_tests.py`
  - `145 passed, 8 skipped`
- `UV_PYTHON=/opt/homebrew/bin/python3 /opt/homebrew/bin/uv run --offline --frozen python -m pytest verify/test_refute_gate.py verify/test_gate_diff_classes.py`
  - `26 passed`
- `UV_PYTHON=/opt/homebrew/bin/python3 /opt/homebrew/bin/uv run --offline --frozen python verify/check_validator_integrity.py`
  - `ok: trusted validation stack matches the pin (27 files)`
- `UV_PYTHON=/opt/homebrew/bin/python3 /opt/homebrew/bin/uv run --offline --frozen ruff check --select I,F verify/gate_changed.py verify/test_refute_gate.py`
  - `All checks passed`
- `git diff --check`
  - clean
