### PR TITLE
Enforce connected Tanner graphs in verifier (#921)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,8 @@ accepted and recorded but will not sit on the frontier. See `TRACKS.md`.
 - Store `interaction_radius` as the exact measured max check diameter, not a
   rounded value.
 - Do not repeat a qubit index within a single check.
+- Submit one connected code, not a direct sum: the combined X and Z Tanner
+  graph must be a single connected component.
 - Use `provenance.origin` only for provenance (`baseline` vs `submission`), not
   novelty. If the same `[[n,k,d]]` parameter set exists in the literature, set
   `provenance.novelty` to `known_parameters` and cite it in

--- a/verify/qldpc_verify.py
+++ b/verify/qldpc_verify.py
@@ -203,6 +203,33 @@ def _vec(support, n):
     return v
 
 
+def _tanner_component_count(checks, n):
+    """Count connected components of the combined qubit/check Tanner graph."""
+    rows = checks["X"] + checks["Z"]
+    neighbors = [[] for _ in range(n + len(rows))]
+    for i, support in enumerate(rows):
+        check_vertex = n + i
+        for qubit in support:
+            neighbors[qubit].append(check_vertex)
+            neighbors[check_vertex].append(qubit)
+
+    seen = bytearray(len(neighbors))
+    components = 0
+    for start in range(len(neighbors)):
+        if seen[start]:
+            continue
+        components += 1
+        seen[start] = 1
+        stack = [start]
+        while stack:
+            vertex = stack.pop()
+            for neighbor in neighbors[vertex]:
+                if not seen[neighbor]:
+                    seen[neighbor] = 1
+                    stack.append(neighbor)
+    return components
+
+
 def verify(doc, refute=False, seed=None):
     """Verify a submission. If ``refute`` is set, run the distance refutation with
     ``seed`` -- when ``seed is None`` a fresh RANDOM seed is drawn, so the gate is
@@ -264,6 +291,13 @@ def _verify_semantic(doc, report, record, refute=False, seed=None):
                   if len(set(s)) != len(s)]
     record("no_repeated_qubits_in_a_check", not empty_rows,
            f"rows with repeats: {empty_rows[:5]}")
+
+    # The challenge rule applies to the combined X/Z Tanner graph. Count all
+    # qubit and check vertices, including isolated vertices, so a disconnected
+    # direct sum or an unused qubit cannot pass by construction.
+    ncomponents = _tanner_component_count(doc["checks"], n)
+    record("tanner_connected", ncomponents == 1,
+           f"Tanner graph has {ncomponents} connected component(s)")
 
     # 3. CSS commutation
     css = not bool(((HX @ HZ.T) % 2).any())

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -15,7 +15,6 @@ import glob
 import importlib.util
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import qldpc_verify
@@ -335,10 +334,8 @@ def main():
 
     # every shipped example/code still verifies
     print("\nshipped submissions still verify:")
-    tracked_codes = subprocess.check_output(
-        ["git", "ls-files", "codes"], cwd=ROOT, text=True).splitlines()
-    paths = [os.path.join(ROOT, p) for p in tracked_codes if p.endswith(".json")]
-    paths += sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json")))
+    paths = (sorted(glob.glob(os.path.join(ROOT, "codes", "*.json")))
+             + sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json"))))
     for p in paths:
         doc = json.load(open(p))
         r = verify(doc)

--- a/verify/test_verifier.py
+++ b/verify/test_verifier.py
@@ -15,9 +15,11 @@ import glob
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import qldpc_verify
+import verify_all
 
 verify = qldpc_verify.verify
 
@@ -54,6 +56,33 @@ def main():
     r = rep(GOOD)
     check("valid code passes", r["ok"])
     check("earns a distance tier", "d" in r["earned_distance"])
+    check("connected Tanner graph passes",
+          "tanner_connected" not in failed_checks(r))
+    check("X and Z checks use one combined graph",
+          qldpc_verify._tanner_component_count(
+              {"X": [[0], [1]], "Z": [[0, 1]]}, 2) == 1)
+
+    disconnected = {
+        "schema_version": "0.1",
+        "name": "disconnected synthetic code",
+        "code_type": "CSS",
+        "n": 3,
+        "k": 1,
+        "checks": {"X": [[0]], "Z": [[1]]},
+        "distance": {
+            "d": 1,
+            "X": {"value": 1, "confidence": "upper_bound", "witness": [2]},
+            "Z": {"value": 1, "confidence": "upper_bound", "witness": [2]},
+        },
+        "provenance": {"authors": ["@test"], "construction": "synthetic"},
+    }
+    r = rep(disconnected)
+    check("disconnected Tanner graph rejected",
+          not r["ok"] and "tanner_connected" in failed_checks(r))
+    tanner_check = next(c for c in r["checks"]
+                        if c["check"] == "tanner_connected")
+    check("isolated qubit is counted as a component",
+          tanner_check["detail"] == "Tanner graph has 3 connected component(s)")
 
     print("\nREJECT tampered submissions:")
 
@@ -306,13 +335,21 @@ def main():
 
     # every shipped example/code still verifies
     print("\nshipped submissions still verify:")
-    for p in (sorted(glob.glob(os.path.join(ROOT, "codes", "*.json")))
-              + sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json")))):
-        ok = verify(json.load(open(p)))["ok"]
-        if not ok:
-            check(f"{os.path.basename(p)} verifies", False)
+    tracked_codes = subprocess.check_output(
+        ["git", "ls-files", "codes"], cwd=ROOT, text=True).splitlines()
+    paths = [os.path.join(ROOT, p) for p in tracked_codes if p.endswith(".json")]
+    paths += sorted(glob.glob(os.path.join(ROOT, "verify", "fixtures", "*.json")))
+    for p in paths:
+        doc = json.load(open(p))
+        r = verify(doc)
+        rel = os.path.relpath(p, ROOT)
+        if rel in verify_all.LEGACY_DISCONNECTED:
+            check(f"{os.path.basename(p)} is an explicit legacy connectivity failure",
+                  not r["ok"] and failed_checks(r) == {"tanner_connected"})
+        else:
+            check(f"{os.path.basename(p)} verifies", r["ok"])
     if not _fail:
-        print("  ok    all shipped submissions verify")
+        print("  ok    all shipped submissions verify or are explicit legacy entries")
 
     check("normal file size accepted",
           qldpc_verify.file_size_error(__file__) == "")

--- a/verify/test_verify_all.py
+++ b/verify/test_verify_all.py
@@ -1,0 +1,47 @@
+"""Tests for the issue #921 legacy Tanner-connectivity migration."""
+
+import verify_all
+
+
+def _disconnected_report():
+    return {
+        "ok": False,
+        "checks": [{
+            "check": "tanner_connected",
+            "ok": False,
+            "detail": "Tanner graph has 2 connected component(s)",
+        }],
+    }
+
+
+def test_legacy_allowlist_is_explicit_and_bounded():
+    assert len(verify_all.LEGACY_DISCONNECTED) == 34
+    assert all(path.startswith("codes/") for path in verify_all.LEGACY_DISCONNECTED)
+
+
+def test_legacy_disconnected_entry_is_warned_and_allowed(capsys):
+    report = _disconnected_report()
+    path = "codes/112-8-5.json"
+
+    assert verify_all.allow_legacy_disconnected(path, report)
+    assert report["ok"]
+    assert "legacy entry; cleanup pending" in capsys.readouterr().out
+
+
+def test_new_disconnected_entry_is_not_allowed():
+    report = _disconnected_report()
+
+    assert not verify_all.allow_legacy_disconnected("codes/new.json", report)
+    assert not report["ok"]
+
+
+def test_legacy_entry_with_another_failure_is_not_allowed():
+    report = _disconnected_report()
+    report["checks"].append({
+        "check": "css_commutation",
+        "ok": False,
+        "detail": "not commuting",
+    })
+
+    assert not verify_all.allow_legacy_disconnected("codes/112-8-5.json", report)
+    assert not report["ok"]

--- a/verify/validator_manifest.json
+++ b/verify/validator_manifest.json
@@ -24,9 +24,9 @@
     "verify/heuristic_distance.py": "57d9e56ce8a409e6cb1a63f48e98878624f0df611b8578c32839b7bfd00989fe",
     "verify/ler_tools.py": "908d7e63ea6ed6e855e35768e51a269ce20ebeb5757c12e08e91a641cf353de2",
     "verify/ler_verify.py": "3c75ba7dfdc0d7ddd4d12f05aa06c8b36301f2c13045a4f640c22158457e5650",
-    "verify/qldpc_verify.py": "71308665b86762335d71300e4a8507fff9466986ee68a5fcd1c4df72406f946f",
+    "verify/qldpc_verify.py": "b2560de19f1b5853865005e2b8a2502bd70fed37b83d68e9a1e03ef15ff3256d",
     "verify/refute_board.py": "d45c3d4475acd77dac0e6da7854c8d9dd142d1d077b75a166d6d3e5f729ef20d",
     "verify/validate_candidate.py": "e85d28612a9b798e4693c86bbaacc3fd84a674890fe6af4d8253cf07018183b1",
-    "verify/verify_all.py": "22411a86bee71f128d909b05199b3b0f97127f7dd73019422c187c914530b381"
+    "verify/verify_all.py": "7c08820ef24adf483c9f2af00f36d764bb4ee6844315d90ca8c38c80ebd203aa"
   }
 }

