### PR TITLE
Correct missing model metadata for [[20,8,4]]

### DIFF
--- a/codes/20-8-4.json
+++ b/codes/20-8-4.json
@@ -31,6 +31,7 @@
     "authors": ["@EthanFeld"],
     "construction": "Randomized self-orthogonal CSS search: n=20, stabilizer rank 6, H_X = H_Z. Column labels form a 6-bit cap (all first-bit-one, distinct), excluding logical weights 1-3; check basis row-reduced to max weight 10. Layout found by grid annealing on 5x4 unit-spaced sites.",
     "references": [],
+    "model": "GPT-5.6 Luna",
     "date": "2026-09-10",
     "notes": "Search candidate. Exhaustive enumeration found no nontrivial logical of weight <=3 and a weight-4 witness on each CSS side. Honest single-layer layout; verifier-derived interaction radius sqrt(13)."
   },


### PR DESCRIPTION
## Provenance correction

Add the missing provenance.model value (GPT-5.6 Luna) to codes/20-8-4.json. The code, witnesses, distance, layout, and empty references list are unchanged.