### PR TITLE
site: soften page background and sharpen card borders

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -366,8 +366,8 @@ LI_ICON = ('<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" 
            '23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>')
 
 CSS = f"""
-:root{{--ink:#0f172a;--mut:#64748b;--ln:#e2e8f0;--ac:{ACCENT};--ex:{EXACT};
---exb:{GREEN_BRIGHT};--dark:{DARK};--bg:#fff;--soft:#f8fafc}}
+:root{{--ink:#0f172a;--mut:#64748b;--ln:#d9dfe9;--ac:{ACCENT};--ex:{EXACT};
+--exb:{GREEN_BRIGHT};--dark:{DARK};--bg:#fbfbfd;--soft:#f8fafc}}
 *{{box-sizing:border-box}}
 /* Unitary Foundation type stack: Manrope for body and page-level headings
    (H1/H2, per UF homepage), Space Grotesk for in-container display text,


### PR DESCRIPTION
## Summary

Two small visual polish tweaks to the light theme, from Anthony Hobday's "safe rules" guide (https://anthonyhobday.com/sideprojects/saferules/). Confined to the CSS `:root` tokens in `site/build.py`; CI regenerates `docs/style.css` on merge.

## Changes

- **`--bg: #fff -> #fbfbfd`** — near-white instead of pure white, softening glare on the largest light surface.
- **`--ln: #e2e8f0 -> #d9dfe9`** — borders now contrast with both the card and the page, so edges read sharp.

Side effect: cards at `#fff` now sit slightly above the near-white page, giving a subtle three-tier depth hierarchy (page < soft panels < cards).

## Scope

- One file, 2 lines. No layout/content change; no generated files committed.
- Verified: `uv run python site/build.py` builds clean and emits the new tokens.