--- a/verify/verify_all.py
+++ b/verify/verify_all.py
@@ -22,6 +22,59 @@ from ler_verify import verify_ler
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Temporary migration exception for entries that predate issue #921. The hard
+# verifier still rejects these graphs; this board sweep reports them as warnings
+# until the follow-up cleanup PR removes the entries and this set.
+LEGACY_DISCONNECTED = frozenset({
+    "codes/112-8-5.json",
+    "codes/120-5-8.json",
+    "codes/128-12-8.json",
+    "codes/144-16-8.json",
+    "codes/144-24-6.json",
+    "codes/153-5-9.json",
+    "codes/162-36-4.json",
+    "codes/176-22-4.json",
+    "codes/192-24-4.json",
+    "codes/192-6-8.json",
+    "codes/214-15-11.json",
+    "codes/216-15-11.json",
+    "codes/231-5-11.json",
+    "codes/242-2-11.json",
+    "codes/261-16-12.json",
+    "codes/263-16-12.json",
+    "codes/288-32-8.json",
+    "codes/288-48-6.json",
+    "codes/299-5-13.json",
+    "codes/324-4-9.json",
+    "codes/338-2-13.json",
+    "codes/360-16-14.json",
+    "codes/360-24-10.json",
+    "codes/360-32-6.json",
+    "codes/45-5-4.json",
+    "codes/484-4-11.json",
+    "codes/66-5-5.json",
+    "codes/676-4-13.json",
+    "codes/78-6-5.json",
+    "codes/88-8-7.json",
+    "codes/90-6-5.json",
+    "codes/91-5-7.json",
+    "codes/96-12-4-mvb.json",
+    "codes/96-12-4.json",
+})
+
+
+def allow_legacy_disconnected(path, report):
+    """Downgrade only the reviewed legacy connectivity failure to a warning."""
+    failed = [c["check"] for c in report["checks"] if not c["ok"]]
+    if path not in LEGACY_DISCONNECTED or failed != ["tanner_connected"]:
+        return False
+    detail = next(c["detail"] for c in report["checks"]
+                  if c["check"] == "tanner_connected")
+    print(f"WARN  {path}  -> {detail} (legacy entry; cleanup pending)")
+    report["ok"] = True
+    return True
+
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=ROOT,
@@ -50,6 +103,7 @@ if __name__ == "__main__":
         with open(p) as f:
             doc = json.load(f)
         rep = verify(doc)   # structural checks; refutation lives in gate_changed / refute_board
