### PR TITLE
[[20,8,4]] single-layer local code

### DIFF
--- a/codes/20-8-4.json
+++ b/codes/20-8-4.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "0.1",
+  "name": "[[20,8,4]] self-orthogonal CSS single-layer search candidate",
+  "code_type": "CSS",
+  "n": 20,
+  "k": 8,
+  "checks": {
+    "X": [
+      [4, 7, 8, 13, 15, 17, 18, 19],
+      [0, 1, 3, 9, 10, 13, 16, 17],
+      [2, 5, 6, 11, 12, 13, 14, 17],
+      [6, 7, 9, 11, 13, 15, 16, 17],
+      [1, 2, 8, 9, 10, 12, 16, 19],
+      [1, 2, 3, 4, 5, 7, 9, 11, 13, 19]
+    ],
+    "Z": [
+      [4, 7, 8, 13, 15, 17, 18, 19],
+      [0, 1, 3, 9, 10, 13, 16, 17],
+      [2, 5, 6, 11, 12, 13, 14, 17],
+      [6, 7, 9, 11, 13, 15, 16, 17],
+      [1, 2, 8, 9, 10, 12, 16, 19],
+      [1, 2, 3, 4, 5, 7, 9, 11, 13, 19]
+    ]
+  },
+  "distance": {
+    "d": 4,
+    "X": {"value": 4, "confidence": "upper_bound", "witness": [0, 3, 6, 11]},
+    "Z": {"value": 4, "confidence": "upper_bound", "witness": [1, 2, 10, 12]}
+  },
+  "provenance": {
+    "authors": ["@EthanFeld"],
+    "construction": "Randomized self-orthogonal CSS search: n=20, stabilizer rank 6, H_X = H_Z. Column labels form a 6-bit cap (all first-bit-one, distinct), excluding logical weights 1-3; check basis row-reduced to max weight 10. Layout found by grid annealing on 5x4 unit-spaced sites.",
+    "references": [],
+    "date": "2026-09-10",
+    "notes": "Search candidate. Exhaustive enumeration found no nontrivial logical of weight <=3 and a weight-4 witness on each CSS side. Honest single-layer layout; verifier-derived interaction radius sqrt(13)."
+  },
+  "family": "other",
+  "locality": {
+    "coordinates": [
+      [4, 3], [3, 1], [1, 0], [1, 2], [3, 3], [0, 2], [0, 3], [3, 2], [4, 2], [1, 3],
+      [4, 1], [0, 1], [2, 1], [2, 3], [0, 0], [2, 0], [2, 2], [1, 1], [4, 0], [3, 0]
+    ],
+    "interaction_radius": 3.605551275463989,
+    "layers": 1
+  }
+}

--- a/notes/20-8-4.md
+++ b/notes/20-8-4.md
@@ -1,0 +1,33 @@
+# [[20,8,4]] — self-orthogonal CSS single-layer code
+
+## Direction
+
+Target `any weight × local-2d-single`. The current headline is `[[16,6,4]]`
+with `k d^2/n = 6.00`. This candidate reaches `8·4^2/20 = 6.40`.
+
+## Construction
+
+Randomized search over self-orthogonal binary CSS parity-check spaces. The
+candidate uses the same rank-6 matrix for X and Z checks, giving
+`k = 20 - 6 - 6 = 8`. Its six-bit column labels are distinct points in an
+affine cap, excluding logical operators of weights 1–3. The submitted check
+basis has weights 8, 8, 8, 8, 8, 10.
+
+Qubits use a 5×4 integer grid, one qubit per site, one physical layer. The
+verifier measures interaction radius `sqrt(13) = 3.6056`, inside the
+`local-2d-single` cap of 4.0.
+
+## Evidence
+
+- `verify/qldpc_verify.py`: pass; CSS, k, witnesses, spacing, occupancy,
+  radius, and locality class all pass.
+- Trusted refutation gate: pass; no lighter logical in 3300 RIS trials.
+- Local SciPy/HiGHS certification: no logical below weight 4 on either side;
+  d=4 exact locally. Submission keeps `upper_bound` confidence per board
+  policy.
+- No exact duplicate or WL-equivalent board code; candidate advances the
+  `weight-9plus × local-2d-single` cell.
+
+## Reproduction
+
+Run `uv run python verify/qldpc_verify.py codes/20-8-4.json`.


### PR DESCRIPTION
## Candidate

Adds `[[20,8,4]]` with an honest single-layer layout:

- `k d^2 / n = 6.40`, above current `[[16,6,4]]` headline 6.00
- computed locality: `local-2d-single`
- interaction radius `sqrt(13) = 3.6056 <= 4.0`
- max check weight 10
- CSS and `k=8` verified
- explicit X/Z weight-4 witnesses
- local SciPy/HiGHS certification: no logical below 4 on either side
- trusted RIS refutation: no lighter logical in 3300 trials

Distance remains filed as `upper_bound` per board policy; MILP result is included in the note.