### PR TITLE
Remove repository link from [[700,206,28]] metadata

### DIFF
--- a/codes/700-206-28.json
+++ b/codes/700-206-28.json
@@ -14911,8 +14911,7 @@
     "model": "GPT-5.6 Luna",
     "references": [
       "https://arxiv.org/abs/1904.02703",
-      "https://arxiv.org/abs/2203.17216",
-      "https://github.com/unitaryfoundation/qldpc-challenge/blob/main/CONTRIBUTING.md"
+      "https://arxiv.org/abs/2203.17216"
     ],
     "date": "2026-09-01",
     "notes": "A cyclic-shift audit found validated weight-28 X and Z logical witnesses. The earlier d<=74 claim is superseded; no exact duplicate was found in current main-board filenames."


### PR DESCRIPTION
## Provenance correction

Remove the qLDPC repository link from provenance.references in codes/700-206-28.json. The two arXiv references, model, code, witnesses, and distance are unchanged.