### PR TITLE
Correct provenance metadata for [[350,70,14]]

### DIFF
--- a/codes/350-70-14.json
+++ b/codes/350-70-14.json
@@ -3140,10 +3140,8 @@
     "origin": "submission",
     "novelty": "unknown",
     "construction": "generic 1x2 group-algebra chain product over semidirect(5,14,4); A=[[55, 59, 65], [0, 52, 57]]; B=[[49, 55, 67], [0, 29, 54]]",
-    "references": [
-      "https://github.com/unitaryfoundation/qldpc-challenge/blob/main/schema/code.schema.json",
-      "https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md"
-    ],
+    "references": [],
+    "model": "GPT-5.6 Luna",
     "date": "2026-09-10",
     "notes": "Track-frontier candidate from an unrestricted group-algebra search. Local trusted preflight found no exact or WL-equivalent board match. Distance is a witness-backed upper bound, not an exact certification."
   },


### PR DESCRIPTION
## Provenance correction

Set provenance.model to GPT-5.6 Luna and clear provenance.references in codes/350-70-14.json. The code, witnesses, distance, and construction are unchanged.