+        allow_legacy_disconnected(rel, rep)
         circ = ""
         if rep["ok"] and is_code and doc.get("circuit"):
             slug = os.path.splitext(os.path.basename(p))[0]


### PR DESCRIPTION
## Summary

- enforce the combined X/Z Tanner graph connectivity rule in the trusted verifier;
- report the component count through the `tanner_connected` check, including isolated vertices;
- add regression coverage for connected, disconnected, isolated, and cross-side connectivity cases;
- add an explicit 34-entry migration warning set for legacy board entries in `verify_all.py`;
- document the connectivity requirement in `CONTRIBUTING.md`.

The hard verifier remains strict for every submission. The migration set affects only the all-board sweep and only when connectivity is the sole failure.

## Temporary migration window

The separate cleanup PR [#1005](https://github.com/unitaryfoundation/qldpc-challenge/pull/1005) removes the 34 legacy disconnected entries and the temporary exception. Because the site builder uses the hard verifier directly, merging this PR before #1005 will temporarily reduce the public board from 581 to 547 entries and remove those 34 detail pages. That transition is expected only until #1005 lands immediately afterward; #1005 is intentionally kept stacked on this PR until then.

## Validation

- `uv run pytest verify/test_verifier.py verify/test_verify_all.py verify/test_validator_integrity.py` — 37 passed
- `uv run python verify/check_validator_integrity.py` — passed
- `uv run python verify/verify_all.py` — 582/582 passed, with 34 explicit legacy warnings

Closes #921
