### PR TITLE
Correct the k=10 claim in notes/630-12-34.md (no code file touched)

### DIFF
--- a/notes/630-12-34.md
+++ b/notes/630-12-34.md
@@ -73,9 +73,13 @@ pairs that read 32 at 200k fell to 30 at 1M and held 30 at 2M (kd²/n 20.0; Pare
 submitted here, left as open leads). k = 10 (n = 682 needs
 d ≥ 37): 274 pairs above 19.2 at 20k, 40 run at 200k, 10 at 1M, after which
 the seven still above 19.2 went to 2M (pair depth 24, one of them in an earlier
-pass; the [[682,10,≤40]] read 38) and four to 5M (pair depth 32): only f = 1+x+x⁵¹, g = 1+x¹⁰+x²³³ held 38
-([[682,10,≤38]], kd²/n 21.2, a Pareto point at k = 10 below this submission's
-22.0, not submitted here); the others fell to 36 or 34. That 200k → 1M → 2M attrition is the
+pass; the [[682,10,≤40]] read 38) and four to 5M (pair depth 32): only f = 1+x+x⁵¹, g = 1+x¹⁰+x²³³ still
+read 38 there, and the others fell to 36 or 34. **Correction (2026-09-10): that survivor falls too.**
+A fresh-seed ladder on it returns a valid weight-36 logical at 20M trials (seed 990001), verified
+against the opposite-type checks and outside the same-type row space; a second [[682,10]] pair
+(f = 1+x+x⁴³, g = 1+x¹⁷+x⁶⁶) falls the same way at 5M. So k = 10 at N = 341 tops out at
+[[682,10,≤36]], kd²/n 19.0 — below the 19.2 this note quotes as the bar, not the 21.2 it claimed.
+Nothing at k = 10 in this family is a Pareto point above that bar. That 200k → 1M → 2M attrition is the
 calibration warning of this family: a value flat across 20k → 200k is not
 converged at n = 630, and 34 for this code is an upper bound that seven seeds and
 8.2M trials failed to lower, not a proof.


### PR DESCRIPTION
## Correction to an existing note (no code file touched)

`notes/630-12-34.md` reports, of the k = 10 branch of the same cyclic generalized-bicycle search:

> only f = 1+x+x⁵¹, g = 1+x¹⁰+x²³³ held 38 ([[682,10,≤38]], kd²/n 21.2, a Pareto point at k = 10
> below this submission's 22.0, not submitted here)

That survivor falls too, and I found it while preparing to submit it.

- A fresh-seed RIS ladder on that exact code returns a **valid weight-36 logical at 20M trials**
  (seed 990001). I validated it deterministically with the repository's own GF(2) stack: it commutes
  with every opposite-type check and is not in the same-type row space.
- A second [[682,10]] pair from the same search, f = 1+x+x⁴³, g = 1+x¹⁷+x⁶⁶, falls the same way at 5M.
- So k = 10 at N = 341 tops out at **[[682,10,≤36]], kd²/n 19.0** — below the 19.2 the note itself
  quotes as the bar, not the 21.2 it claimed. Nothing at k = 10 in this family is a Pareto point above
  that bar, and there is no k = 10 submission to make here.

**The submitted [[630,12,34]] is unaffected.** I re-measured it with fresh seeds on 2026-09-09 and it
held 34 through 200k, 1M and 5M trials; `verify/qldpc_verify.py codes/630-12-34.json` still passes on
this branch, and the code file is untouched.

The general lesson, which this note already argues and this correction sharpens: a value flat across
20k → 200k → 5M in this family is still not converged. The claim that fell here had survived four
independent rungs to 5M before a 20M rung with a new seed broke it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
